### PR TITLE
Fix/delete integrated feature without version

### DIFF
--- a/retail/api/integrated_feature/views.py
+++ b/retail/api/integrated_feature/views.py
@@ -19,10 +19,7 @@ from retail.projects.models import Project
 class IntegratedFeatureView(BaseServiceView):
     def post(self, request, *args, **kwargs):
         user, _ = User.objects.get_or_create(
-            email=request.user.email,
-            defaults={
-                "username": request.user.email
-            }
+            email=request.user.email, defaults={"username": request.user.email}
         )
         request_data = request.data.copy()
         request_data["feature_uuid"] = kwargs.get("feature_uuid")
@@ -73,7 +70,11 @@ class IntegratedFeatureView(BaseServiceView):
 
         body = {
             "project_uuid": str(project.uuid),
-            "feature_version": str(integrated_feature.feature_version.uuid),
+            "feature_version": (
+                str(integrated_feature.feature_version.uuid)
+                if integrated_feature.feature_version
+                else ""
+            ),
             "feature_uuid": str(integrated_feature.feature.uuid),
             "user_email": request.user.email,
         }


### PR DESCRIPTION
### What
Adds verification to ensure that a integrated feature has a version before trying to access the version's UUID, when deleting the instance.

### Why
To avoid internal error due to the version's UUID access attempt.