### PR TITLE
feat: Add suspend trial project flow with consumer and Connect integration

### DIFF
--- a/retail/clients/connect/client.py
+++ b/retail/clients/connect/client.py
@@ -80,3 +80,18 @@ class ConnectClient(RequestClient, ConnectClientInterface):
             headers=self.internal_authentication.headers,
         )
         return response.json()
+
+    def suspend_trial_project(
+        self,
+        project_uuid: str,
+        conversation_limit: int,
+    ) -> Dict:
+        url = f"{self.base_url}/v2/commerce/projects/" f"{project_uuid}/suspend/"
+
+        response = self.make_request(
+            url=url,
+            method="POST",
+            json={"conversation_limit": conversation_limit},
+            headers=self.internal_authentication.headers,
+        )
+        return response.json()

--- a/retail/event_driven/pika_handle.py
+++ b/retail/event_driven/pika_handle.py
@@ -1,5 +1,14 @@
 import pika
 
+from retail.projects.consumers.project_trial_limit_consumer import (
+    ProjectTrialLimitConsumer,
+)
+
+TRIAL_LIMIT_QUEUE = "retail-setup.projects.trial-limit"
+
 
 def handle_consumers(channel: pika.channel.Channel):
-    pass
+    channel.basic_consume(
+        TRIAL_LIMIT_QUEUE,
+        on_message_callback=ProjectTrialLimitConsumer().handle,
+    )

--- a/retail/interfaces/clients/connect/interface.py
+++ b/retail/interfaces/clients/connect/interface.py
@@ -23,3 +23,10 @@ class ConnectClientInterface(Protocol):
         vtex_host_store: str,
     ) -> Dict:
         ...
+
+    def suspend_trial_project(
+        self,
+        project_uuid: str,
+        conversation_limit: int,
+    ) -> Dict:
+        ...

--- a/retail/interfaces/services/connect.py
+++ b/retail/interfaces/services/connect.py
@@ -23,3 +23,10 @@ class ConnectServiceInterface(Protocol):
         vtex_host_store: str,
     ) -> Dict:
         ...
+
+    def suspend_trial_project(
+        self,
+        project_uuid: str,
+        conversation_limit: int,
+    ) -> Dict:
+        ...

--- a/retail/projects/consumers/project_trial_limit_consumer.py
+++ b/retail/projects/consumers/project_trial_limit_consumer.py
@@ -1,0 +1,46 @@
+import logging
+
+import pika
+
+from weni.pika_eda.django.consumers import PikaEDAConsumer
+
+from retail.projects.usecases.suspend_trial_dto import SuspendTrialProjectDTO
+from retail.projects.usecases.suspend_trial_project import SuspendTrialProjectUseCase
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectTrialLimitConsumer(PikaEDAConsumer):
+    """
+    Consumes messages from Nexus (via Amazon MQ / pika_eda) when a
+    project reaches its trial conversation limit.
+
+    Expected message body:
+        {
+            "project_uuid": "<uuid>",
+            "conversation_limit": 1000
+        }
+    """
+
+    def consume(
+        self,
+        channel: pika.channel.Channel,
+        method: pika.spec.Basic.Deliver,
+        properties: pika.spec.BasicProperties,
+        body: bytes,
+    ):
+        data = self.body
+        logger.info(f"[ProjectTrialLimitConsumer] - Consuming message: {data}")
+
+        dto = SuspendTrialProjectDTO(
+            project_uuid=data.get("project_uuid"),
+            conversation_limit=data.get("conversation_limit"),
+        )
+
+        use_case = SuspendTrialProjectUseCase()
+        use_case.execute(dto)
+
+        logger.info(
+            f"[ProjectTrialLimitConsumer] - Successfully processed "
+            f"trial limit for project: {dto.project_uuid}"
+        )

