### PR TITLE
feat: unassign agent

### DIFF
--- a/retail/agents/tests/usecases/test_unassign_agent.py
+++ b/retail/agents/tests/usecases/test_unassign_agent.py
@@ -1,0 +1,47 @@
+from uuid import uuid4
+
+from django.test import TestCase
+
+from rest_framework.exceptions import NotFound
+
+from retail.agents.models import Agent, IntegratedAgent
+from retail.projects.models import Project
+from retail.agents.usecases import UnassignAgentUseCase
+
+
+class UnassignAgentUseCaseTest(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Project", uuid=uuid4())
+        self.agent = Agent.objects.create(
+            uuid=uuid4(),
+            is_oficial=True,
+            lambda_arn="arn:aws:lambda:...",
+            name="Agent",
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            client_secret="hashedsecret",
+            lambda_arn=self.agent.lambda_arn,
+        )
+        self.use_case = UnassignAgentUseCase()
+
+    def test_execute_success(self):
+        self.assertTrue(
+            IntegratedAgent.objects.filter(
+                agent=self.agent, project=self.project
+            ).exists()
+        )
+        self.use_case.execute(self.agent, str(self.project.uuid))
+        self.assertFalse(
+            IntegratedAgent.objects.filter(
+                agent=self.agent, project=self.project
+            ).exists()
+        )
+
+    def test_execute_not_found(self):
+        self.integrated_agent.delete()
+        with self.assertRaises(NotFound) as context:
+            self.use_case.execute(self.agent, str(self.project.uuid))
+        self.assertIn("Integrated agent not found", str(context.exception))

--- a/retail/agents/tests/views/test_unassign_agent_view.py
+++ b/retail/agents/tests/views/test_unassign_agent_view.py
@@ -1,0 +1,85 @@
+from uuid import uuid4
+
+from rest_framework.test import APIClient, APITestCase
+from rest_framework import status
+
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from retail.agents.models import Agent, IntegratedAgent
+from retail.projects.models import Project
+
+User = get_user_model()
+
+
+class UnassignAgentViewTest(APITestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Project", uuid=uuid4())
+        self.agent_oficial = Agent.objects.create(
+            uuid=uuid4(),
+            is_oficial=True,
+            lambda_arn="arn:aws:lambda:...",
+            name="Agent Oficial",
+            project=self.project,
+        )
+        self.agent_not_oficial = Agent.objects.create(
+            uuid=uuid4(),
+            is_oficial=False,
+            lambda_arn="arn:aws:lambda:...",
+            name="Agent Não Oficial",
+            project=self.project,
+        )
+        self.integrated_agent_oficial = IntegratedAgent.objects.create(
+            agent=self.agent_oficial,
+            project=self.project,
+            client_secret="hashedsecret",
+            lambda_arn=self.agent_oficial.lambda_arn,
+        )
+        self.integrated_agent_not_oficial = IntegratedAgent.objects.create(
+            agent=self.agent_not_oficial,
+            project=self.project,
+            client_secret="hashedsecret",
+            lambda_arn=self.agent_not_oficial.lambda_arn,
+        )
+        self.user = User.objects.create_user(username="testuser", password="12345")
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_unassign_agent_oficial_success(self):
+        url = reverse("unassign-agent", kwargs={"agent_uuid": self.agent_oficial.uuid})
+        response = self.client.post(url, HTTP_PROJECT_UUID=str(self.project.uuid))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(
+            IntegratedAgent.objects.filter(
+                agent=self.agent_oficial, project=self.project
+            ).exists()
+        )
+
+    def test_unassign_agent_not_oficial_success(self):
+        url = reverse(
+            "unassign-agent", kwargs={"agent_uuid": self.agent_not_oficial.uuid}
+        )
+        response = self.client.post(url, HTTP_PROJECT_UUID=str(self.project.uuid))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(
+            IntegratedAgent.objects.filter(
+                agent=self.agent_not_oficial, project=self.project
+            ).exists()
+        )
+
+    def test_unassign_agent_not_oficial_wrong_project(self):
+        url = reverse(
+            "unassign-agent", kwargs={"agent_uuid": self.agent_not_oficial.uuid}
+        )
+        response = self.client.post(url, HTTP_PROJECT_UUID=str(uuid4()))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unassign_agent_missing_project_uuid_header(self):
+        url = reverse("unassign-agent", kwargs={"agent_uuid": self.agent_oficial.uuid})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unassign_agent_not_found(self):
+        url = reverse("unassign-agent", kwargs={"agent_uuid": uuid4()})
+        response = self.client.post(url, HTTP_PROJECT_UUID=str(self.project.uuid))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/retail/agents/urls.py
+++ b/retail/agents/urls.py
@@ -2,7 +2,12 @@ from django.urls import path
 
 from rest_framework.routers import SimpleRouter
 
-from retail.agents.views import PushAgentView, AgentViewSet, AssignAgentView
+from retail.agents.views import (
+    PushAgentView,
+    AgentViewSet,
+    AssignAgentView,
+    UnassignAgentView,
+)
 
 router = SimpleRouter()
 router.register(r"", AgentViewSet, basename="agents")
@@ -10,6 +15,11 @@ router.register(r"", AgentViewSet, basename="agents")
 urlpatterns = [
     path("push/", PushAgentView.as_view(), name="push-agent"),
     path("<uuid:agent_uuid>/assign/", AssignAgentView.as_view(), name="assign-agent"),
+    path(
+        "<uuid:agent_uuid>/unassign/",
+        UnassignAgentView.as_view(),
+        name="unassign-agent",
+    ),
 ]
 
 urlpatterns += router.urls

--- a/retail/agents/usecases/__init__.py
+++ b/retail/agents/usecases/__init__.py
@@ -3,3 +3,4 @@ from .validate_pre_approved_templates import ValidatePreApprovedTemplatesUseCase
 from .list_agents import ListAgentsUseCase
 from .retrieve_agent import RetrieveAgentUseCase
 from .assign_agent import AssignAgentUseCase
+from .unassign_agent import UnassignAgentUseCase

--- a/retail/agents/usecases/unassign_agent.py
+++ b/retail/agents/usecases/unassign_agent.py
@@ -1,0 +1,15 @@
+from rest_framework.exceptions import NotFound
+
+from retail.agents.models import IntegratedAgent, Agent
+
+
+class UnassignAgentUseCase:
+    def _get_integrated_agent(self, agent: Agent, project_uuid: str) -> IntegratedAgent:
+        try:
+            return IntegratedAgent.objects.get(agent=agent, project__uuid=project_uuid)
+        except IntegratedAgent.DoesNotExist:
+            raise NotFound("Integrated agent not found")
+
+    def execute(self, agent: Agent, project_uuid: str) -> None:
+        integrated_agent = self._get_integrated_agent(agent, project_uuid)
+        integrated_agent.delete()


### PR DESCRIPTION
- Endpoint to unassign an integrated from a project.

Business rules:
- It is not possible to unassign an agent from another project that is not yours.