### PR TITLE
feat: auth by user token

### DIFF
--- a/retail/agents/tests/views/test_assign_agent_view.py
+++ b/retail/agents/tests/views/test_assign_agent_view.py
@@ -3,6 +3,8 @@ from rest_framework import status
 
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 
 from uuid import uuid4
 from urllib.parse import urlencode
@@ -36,6 +38,16 @@ class AssignAgentViewTest(APITestCase):
         self.user = User.objects.create_user(
             username="testuser", password="12345", email="testuser@example.com"
         )
+
+        # Give user internal communication permission for tests
+        content_type = ContentType.objects.get_for_model(User)
+        permission, created = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            name="can communicate internally",
+            content_type=content_type,
+        )
+        self.user.user_permissions.add(permission)
+
         self.client = APIClient()
         self.client.force_authenticate(self.user)
 

--- a/retail/agents/tests/views/test_unassign_agent_view.py
+++ b/retail/agents/tests/views/test_unassign_agent_view.py
@@ -6,6 +6,8 @@ from rest_framework import status
 
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 
 from retail.agents.models import Agent, IntegratedAgent
 from retail.projects.models import Project
@@ -48,6 +50,16 @@ class UnassignAgentViewTest(APITestCase):
         self.user = User.objects.create_user(
             username="testuser", password="12345", email="testuser@example.com"
         )
+
+        # Give user internal communication permission for tests
+        content_type = ContentType.objects.get_for_model(User)
+        permission, created = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            name="can communicate internally",
+            content_type=content_type,
+        )
+        self.user.user_permissions.add(permission)
+
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
 

