### PR TITLE
fix: check current version before triggering template

### DIFF
--- a/retail/agents/tests/usecases/test_agent_webhook.py
+++ b/retail/agents/tests/usecases/test_agent_webhook.py
@@ -456,6 +456,17 @@ class BroadcastHandlerTest(TestCase):
 
         self.assertIsNone(result)
 
+    def test_get_current_template_name_no_current_version(self):
+        data = {"template": "order_update"}
+        mock_template = MagicMock()
+        mock_template.current_version = None
+        self.mock_agent.templates.get.return_value = mock_template
+
+        result = self.handler.get_current_template_name(self.mock_agent, data)
+
+        self.assertIsNone(result)
+        self.mock_agent.templates.get.assert_called_once_with(name="order_update")
+
     def test_send_message(self):
         message = {"template": "test", "contact": "whatsapp:123"}
 

--- a/retail/agents/usecases/agent_webhook.py
+++ b/retail/agents/usecases/agent_webhook.py
@@ -183,6 +183,9 @@ class BroadcastHandler:
         template_name = data.get("template")
         try:
             template = integrated_agent.templates.get(name=template_name)
+            if template.current_version is None:
+                logger.error(f"Template {template_name} has no current version.")
+                return None
             return template.current_version.template_name
         except Template.DoesNotExist:
             return None

--- a/retail/agents/usecases/agent_webhook.py
+++ b/retail/agents/usecases/agent_webhook.py
@@ -184,7 +184,7 @@ class BroadcastHandler:
         try:
             template = integrated_agent.templates.get(name=template_name)
             if template.current_version is None:
-                logger.error(f"Template {template_name} has no current version.")
+                logger.info(f"Template {template_name} has no current version.")
                 return None
             return template.current_version.template_name
         except Template.DoesNotExist:


### PR DESCRIPTION
Resolved an issue that caused templates without an approved current version to be triggered.