### PR TITLE
fix: sentry error in retrieving template name without current version

### DIFF
--- a/retail/agents/tests/usecases/test_agent_webhook.py
+++ b/retail/agents/tests/usecases/test_agent_webhook.py
@@ -466,7 +466,7 @@ class BroadcastHandlerTest(TestCase):
 
         result = self.handler.get_current_template_name(self.mock_agent, data)
 
-        self.assertIsNone(result)
+        self.assertFalse(result)
         self.mock_agent.templates.get.assert_called_once_with(name="order_update")
 
     def test_send_message(self):

--- a/retail/agents/usecases/agent_webhook.py
+++ b/retail/agents/usecases/agent_webhook.py
@@ -179,14 +179,14 @@ class BroadcastHandler:
 
     def get_current_template_name(
         self, integrated_agent: IntegratedAgent, data: Dict[str, Any]
-    ) -> str:
+    ) -> Optional[str | bool]:
         """Get current template name from integrated agent templates."""
         template_name = data.get("template")
         try:
             template = integrated_agent.templates.get(name=template_name)
             if template.current_version is None:
                 logger.info(f"Template {template_name} has no current version.")
-                return None
+                return False
             return template.current_version.template_name
         except Template.DoesNotExist:
             return None
@@ -197,7 +197,13 @@ class BroadcastHandler:
         """Build broadcast message from lambda response data."""
         logger.info("Retrieving current template name.")
         template_name = self.get_current_template_name(integrated_agent, data)
-        if not template_name:
+
+        if template_name is False:
+            logger.info(
+                "Could not build message because template has no current version."
+            )
+
+        if template_name is None:
             logger.error(f"Template not found: {template_name}")
             return None
 

--- a/retail/agents/usecases/agent_webhook.py
+++ b/retail/agents/usecases/agent_webhook.py
@@ -202,10 +202,11 @@ class BroadcastHandler:
             logger.info(
                 "Could not build message because template has no current version."
             )
+            return
 
         if template_name is None:
             logger.error(f"Template not found: {template_name}")
-            return None
+            return
 
         logger.info("Building broadcast template message.")
         message = build_broadcast_template_message(
@@ -292,7 +293,7 @@ class AgentWebhookUseCase:
         try:
             message = self.broadcast_handler.build_message(integrated_agent, data)
             if not message:
-                logger.error(
+                logger.info(
                     f"Failed to build broadcast message from payload data: {data}"
                 )
                 return response


### PR DESCRIPTION
- Adapt get_template_name to return False or None in order to know if it is not found or has no current version