### PR TITLE
feat: Adds WPP Cloud activate endpoint for abandoned cart

### DIFF
--- a/retail/api/onboard/serializers.py
+++ b/retail/api/onboard/serializers.py
@@ -6,3 +6,10 @@ class ActivateWebchatSerializer(serializers.Serializer):
 
     app_uuid = serializers.UUIDField(required=True)
     account_id = serializers.CharField(required=True, max_length=64)
+
+
+class ActivateWppCloudSerializer(serializers.Serializer):
+    """Validates the payload for WPP Cloud channel activation."""
+
+    project_uuid = serializers.UUIDField(required=True)
+    percentage = serializers.IntegerField(required=True, min_value=0, max_value=100)

--- a/retail/api/onboard/tests/test_views.py
+++ b/retail/api/onboard/tests/test_views.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
-from retail.api.onboard.views import ActivateWebchatView
+from retail.api.onboard.views import ActivateWebchatView, ActivateWppCloudView
 
 
 class TestActivateWebchatView(TestCase):
@@ -73,5 +74,87 @@ class TestActivateWebchatView(TestCase):
         with patch.object(ActivateWebchatView, "authentication_classes", []):
             with patch.object(ActivateWebchatView, "permission_classes", []):
                 response = ActivateWebchatView.as_view()(request)
+
+        self.assertEqual(response.status_code, 400)
+
+
+class TestActivateWppCloudView(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.project_uuid = str(uuid4())
+        self.valid_payload = {
+            "project_uuid": self.project_uuid,
+            "percentage": 10,
+        }
+
+    def _post(self, data):
+        request = self.factory.post(
+            "/api/onboard/wpp-cloud/activate/",
+            data=data,
+            format="json",
+        )
+        request.user = MagicMock(is_authenticated=True)
+        return request
+
+    @patch("retail.api.onboard.views.ActivateWppCloudUseCase")
+    def test_success_returns_200(self, MockUseCase):
+        mock_integrated = MagicMock()
+        mock_integrated.uuid = uuid4()
+        mock_integrated.contact_percentage = 10
+        MockUseCase.return_value.execute.return_value = mock_integrated
+
+        request = self._post(self.valid_payload)
+
+        with patch.object(ActivateWppCloudView, "authentication_classes", []):
+            with patch.object(ActivateWppCloudView, "permission_classes", []):
+                response = ActivateWppCloudView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["contact_percentage"], 10)
+        self.assertIn("integrated_agent_uuid", response.data)
+
+    def test_missing_project_uuid_returns_400(self):
+        request = self._post({"percentage": 10})
+
+        with patch.object(ActivateWppCloudView, "authentication_classes", []):
+            with patch.object(ActivateWppCloudView, "permission_classes", []):
+                response = ActivateWppCloudView.as_view()(request)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_percentage_returns_400(self):
+        request = self._post({"project_uuid": self.project_uuid})
+
+        with patch.object(ActivateWppCloudView, "authentication_classes", []):
+            with patch.object(ActivateWppCloudView, "permission_classes", []):
+                response = ActivateWppCloudView.as_view()(request)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_percentage_above_100_returns_400(self):
+        request = self._post(
+            {
+                "project_uuid": self.project_uuid,
+                "percentage": 101,
+            }
+        )
+
+        with patch.object(ActivateWppCloudView, "authentication_classes", []):
+            with patch.object(ActivateWppCloudView, "permission_classes", []):
+                response = ActivateWppCloudView.as_view()(request)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_negative_percentage_returns_400(self):
+        request = self._post(
+            {
+                "project_uuid": self.project_uuid,
+                "percentage": -1,
+            }
+        )
+
+        with patch.object(ActivateWppCloudView, "authentication_classes", []):
+            with patch.object(ActivateWppCloudView, "permission_classes", []):
+                response = ActivateWppCloudView.as_view()(request)
 
         self.assertEqual(response.status_code, 400)

