### PR TITLE
feat: add 13-digits hash as active agent lambda function name

### DIFF
--- a/retail/agents/tests/usecases/test_push_agent.py
+++ b/retail/agents/tests/usecases/test_push_agent.py
@@ -148,8 +148,73 @@ class PushAgentUseCaseTest(TestCase):
 
     def test_create_function_name(self):
         name = self.usecase._create_function_name(self.agent_slug, self.agent_uuid)
-        self.assertIn(self.agent_slug, name)
-        self.assertIn(self.agent_uuid.hex, name)
+
+        self.assertTrue(name.startswith("retail-setup-"))
+
+        hash_part = name.replace("retail-setup-", "")
+        self.assertEqual(len(hash_part), 13)
+        self.assertTrue(hash_part.isalnum())
+        self.assertTrue(hash_part.islower())
+
+        self.assertLessEqual(len(name), 64)
+
+    def test_create_function_name_different_inputs_different_hashes(self):
+        different_uuid = uuid4()
+        different_slug = "different-agent"
+
+        name_original = self.usecase._create_function_name(
+            self.agent_slug, self.agent_uuid
+        )
+        name_diff_uuid = self.usecase._create_function_name(
+            self.agent_slug, different_uuid
+        )
+        name_diff_slug = self.usecase._create_function_name(
+            different_slug, self.agent_uuid
+        )
+
+        self.assertNotEqual(name_original, name_diff_uuid)
+        self.assertNotEqual(name_original, name_diff_slug)
+        self.assertNotEqual(name_diff_uuid, name_diff_slug)
+
+        for name in [name_original, name_diff_uuid, name_diff_slug]:
+            self.assertTrue(name.startswith("retail-setup-"))
+            hash_part = name.replace("retail-setup-", "")
+            self.assertEqual(len(hash_part), 13)
+            self.assertTrue(hash_part.isalnum())
+
+    def test_create_function_name_hash_only_alphanumeric_characters(self):
+        import string
+
+        test_cases = [
+            "agent-with-dashes",
+            "agent_with_underscores",
+            "AGENT.WITH.DOTS",
+            "agent@with#special$chars%",
+            "agent with spaces",
+            "agênt-wïth-àccénts",
+            "агент-кириллица",
+            "エージェント",
+        ]
+
+        valid_chars = set(string.ascii_lowercase + string.digits)
+
+        for agent_name in test_cases:
+            name = self.usecase._create_function_name(agent_name, self.agent_uuid)
+
+            self.assertTrue(name.startswith("retail-setup-"))
+
+            hash_part = name.replace("retail-setup-", "")
+
+            self.assertEqual(len(hash_part), 13)
+
+            for char in hash_part:
+                self.assertIn(char, valid_chars)
+
+            self.assertTrue(
+                hash_part.islower()
+                or hash_part.isdigit()
+                or all(c.islower() or c.isdigit() for c in hash_part)
+            )
 
     def test_create_pre_approved_templates_creates_and_updates(self):
         agent = Agent.objects.create(

--- a/retail/agents/usecases/push_agent.py
+++ b/retail/agents/usecases/push_agent.py
@@ -1,5 +1,9 @@
 import logging
 
+import hashlib
+
+import base64
+
 from typing import Any, Dict, List, Optional, TypedDict
 
 from uuid import UUID
@@ -100,8 +104,17 @@ class PushAgentUseCase:
         return agent
 
     def _create_function_name(self, agent_name: str, agent_uuid: UUID) -> str:
-        simple_hash = f"retail-setup-{agent_name}-{str(agent_uuid.hex)}"
-        return simple_hash
+        input_hash_string = f"{agent_name}-{str(agent_uuid.hex)}"
+
+        hash_object = hashlib.sha256(input_hash_string.encode("utf-8"))
+        hash_bytes = hash_object.digest()
+
+        base64_hash = base64.b64encode(hash_bytes).decode("utf-8")
+        only_alphanumeric_hash = "".join(c.lower() for c in base64_hash if c.isalnum())
+
+        hash_13_digits = only_alphanumeric_hash[:13]
+
+        return f"retail-setup-{hash_13_digits}"
 
     def _update_or_create_pre_approved_templates(
         self, agent: Agent, agent_payload: AgentItemsData


### PR DESCRIPTION
- Using a bijective function to create a unique hash for an active agent's lambda;
- Extract only first 13 digits and use only alphanumeric digits.