--- a/retail/clients/base.py
+++ b/retail/clients/base.py
@@ -84,3 +84,19 @@ class InternalAuthentication(RequestClient):
         Useful when passing raw tokens to external services.
         """
         return self.__get_module_token().replace("Bearer ", "")
+
+
+class UserAuthentication:
+    """
+    Authentication class for regular users using JWT tokens.
+    """
+
+    def __init__(self, user_token: str):
+        self.user_token = user_token
+
+    @property
+    def headers(self):
+        return {
+            "Content-Type": "application/json; charset: utf-8",
+            "Authorization": f"Bearer {self.user_token}",
+        }

--- a/retail/clients/connect/client.py
+++ b/retail/clients/connect/client.py
@@ -1,24 +1,37 @@
+from typing import Optional
 from django.conf import settings
 
 from retail.interfaces.clients.connect.interface import (
     ConnectClientInterface,
 )
-from retail.clients.base import RequestClient, InternalAuthentication
+from retail.clients.base import (
+    RequestClient,
+    InternalAuthentication,
+    UserAuthentication,
+)
 
 
 class ConnectClient(RequestClient, ConnectClientInterface):
     def __init__(self):
         self.base_url = settings.CONNECT_REST_ENDPOINT
-        self.authentication_instance = InternalAuthentication()
+        self.internal_authentication = InternalAuthentication()
 
-    def get_user_permissions(self, project_uuid, user_email):
+    def get_user_permissions(
+        self, project_uuid, user_email, user_token: Optional[str] = None
+    ):
         url = f"{self.base_url}/v2/projects/{project_uuid}/authorization"
-        params = {"user": user_email}
+
+        if user_token:
+            auth_instance = UserAuthentication(user_token)
+            params = {}
+        else:
+            auth_instance = self.internal_authentication
+            params = {"user": user_email}
 
         response = self.make_request(
             url=url,
             method="GET",
-            headers=self.authentication_instance.headers,
+            headers=auth_instance.headers,
             params=params,
         )
 

--- a/retail/interfaces/clients/connect/interface.py
+++ b/retail/interfaces/clients/connect/interface.py
@@ -1,8 +1,7 @@
-from typing import Protocol, Dict, Tuple
+from typing import Protocol, Dict, Tuple, Optional
 
 
 class ConnectClientInterface(Protocol):
     def get_user_permissions(
-        self, project_uuid: str, user_email: str
-    ) -> Tuple[int, Dict[str, str]]:
-        ...
+        self, project_uuid: str, user_email: str, user_token: Optional[str] = None
+    ) -> Tuple[int, Dict[str, str]]: ...

--- a/retail/interfaces/services/connect.py
+++ b/retail/interfaces/services/connect.py
@@ -1,8 +1,7 @@
-from typing import Protocol, Tuple, Dict
+from typing import Protocol, Tuple, Dict, Optional
 
 
 class ConnectServiceInterface(Protocol):
     def get_user_permissions(
-        self, project_uuid: str, user_email: str
-    ) -> Tuple[int, Dict[str, str]]:
-        ...
+        self, project_uuid: str, user_email: str, user_token: Optional[str] = None
+    ) -> Tuple[int, Dict[str, str]]: ...

--- a/retail/internal/permissions.py
+++ b/retail/internal/permissions.py
@@ -11,12 +11,10 @@ from retail.interfaces.services.connect import ConnectServiceInterface
 
 class CanCommunicateInternally(permissions.IsAuthenticated):
     def has_permission(self, request, view):
-        # Check if the user is authenticated
         user = request.user
         if not user.is_authenticated:
             return False
 
-        # Check if the user has 'can_communicate_internally' permission
         has_internal_permission = user.user_permissions.filter(
             codename="can_communicate_internally"
         ).exists()
@@ -34,19 +32,65 @@ class PermissionsLevels(IntEnum):
 
 
 class HasProjectPermission(permissions.BasePermission):
+    """
+    Permission class that verifies if a user has project-level permissions.
+
+    This permission supports two types of users:
+
+    1. **Internal Users** (with 'authentication.can_communicate_internally' permission):
+       - Can query permissions for other users by providing 'user_email' in query params
+       - Uses internal system authentication with Connect API
+       - Request format: Header 'Project-Uuid' + Query param 'user_email'
+
+    2. **Regular Users** (without internal permission):
+       - Can only query their own permissions
+       - Uses their JWT token for authentication with Connect API
+       - Request format: Header 'Project-Uuid' + Authorization header with JWT
+
+    The permission is granted if the user has 'contributor' or 'moderator' role
+    in the specified project according to Connect microservice.
+
+    Args:
+        connect_service: Optional ConnectServiceInterface implementation for testing
+
+    Returns:
+        bool: True if user has contributor/moderator permissions, False otherwise
+
+    Raises:
+        No exceptions - returns False for any authentication/authorization failures
+    """
+
     def __init__(self, connect_service: Optional[ConnectServiceInterface] = None):
         self.connect_service = connect_service or ConnectService()
 
     def has_permission(self, request: Request, view):
         project_uuid = request.headers.get("Project-Uuid")
-        user_email = request.query_params.get("user_email")
+        user = request.user
 
-        if project_uuid is None or user_email is None:
+        if project_uuid is None or not user.is_authenticated:
             return False
 
-        status_code, response = self.connect_service.get_user_permissions(
-            project_uuid, user_email
-        )
+        is_internal_user = user.has_perm("authentication.can_communicate_internally")
+
+        if is_internal_user:
+            user_email = request.query_params.get("user_email")
+            if user_email is None:
+                return False
+
+            status_code, response = self.connect_service.get_user_permissions(
+                project_uuid, user_email
+            )
+        else:
+            auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+            if not auth_header.startswith("Bearer "):
+                return False
+
+            user_token = auth_header.replace("Bearer ", "")
+            user_email = user.email
+
+            status_code, response = self.connect_service.get_user_permissions(
+                project_uuid, user_email, user_token
+            )
 
         if status_code != 200:
             return False

--- a/retail/internal/permissions.py
+++ b/retail/internal/permissions.py
@@ -70,7 +70,7 @@ class HasProjectPermission(permissions.BasePermission):
         if project_uuid is None or not user.is_authenticated:
             return False
 
-        is_internal_user = user.has_perm("authentication.can_communicate_internally")
+        is_internal_user = user.has_perm("auth.can_communicate_internally")
 
         if is_internal_user:
             user_email = request.query_params.get("user_email")

--- a/retail/internal/tests/test_permissions.py
+++ b/retail/internal/tests/test_permissions.py
@@ -1,0 +1,252 @@
+from unittest.mock import Mock
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from retail.internal.permissions import HasProjectPermission
+from retail.services.connect.service import ConnectService
+
+User = get_user_model()
+
+
+class HasProjectPermissionTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass"
+        )
+
+        content_type = ContentType.objects.get_for_model(User)
+        self.internal_permission, _ = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            name="can communicate internally",
+            content_type=content_type,
+        )
+
+        self.mock_connect_service = Mock(spec=ConnectService)
+        self.permission = HasProjectPermission(
+            connect_service=self.mock_connect_service
+        )
+
+    def _make_drf_request(self, django_request, user=None):
+        """Convert Django request to DRF request with authentication"""
+        if user:
+            force_authenticate(django_request, user=user)
+        return Request(django_request)
+
+    def test_missing_project_uuid_returns_false(self):
+        """Test that missing Project-Uuid header returns False"""
+        django_request = self.factory.get("/")
+        request = self._make_drf_request(django_request, user=self.user)
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_unauthenticated_user_returns_false(self):
+        """Test that unauthenticated user returns False"""
+        django_request = self.factory.get("/", HTTP_PROJECT_UUID="test-uuid")
+        django_request.user = Mock()
+        django_request.user.is_authenticated = False
+        request = self._make_drf_request(django_request)
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_internal_user_missing_user_email_returns_false(self):
+        """Test that internal user without user_email param returns False"""
+        self.user.user_permissions.add(self.internal_permission)
+
+        django_request = self.factory.get("/", HTTP_PROJECT_UUID="test-uuid")
+        request = self._make_drf_request(django_request, user=self.user)
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_internal_user_with_user_email_success(self):
+        """Test successful internal user permission check"""
+        self.user.user_permissions.add(self.internal_permission)
+
+        django_request = self.factory.get(
+            "/?user_email=other@example.com", HTTP_PROJECT_UUID="test-uuid"
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        self.mock_connect_service.get_user_permissions.return_value = (
+            200,
+            {"project_authorization": 2},
+        )
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertTrue(result)
+        self.mock_connect_service.get_user_permissions.assert_called_once_with(
+            "test-uuid", "other@example.com"
+        )
+
+    def test_internal_user_non_200_status_returns_false(self):
+        """Test that non-200 status from connect service returns False"""
+        self.user.user_permissions.add(self.internal_permission)
+
+        django_request = self.factory.get(
+            "/?user_email=other@example.com", HTTP_PROJECT_UUID="test-uuid"
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        self.mock_connect_service.get_user_permissions.return_value = (
+            404,
+            {"error": "Not found"},
+        )
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_internal_user_insufficient_permissions_returns_false(self):
+        """Test that insufficient project authorization returns False"""
+        self.user.user_permissions.add(self.internal_permission)
+
+        django_request = self.factory.get(
+            "/?user_email=other@example.com", HTTP_PROJECT_UUID="test-uuid"
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        self.mock_connect_service.get_user_permissions.return_value = (
+            200,
+            {"project_authorization": 1},
+        )
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_regular_user_missing_auth_header_returns_false(self):
+        """Test that regular user without Authorization header returns False"""
+        django_request = self.factory.get("/", HTTP_PROJECT_UUID="test-uuid")
+        request = self._make_drf_request(django_request, user=self.user)
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_regular_user_invalid_auth_header_returns_false(self):
+        """Test that regular user with invalid Authorization header returns False"""
+        django_request = self.factory.get(
+            "/", HTTP_PROJECT_UUID="test-uuid", HTTP_AUTHORIZATION="Invalid token"
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_regular_user_with_valid_token_success(self):
+        """Test successful regular user permission check"""
+        django_request = self.factory.get(
+            "/",
+            HTTP_PROJECT_UUID="test-uuid",
+            HTTP_AUTHORIZATION="Bearer valid-jwt-token",
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        self.mock_connect_service.get_user_permissions.return_value = (
+            200,
+            {"project_authorization": 3},
+        )
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertTrue(result)
+        self.mock_connect_service.get_user_permissions.assert_called_once_with(
+            "test-uuid", "test@example.com", "valid-jwt-token"
+        )
+
+    def test_regular_user_non_200_status_returns_false(self):
+        """Test that regular user with non-200 status returns False"""
+        django_request = self.factory.get(
+            "/",
+            HTTP_PROJECT_UUID="test-uuid",
+            HTTP_AUTHORIZATION="Bearer valid-jwt-token",
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        self.mock_connect_service.get_user_permissions.return_value = (
+            403,
+            {"error": "Forbidden"},
+        )
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_regular_user_insufficient_permissions_returns_false(self):
+        """Test that regular user with insufficient permissions returns False"""
+        django_request = self.factory.get(
+            "/",
+            HTTP_PROJECT_UUID="test-uuid",
+            HTTP_AUTHORIZATION="Bearer valid-jwt-token",
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        self.mock_connect_service.get_user_permissions.return_value = (
+            200,
+            {"project_authorization": 4},
+        )
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertFalse(result)
+
+    def test_contributor_permission_allowed(self):
+        """Test that contributor level permission is allowed"""
+        self.user.user_permissions.add(self.internal_permission)
+
+        django_request = self.factory.get(
+            "/?user_email=other@example.com", HTTP_PROJECT_UUID="test-uuid"
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        self.mock_connect_service.get_user_permissions.return_value = (
+            200,
+            {"project_authorization": 2},
+        )
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertTrue(result)
+
+    def test_moderator_permission_allowed(self):
+        """Test that moderator level permission is allowed"""
+        self.user.user_permissions.add(self.internal_permission)
+
+        django_request = self.factory.get(
+            "/?user_email=other@example.com", HTTP_PROJECT_UUID="test-uuid"
+        )
+        request = self._make_drf_request(django_request, user=self.user)
+
+        self.mock_connect_service.get_user_permissions.return_value = (
+            200,
+            {"project_authorization": 3},
+        )
+
+        result = self.permission.has_permission(request, None)
+
+        self.assertTrue(result)
+
+    def test_default_connect_service_initialization(self):
+        """Test that HasProjectPermission initializes with default ConnectService when none provided"""
+        permission = HasProjectPermission()
+
+        self.assertIsNotNone(permission.connect_service)
+
+    def test_custom_connect_service_initialization(self):
+        """Test that HasProjectPermission uses provided ConnectService"""
+        custom_service = Mock(spec=ConnectService)
+        permission = HasProjectPermission(connect_service=custom_service)
+
+        self.assertEqual(permission.connect_service, custom_service)

--- a/retail/services/connect/service.py
+++ b/retail/services/connect/service.py
@@ -9,5 +9,9 @@ class ConnectService(ConnectServiceInterface):
     def __init__(self, connect_client: Optional[ConnectClientInterface] = None):
         self.connect_client = connect_client or ConnectClient()
 
-    def get_user_permissions(self, project_uuid, user_email):
-        return self.connect_client.get_user_permissions(project_uuid, user_email)
+    def get_user_permissions(
+        self, project_uuid, user_email, user_token: Optional[str] = None
+    ):
+        return self.connect_client.get_user_permissions(
+            project_uuid, user_email, user_token
+        )

--- a/retail/services/tests/test_connect.py
+++ b/retail/services/tests/test_connect.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock
+from django.test import TestCase
+
+from retail.services.connect.service import ConnectService
+from retail.interfaces.clients.connect.interface import ConnectClientInterface
+
+
+class ConnectServiceTest(TestCase):
+    def setUp(self):
+        self.mock_client = Mock(spec=ConnectClientInterface)
+        self.service = ConnectService(connect_client=self.mock_client)
+
+    def test_get_user_permissions_without_token(self):
+        """Test get_user_permissions without user token (internal user flow)"""
+        self.mock_client.get_user_permissions.return_value = (
+            200,
+            {"project_authorization": 2},
+        )
+
+        result = self.service.get_user_permissions("project-uuid", "user@example.com")
+
+        self.assertEqual(result, (200, {"project_authorization": 2}))
+        self.mock_client.get_user_permissions.assert_called_once_with(
+            "project-uuid", "user@example.com", None
+        )
+
+    def test_get_user_permissions_with_token(self):
+        """Test get_user_permissions with user token (regular user flow)"""
+        self.mock_client.get_user_permissions.return_value = (
+            200,
+            {"project_authorization": 3},
+        )
+
+        result = self.service.get_user_permissions(
+            "project-uuid", "user@example.com", "jwt-token"
+        )
+
+        self.assertEqual(result, (200, {"project_authorization": 3}))
+        self.mock_client.get_user_permissions.assert_called_once_with(
+            "project-uuid", "user@example.com", "jwt-token"
+        )
+
+    def test_get_user_permissions_error_response(self):
+        """Test get_user_permissions with error response"""
+        self.mock_client.get_user_permissions.return_value = (
+            404,
+            {"error": "User not found"},
+        )
+
+        result = self.service.get_user_permissions("project-uuid", "user@example.com")
+
+        self.assertEqual(result, (404, {"error": "User not found"}))
+
+    def test_default_connect_client_initialization(self):
+        """Test that ConnectService initializes with default ConnectClient when none provided"""
+        service = ConnectService()
+
+        self.assertIsNotNone(service.connect_client)
+
+    def test_custom_connect_client_initialization(self):
+        """Test that ConnectService uses provided ConnectClient"""
+        custom_client = Mock(spec=ConnectClientInterface)
+        service = ConnectService(connect_client=custom_client)
+
+        self.assertEqual(service.connect_client, custom_client)


### PR DESCRIPTION
## Support for Regular and Internal Users in Project Permissions

### Overview
Enhanced `HasProjectPermission` class to support both **regular users** and **internal users** when validating project-level permissions through the Connect microservice.

### Changes Made

#### **Architecture Updates**
- **New Authentication Class**: Added `UserAuthentication` for regular user JWT tokens
- **Enhanced ConnectClient**: Now supports dual authentication modes based on user type

####  **Permission Logic**
The `HasProjectPermission` class now automatically detects user type and applies appropriate authentication:

| User Type | Detection | Authentication | API Call |
|-----------|-----------|----------------|----------|
| **Internal** | Has `can_communicate_internally` permission | System token + `user` param | Can query other users' permissions |
| **Regular** | No internal permission | User's JWT token | Can only query own permissions |

### Usage
```python
permission_classes = [HasProjectPermission]

# Internal users: Header Project-Uuid + Query user_email
# Regular users: Header Project-Uuid + Authorization Bearer token
```