--- a/retail/api/onboard/usecases/activate_wpp_cloud.py
+++ b/retail/api/onboard/usecases/activate_wpp_cloud.py
@@ -1,0 +1,46 @@
+import logging
+
+from django.conf import settings
+
+from rest_framework.exceptions import NotFound, ValidationError
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.api.onboard.usecases.dto import ActivateWppCloudDTO
+
+logger = logging.getLogger(__name__)
+
+
+class ActivateWppCloudUseCase:
+    """
+    Activates the abandoned cart agent for a WPP Cloud channel
+    by setting its contact_percentage.
+    """
+
+    def execute(self, dto: ActivateWppCloudDTO) -> IntegratedAgent:
+        abandoned_cart_uuid = getattr(settings, "ABANDONED_CART_AGENT_UUID", "")
+        if not abandoned_cart_uuid:
+            raise ValidationError("ABANDONED_CART_AGENT_UUID is not configured.")
+
+        try:
+            integrated_agent = IntegratedAgent.objects.get(
+                agent__uuid=abandoned_cart_uuid,
+                project__uuid=dto.project_uuid,
+                is_active=True,
+            )
+        except IntegratedAgent.DoesNotExist:
+            raise NotFound(
+                f"No active abandoned cart agent found for "
+                f"project={dto.project_uuid}"
+            )
+
+        integrated_agent.contact_percentage = dto.percentage
+        integrated_agent.save(update_fields=["contact_percentage"])
+
+        logger.info(
+            f"WPP Cloud abandoned cart activated: "
+            f"integrated_agent={integrated_agent.uuid} "
+            f"project={dto.project_uuid} "
+            f"contact_percentage={dto.percentage}"
+        )
+
+        return integrated_agent

--- a/retail/api/onboard/usecases/dto.py
+++ b/retail/api/onboard/usecases/dto.py
@@ -7,3 +7,11 @@ class ActivateWebchatDTO:
 
     app_uuid: str
     account_id: str
+
+
+@dataclass(frozen=True)
+class ActivateWppCloudDTO:
+    """Data needed to activate the WPP Cloud abandoned cart agent."""
+
+    project_uuid: str
+    percentage: int

--- a/retail/api/onboard/usecases/tests/test_activate_wpp_cloud.py
+++ b/retail/api/onboard/usecases/tests/test_activate_wpp_cloud.py
@@ -1,0 +1,95 @@
+from uuid import uuid4
+
+from django.test import TestCase, override_settings
+
+from rest_framework.exceptions import NotFound, ValidationError
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.api.onboard.usecases.activate_wpp_cloud import ActivateWppCloudUseCase
+from retail.api.onboard.usecases.dto import ActivateWppCloudDTO
+from retail.projects.models import Project
+
+
+FAKE_AGENT_UUID = str(uuid4())
+
+
+@override_settings(ABANDONED_CART_AGENT_UUID=FAKE_AGENT_UUID)
+class TestActivateWppCloudUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+        self.agent = Agent.objects.create(
+            uuid=FAKE_AGENT_UUID,
+            name="Abandoned Cart",
+            slug="abandoned-cart",
+            is_oficial=True,
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            is_active=True,
+            contact_percentage=0,
+        )
+        self.use_case = ActivateWppCloudUseCase()
+
+    def test_sets_contact_percentage(self):
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(self.project.uuid),
+            percentage=10,
+        )
+
+        result = self.use_case.execute(dto)
+
+        self.integrated_agent.refresh_from_db()
+        self.assertEqual(result.contact_percentage, 10)
+        self.assertEqual(self.integrated_agent.contact_percentage, 10)
+
+    def test_sets_percentage_to_zero(self):
+        self.integrated_agent.contact_percentage = 50
+        self.integrated_agent.save()
+
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(self.project.uuid),
+            percentage=0,
+        )
+
+        result = self.use_case.execute(dto)
+
+        self.integrated_agent.refresh_from_db()
+        self.assertEqual(result.contact_percentage, 0)
+
+    def test_raises_not_found_when_no_integrated_agent(self):
+        self.integrated_agent.delete()
+
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(self.project.uuid),
+            percentage=10,
+        )
+
+        with self.assertRaises(NotFound):
+            self.use_case.execute(dto)
+
+    def test_raises_not_found_when_agent_inactive(self):
+        self.integrated_agent.is_active = False
+        self.integrated_agent.save()
+
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(self.project.uuid),
+            percentage=10,
+        )
+
+        with self.assertRaises(NotFound):
+            self.use_case.execute(dto)
+
+    @override_settings(ABANDONED_CART_AGENT_UUID="")
+    def test_raises_validation_error_when_uuid_not_configured(self):
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(self.project.uuid),
+            percentage=10,
+        )
+
+        with self.assertRaises(ValidationError):
+            self.use_case.execute(dto)