--- a/retail/projects/tests/test_project_trial_limit_consumer.py
+++ b/retail/projects/tests/test_project_trial_limit_consumer.py
@@ -1,0 +1,83 @@
+import json
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.consumers.project_trial_limit_consumer import (
+    ProjectTrialLimitConsumer,
+)
+
+
+class TestProjectTrialLimitConsumer(TestCase):
+    def setUp(self):
+        self.consumer = ProjectTrialLimitConsumer()
+        self.project_uuid = str(uuid4())
+
+    def _call_handle(self, body: dict):
+        """Calls handle() with mocked pika args, returning the mock channel."""
+        channel = MagicMock()
+        method = MagicMock()
+        method.delivery_tag = "tag-1"
+        properties = MagicMock()
+        raw_body = json.dumps(body).encode("utf-8")
+        self.consumer.handle(channel, method, properties, raw_body)
+        return channel
+
+    @patch(
+        "retail.projects.consumers.project_trial_limit_consumer"
+        ".SuspendTrialProjectUseCase"
+    )
+    def test_delegates_to_use_case_with_correct_dto(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case_cls.return_value = mock_use_case
+
+        channel = self._call_handle(
+            {
+                "project_uuid": self.project_uuid,
+                "conversation_limit": 1000,
+            }
+        )
+
+        mock_use_case.execute.assert_called_once()
+        dto = mock_use_case.execute.call_args[0][0]
+        self.assertEqual(dto.project_uuid, self.project_uuid)
+        self.assertEqual(dto.conversation_limit, 1000)
+        channel.basic_ack.assert_called_once_with("tag-1")
+
+    @patch(
+        "retail.projects.consumers.project_trial_limit_consumer"
+        ".SuspendTrialProjectUseCase"
+    )
+    def test_rejects_message_on_use_case_failure(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case.execute.side_effect = Exception("Something went wrong")
+        mock_use_case_cls.return_value = mock_use_case
+
+        channel = self._call_handle(
+            {
+                "project_uuid": self.project_uuid,
+                "conversation_limit": 1000,
+            }
+        )
+
+        channel.basic_reject.assert_called_once_with("tag-1", requeue=False)
+        channel.basic_ack.assert_not_called()
+
+    @patch(
+        "retail.projects.consumers.project_trial_limit_consumer"
+        ".SuspendTrialProjectUseCase"
+    )
+    def test_handles_different_conversation_limits(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case_cls.return_value = mock_use_case
+
+        self._call_handle(
+            {
+                "project_uuid": self.project_uuid,
+                "conversation_limit": 2000,
+            }
+        )
+
+        dto = mock_use_case.execute.call_args[0][0]
+        self.assertEqual(dto.conversation_limit, 2000)

--- a/retail/projects/tests/test_suspend_trial_project.py
+++ b/retail/projects/tests/test_suspend_trial_project.py
@@ -1,0 +1,180 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.suspend_trial_dto import SuspendTrialProjectDTO
+from retail.projects.usecases.suspend_trial_project import (
+    SuspendTrialProjectUseCase,
+    SuspendTrialError,
+)
+
+
+class TestSuspendTrialProjectUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project",
+            uuid=uuid4(),
+            vtex_account="teststore",
+        )
+        self.wwc_app_uuid = str(uuid4())
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="teststore",
+            project=self.project,
+            config={"channels": {"wwc": {"app_uuid": self.wwc_app_uuid}}},
+        )
+
+        self.mock_integrations = MagicMock()
+        self.mock_connect = MagicMock()
+
+        self.use_case = SuspendTrialProjectUseCase(
+            integrations_client=MagicMock(),
+            connect_client=MagicMock(),
+        )
+        self.use_case.integrations_service = self.mock_integrations
+        self.use_case.connect_service = self.mock_connect
+
+        self.dto = SuspendTrialProjectDTO(
+            project_uuid=str(self.project.uuid),
+            conversation_limit=1000,
+        )
+
+    def test_full_flow_disables_wwc_and_suspends(self):
+        self.mock_integrations.get_channel_app.return_value = {
+            "config": {"renderPercentage": 10, "mainColor": "#3d3d3d"},
+        }
+        self.mock_integrations.configure_channel_app.return_value = {"ok": True}
+        self.mock_connect.suspend_trial_project.return_value = {
+            "project_uuid": self.dto.project_uuid,
+            "suspended": True,
+        }
+
+        self.use_case.execute(self.dto)
+
+        self.mock_integrations.get_channel_app.assert_called_once_with(
+            "wwc", self.wwc_app_uuid
+        )
+        configure_call = self.mock_integrations.configure_channel_app.call_args
+        self.assertEqual(configure_call[0][0], "wwc")
+        self.assertEqual(configure_call[0][1], self.wwc_app_uuid)
+        self.assertEqual(configure_call[0][2]["renderPercentage"], 0)
+        self.assertEqual(configure_call[0][2]["mainColor"], "#3d3d3d")
+
+        self.mock_connect.suspend_trial_project.assert_called_once_with(
+            project_uuid=self.dto.project_uuid,
+            conversation_limit=1000,
+        )
+
+    def test_skips_wwc_when_no_onboarding(self):
+        project_no_onboarding = Project.objects.create(
+            name="No Onboarding",
+            uuid=uuid4(),
+            vtex_account="noboard",
+        )
+        dto = SuspendTrialProjectDTO(
+            project_uuid=str(project_no_onboarding.uuid),
+            conversation_limit=1000,
+        )
+        self.mock_connect.suspend_trial_project.return_value = {
+            "project_uuid": dto.project_uuid,
+            "suspended": True,
+        }
+
+        self.use_case.execute(dto)
+
+        self.mock_integrations.get_channel_app.assert_not_called()
+        self.mock_connect.suspend_trial_project.assert_called_once()
+
+    def test_skips_wwc_when_no_app_uuid_in_config(self):
+        self.onboarding.config = {"channels": {"wwc": {}}}
+        self.onboarding.save()
+
+        self.mock_connect.suspend_trial_project.return_value = {
+            "project_uuid": self.dto.project_uuid,
+            "suspended": True,
+        }
+
+        self.use_case.execute(self.dto)
+
+        self.mock_integrations.get_channel_app.assert_not_called()
+        self.mock_connect.suspend_trial_project.assert_called_once()
+
+    def test_raises_error_when_project_not_found(self):
+        dto = SuspendTrialProjectDTO(
+            project_uuid=str(uuid4()),
+            conversation_limit=1000,
+        )
+
+        with self.assertRaises(SuspendTrialError) as ctx:
+            self.use_case.execute(dto)
+
+        self.assertIn("Project not found", str(ctx.exception))
+
+    def test_raises_error_when_get_channel_app_fails(self):
+        self.mock_integrations.get_channel_app.return_value = None
+
+        with self.assertRaises(SuspendTrialError) as ctx:
+            self.use_case.execute(self.dto)
+
+        self.assertIn("Failed to retrieve WWC channel config", str(ctx.exception))
+
+    def test_raises_error_when_configure_channel_fails(self):
+        self.mock_integrations.get_channel_app.return_value = {
+            "config": {"renderPercentage": 10},
+        }
+        self.mock_integrations.configure_channel_app.return_value = None
+
+        with self.assertRaises(SuspendTrialError) as ctx:
+            self.use_case.execute(self.dto)
+
+        self.assertIn("Failed to disable WWC channel", str(ctx.exception))
+
+    def test_raises_error_when_connect_suspend_fails(self):
+        self.mock_integrations.get_channel_app.return_value = {
+            "config": {"renderPercentage": 10},
+        }
+        self.mock_integrations.configure_channel_app.return_value = {"ok": True}
+        self.mock_connect.suspend_trial_project.side_effect = Exception(
+            "Connection refused"
+        )
+
+        with self.assertRaises(Exception):
+            self.use_case.execute(self.dto)
+
+    def test_handles_empty_onboarding_config(self):
+        self.onboarding.config = {}
+        self.onboarding.save()
+
+        self.mock_connect.suspend_trial_project.return_value = {
+            "project_uuid": self.dto.project_uuid,
+            "suspended": True,
+        }
+
+        self.use_case.execute(self.dto)
+
+        self.mock_integrations.get_channel_app.assert_not_called()
+        self.mock_connect.suspend_trial_project.assert_called_once()
+
+    def test_preserves_existing_config_keys_when_disabling_wwc(self):
+        self.mock_integrations.get_channel_app.return_value = {
+            "config": {
+                "renderPercentage": 10,
+                "mainColor": "#3d3d3d",
+                "title": "Support Chat",
+                "displayUnreadCount": True,
+            },
+        }
+        self.mock_integrations.configure_channel_app.return_value = {"ok": True}
+        self.mock_connect.suspend_trial_project.return_value = {
+            "project_uuid": self.dto.project_uuid,
+            "suspended": True,
+        }
+
+        self.use_case.execute(self.dto)
+
+        updated_config = self.mock_integrations.configure_channel_app.call_args[0][2]
+        self.assertEqual(updated_config["renderPercentage"], 0)
+        self.assertEqual(updated_config["mainColor"], "#3d3d3d")
+        self.assertEqual(updated_config["title"], "Support Chat")
+        self.assertTrue(updated_config["displayUnreadCount"])

--- a/retail/projects/usecases/suspend_trial_dto.py
+++ b/retail/projects/usecases/suspend_trial_dto.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SuspendTrialProjectDTO:
+    project_uuid: str
+    conversation_limit: int

--- a/retail/projects/usecases/suspend_trial_project.py
+++ b/retail/projects/usecases/suspend_trial_project.py
@@ -1,0 +1,106 @@
+import logging
+
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.suspend_trial_dto import SuspendTrialProjectDTO
+from retail.services.connect.service import ConnectService
+from retail.services.integrations.service import IntegrationsService
+from retail.interfaces.clients.connect.interface import ConnectClientInterface
+from retail.interfaces.clients.integrations.interface import IntegrationsClientInterface
+
+logger = logging.getLogger(__name__)
+
+
+class SuspendTrialError(Exception):
+    """Raised when any step of the trial suspension flow fails."""
+
+
+class SuspendTrialProjectUseCase:
+    """
+    Suspends a trial project that reached its conversation limit.
+
+    Flow:
+        1. Disables the WWC channel by setting renderPercentage to 0.
+        2. Calls Connect to suspend the trial project (deactivates billing,
+           suspends org, notifies Flows, sends email to admins).
+    """
+
+    def __init__(
+        self,
+        integrations_client: IntegrationsClientInterface = None,
+        connect_client: ConnectClientInterface = None,
+    ):
+        self.integrations_service = IntegrationsService(client=integrations_client)
+        self.connect_service = ConnectService(connect_client=connect_client)
+
+    def execute(self, dto: SuspendTrialProjectDTO) -> None:
+        logger.info(
+            f"Starting trial suspension for project_uuid={dto.project_uuid} "
+            f"conversation_limit={dto.conversation_limit}"
+        )
+
+        project = self._get_project(dto.project_uuid)
+        wwc_app_uuid = self._get_wwc_app_uuid(project)
+
+        if wwc_app_uuid:
+            self._disable_wwc_channel(wwc_app_uuid, dto.project_uuid)
+        else:
+            logger.warning(
+                f"No WWC channel found for project_uuid={dto.project_uuid}, "
+                f"skipping renderPercentage update"
+            )
+
+        self._suspend_on_connect(dto.project_uuid, dto.conversation_limit)
+
+        logger.info(f"Trial suspension completed for project_uuid={dto.project_uuid}")
+
+    def _get_project(self, project_uuid: str) -> Project:
+        try:
+            return Project.objects.get(uuid=project_uuid)
+        except Project.DoesNotExist:
+            raise SuspendTrialError(f"Project not found: project_uuid={project_uuid}")
+
+    def _get_wwc_app_uuid(self, project: Project) -> str | None:
+        try:
+            onboarding = project.onboarding
+        except ProjectOnboarding.DoesNotExist:
+            return None
+
+        config = onboarding.config or {}
+        wwc_channel = config.get("channels", {}).get("wwc", {})
+        return wwc_channel.get("app_uuid")
+
+    def _disable_wwc_channel(self, app_uuid: str, project_uuid: str) -> None:
+        """Sets renderPercentage to 0 on the WWC channel, hiding the chat widget."""
+        app_data = self.integrations_service.get_channel_app("wwc", app_uuid)
+        if app_data is None:
+            raise SuspendTrialError(
+                f"Failed to retrieve WWC channel config: "
+                f"app_uuid={app_uuid} project_uuid={project_uuid}"
+            )
+
+        config = app_data.get("config", {})
+        config["renderPercentage"] = 0
+
+        result = self.integrations_service.configure_channel_app(
+            "wwc", app_uuid, config
+        )
+        if result is None:
+            raise SuspendTrialError(
+                f"Failed to disable WWC channel: "
+                f"app_uuid={app_uuid} project_uuid={project_uuid}"
+            )
+
+        logger.info(
+            f"WWC channel disabled (renderPercentage=0): "
+            f"app_uuid={app_uuid} project_uuid={project_uuid}"
+        )
+
+    def _suspend_on_connect(self, project_uuid: str, conversation_limit: int) -> None:
+        response = self.connect_service.suspend_trial_project(
+            project_uuid=project_uuid,
+            conversation_limit=conversation_limit,
+        )
+        logger.info(
+            f"Project suspended on Connect: "
+            f"project_uuid={project_uuid} response={response}"
+        )

--- a/retail/services/connect/service.py
+++ b/retail/services/connect/service.py
@@ -41,3 +41,13 @@ class ConnectService(ConnectServiceInterface):
             project_uuid=project_uuid,
             vtex_host_store=vtex_host_store,
         )
+
+    def suspend_trial_project(
+        self,
+        project_uuid: str,
+        conversation_limit: int,
+    ) -> Dict:
+        return self.connect_client.suspend_trial_project(
+            project_uuid=project_uuid,
+            conversation_limit=conversation_limit,
+        )


### PR DESCRIPTION
**What**
Adds the trial project suspension flow — a pika_eda consumer processes conversation limit events from Nexus, disables the WWC widget via Integrations API, and calls Connect to suspend the project.
**Why**
Without this, trial projects that exceed their conversation limit would keep the chat widget visible and Connect would never be notified to deactivate billing, suspend the organization, or alert admins.