### PR TITLE
fix: Sentry logger error of type project with account not found

### DIFF
--- a/retail/webhooks/vtex/usecases/cart.py
+++ b/retail/webhooks/vtex/usecases/cart.py
@@ -1,5 +1,7 @@
 import logging
 
+from typing import Optional
+
 from rest_framework.exceptions import ValidationError, NotFound
 from retail.features.models import Feature, IntegratedFeature
 from retail.projects.models import Project
@@ -29,7 +31,7 @@ class CartUseCase:
         self.project = self._get_project_by_account()
         self.integrated_feature = self._get_integrated_feature()
 
-    def _get_project_by_account(self) -> Project:
+    def _get_project_by_account(self) -> Optional[Project]:
         """
         Fetch the project associated with the account.
 
@@ -42,9 +44,8 @@ class CartUseCase:
         try:
             return Project.objects.get(vtex_account=self.account)
         except Project.DoesNotExist:
-            error_message = f"Project with account '{self.account}' does not exist."
-            logger.error(error_message)
-            raise NotFound(error_message)
+            logger.info(f"Project with account '{self.account}' does not exist.")
+            return None
         except Project.MultipleObjectsReturned:
             error_message = f"Multiple projects found with account '{self.account}'."
             logger.error(error_message)

--- a/retail/webhooks/vtex/views/abandoned_cart_notification.py
+++ b/retail/webhooks/vtex/views/abandoned_cart_notification.py
@@ -27,6 +27,12 @@ class AbandonedCartNotification(APIView):
         # Instantiate the use case with the given account
         cart_use_case = CartUseCase(account=validated_data["account"])
 
+        if cart_use_case.project is None:
+            return Response(
+                {"message": "Project not found for the given account."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         # Check if the abandoned cart feature is integrated for the project
         if not cart_use_case.integrated_feature:
             return Response(


### PR DESCRIPTION
Fixed a recurring error log in sentry of type "Project with account {account} not found"