--- a/retail/api/onboard/views.py
+++ b/retail/api/onboard/views.py
@@ -3,8 +3,12 @@ import logging
 from rest_framework import status
 from rest_framework.response import Response
 
-from retail.api.onboard.serializers import ActivateWebchatSerializer
-from retail.api.onboard.usecases.dto import ActivateWebchatDTO
+from retail.api.onboard.serializers import (
+    ActivateWebchatSerializer,
+    ActivateWppCloudSerializer,
+)
+from retail.api.onboard.usecases.activate_wpp_cloud import ActivateWppCloudUseCase
+from retail.api.onboard.usecases.dto import ActivateWebchatDTO, ActivateWppCloudDTO
 from retail.api.onboard.usecases.publish_webchat_script import (
     PublishWebchatScriptUseCase,
 )
@@ -40,3 +44,33 @@ class ActivateWebchatView(KeycloakAPIView):
         result = use_case.execute(dto)
 
         return Response(result.to_dict(), status=status.HTTP_201_CREATED)
+
+
+class ActivateWppCloudView(KeycloakAPIView):
+    """
+    Activates the WPP Cloud abandoned cart agent by setting
+    its contact_percentage.
+
+    Called by the front-end when the store owner decides to
+    activate the abandoned cart notifications.
+    """
+
+    def post(self, request):
+        serializer = ActivateWppCloudSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(serializer.validated_data["project_uuid"]),
+            percentage=serializer.validated_data["percentage"],
+        )
+
+        use_case = ActivateWppCloudUseCase()
+        integrated_agent = use_case.execute(dto)
+
+        return Response(
+            {
+                "integrated_agent_uuid": str(integrated_agent.uuid),
+                "contact_percentage": integrated_agent.contact_percentage,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/retail/projects/urls.py
+++ b/retail/projects/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 from rest_framework.routers import SimpleRouter
 from retail.projects import views as project_views
-from retail.api.onboard.views import ActivateWebchatView
+from retail.api.onboard.views import ActivateWebchatView, ActivateWppCloudView
 
 
 router = SimpleRouter()
@@ -41,5 +41,10 @@ urlpatterns = [
         "onboard/wwc/activate/",
         ActivateWebchatView.as_view(),
         name="onboard-wwc-activate",
+    ),
+    path(
+        "onboard/wpp-cloud/activate/",
+        ActivateWppCloudView.as_view(),
+        name="onboard-wpp-cloud-activate",
     ),
 ]


### PR DESCRIPTION
## What
Adds a new endpoint POST /api/onboard/wpp-cloud/activate/ that sets the
contact_percentage of the abandoned cart IntegratedAgent for a given project.

The endpoint receives project_uuid and percentage (0-100), finds the active
abandoned cart IntegratedAgent, and updates its contact_percentage.

## Why
The abandoned cart agent is created during onboarding with contact_percentage=0
(inactive). The store owner needs an explicit activation step to control
what percentage of abandoned carts will receive WhatsApp notifications.