### PR TITLE
fix: templates with variables were not using examples

### DIFF
--- a/retail/templates/tests/usecases/test_create_custom_template.py
+++ b/retail/templates/tests/usecases/test_create_custom_template.py
@@ -74,10 +74,10 @@ class CreateCustomTemplateUseCaseTest(TestCase):
             "parameters": [
                 {
                     "name": "variables",
-                    "value": '[{"definition": "test", "fallback": "default"}]',
+                    "value": [{"definition": "test", "fallback": "default"}],
                 },
                 {"name": "start_condition", "value": "test condition"},
-                {"name": "examples", "value": '[{"input": "example"}]'},
+                {"name": "examples", "value": [{"input": "example"}]},
                 {"name": "template_content", "value": "some template text"},
             ],
             "display_name": "Test Display Name",


### PR DESCRIPTION
Pass variables as body examples to integrations