### PR TITLE
feat: Add endpoint to install agents for a new channel on existing onboarding

### DIFF
--- a/retail/projects/serializer.py
+++ b/retail/projects/serializer.py
@@ -44,6 +44,12 @@ class OnboardingPatchSerializer(serializers.ModelSerializer):
         fields = ["completed", "current_page", "skipped"]
 
 
+class InstallChannelAgentsSerializer(serializers.Serializer):
+    """Serializer to validate the install channel agents request."""
+
+    channel_data = serializers.DictField(required=True)
+
+
 class ProjectOnboardingSerializer(serializers.Serializer):
     """Serializer for the ProjectOnboarding status response."""
 

--- a/retail/projects/tests/test_install_channel_agents.py
+++ b/retail/projects/tests/test_install_channel_agents.py
@@ -327,3 +327,53 @@ class TestInstallChannelAgentsUseCase(TestCase):
         self.usecase.execute(self._build_dto())
 
         self.usecase.nexus_service.integrate_agent.assert_called_once()
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[],
+    )
+    def test_wwc_channel_is_configured_after_creation(self, _mock_agents):
+        """WWC channels require a configure step after creation."""
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wwc-new-uuid"
+        }
+        self.usecase.integrations_service.configure_channel_app.return_value = {
+            "uuid": "wwc-new-uuid"
+        }
+
+        self.usecase.execute(self._build_dto(channel="wwc", channel_data={}))
+
+        self.usecase.integrations_service.configure_channel_app.assert_called_once()
+        call_args = self.usecase.integrations_service.configure_channel_app.call_args
+        self.assertEqual(call_args[0][0], "wwc")
+        self.assertEqual(call_args[0][1], "wwc-new-uuid")
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[],
+    )
+    def test_wpp_cloud_skips_configure_step(self, _mock_agents):
+        """WPP-Cloud channels do not need a separate configure step."""
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+
+        self.usecase.execute(self._build_dto())
+
+        self.usecase.integrations_service.configure_channel_app.assert_not_called()
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[],
+    )
+    def test_raises_error_when_wwc_configure_fails(self, _mock_agents):
+        """Should raise when WWC configure step fails."""
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wwc-new-uuid"
+        }
+        self.usecase.integrations_service.configure_channel_app.return_value = None
+
+        with self.assertRaises(InstallChannelAgentsError) as ctx:
+            self.usecase.execute(self._build_dto(channel="wwc", channel_data={}))
+
+        self.assertIn("Failed to configure", str(ctx.exception))

--- a/retail/projects/tests/test_install_channel_agents.py
+++ b/retail/projects/tests/test_install_channel_agents.py
@@ -3,6 +3,8 @@ from uuid import uuid4
 
 from django.test import TestCase
 
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.install_channel_agents import (
     InstallChannelAgentsError,
@@ -260,3 +262,68 @@ class TestInstallChannelAgentsUseCase(TestCase):
         self.usecase.execute(self._build_dto())
 
         self.usecase.nexus_service.integrate_agent.assert_not_called()
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+    )
+    def test_skips_agent_already_integrated_via_retail(self, mock_get_agents):
+        """Agents integrated via Retail (active) should also be skipped."""
+        retail_agent = Agent.objects.create(
+            uuid=uuid4(),
+            name="Active Agent",
+            slug="active",
+            description="",
+            project=self.project,
+        )
+        IntegratedAgent.objects.create(
+            agent=retail_agent,
+            project=self.project,
+            is_active=True,
+        )
+
+        mock_get_agents.return_value = [
+            StubAgent(str(retail_agent.uuid), "Active Agent"),
+            StubAgent("new-uuid", "New Agent"),
+        ]
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute(self._build_dto())
+
+        self.usecase.nexus_service.integrate_agent.assert_called_once()
+        call_args = self.usecase.nexus_service.integrate_agent.call_args
+        self.assertEqual(call_args[0][1], "new-uuid")
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+    )
+    def test_inactive_retail_agents_are_not_skipped(self, mock_get_agents):
+        """Agents deactivated in Retail should NOT be skipped."""
+        retail_agent = Agent.objects.create(
+            uuid=uuid4(),
+            name="Inactive Agent",
+            slug="inactive",
+            description="",
+            project=self.project,
+        )
+        IntegratedAgent.objects.create(
+            agent=retail_agent,
+            project=self.project,
+            is_active=False,
+        )
+
+        mock_get_agents.return_value = [
+            StubAgent(str(retail_agent.uuid), "Inactive Agent"),
+        ]
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute(self._build_dto())
+
+        self.usecase.nexus_service.integrate_agent.assert_called_once()

--- a/retail/projects/tests/test_install_channel_agents.py
+++ b/retail/projects/tests/test_install_channel_agents.py
@@ -1,0 +1,262 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.install_channel_agents import (
+    InstallChannelAgentsError,
+    InstallChannelAgentsUseCase,
+)
+from retail.projects.usecases.onboarding_agents.base import PassiveAgent
+from retail.projects.usecases.onboarding_dto import InstallChannelAgentsDTO
+
+
+class StubAgent(PassiveAgent):
+    def __init__(self, uuid, name):
+        self.uuid = uuid
+        self.name = name
+
+
+class TestInstallChannelAgentsUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"wwc": {"app_uuid": "wwc-uuid"}}},
+            completed=True,
+        )
+        self.mock_nexus_client = MagicMock()
+        self.mock_integrations_client = MagicMock()
+        self.usecase = InstallChannelAgentsUseCase(
+            nexus_client=self.mock_nexus_client,
+            integrations_client=self.mock_integrations_client,
+        )
+        self.usecase.integrations_service = MagicMock()
+        self.usecase.nexus_service = MagicMock()
+
+    def _build_dto(self, channel="wpp-cloud", channel_data=None):
+        return InstallChannelAgentsDTO(
+            vtex_account="mystore",
+            channel=channel,
+            channel_data=channel_data
+            or {
+                "auth_code": "abc123",
+                "waba_id": "waba-1",
+                "phone_number_id": "phone-1",
+            },
+        )
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[
+            StubAgent("uuid-1", "Agent A"),
+            StubAgent("uuid-2", "Agent B"),
+        ],
+    )
+    def test_creates_channel_and_integrates_agents(self, _mock_agents):
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute(self._build_dto())
+
+        self.usecase.integrations_service.create_channel_app.assert_called_once_with(
+            "wpp-cloud",
+            str(self.project.uuid),
+            {"auth_code": "abc123", "waba_id": "waba-1", "phone_number_id": "phone-1"},
+        )
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(
+            self.onboarding.config["channels"]["wpp-cloud"]["app_uuid"],
+            "wpp-app-uuid",
+        )
+        self.assertEqual(self.usecase.nexus_service.integrate_agent.call_count, 2)
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[
+            StubAgent("uuid-1", "Agent A"),
+            StubAgent("uuid-2", "Agent B"),
+            StubAgent("uuid-3", "Agent C"),
+        ],
+    )
+    def test_skips_already_integrated_agents(self, _mock_agents):
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = [
+            {"uuid": "uuid-1"},
+            {"uuid": "uuid-3"},
+        ]
+        self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute(self._build_dto())
+
+        self.usecase.nexus_service.integrate_agent.assert_called_once()
+        call_args = self.usecase.nexus_service.integrate_agent.call_args
+        self.assertEqual(call_args[0][1], "uuid-2")
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[
+            StubAgent("uuid-1", "Agent A"),
+            StubAgent("uuid-2", "Agent B"),
+        ],
+    )
+    def test_skips_all_when_all_already_integrated(self, _mock_agents):
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = [
+            {"uuid": "uuid-1"},
+            {"uuid": "uuid-2"},
+        ]
+
+        self.usecase.execute(self._build_dto())
+
+        self.usecase.nexus_service.integrate_agent.assert_not_called()
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[],
+    )
+    def test_skips_integration_when_no_agents_configured(self, _mock_agents):
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+
+        self.usecase.execute(self._build_dto())
+
+        self.usecase.nexus_service.integrate_agent.assert_not_called()
+        self.onboarding.refresh_from_db()
+        self.assertEqual(
+            self.onboarding.config["channels"]["wpp-cloud"]["app_uuid"],
+            "wpp-app-uuid",
+        )
+
+    def test_raises_error_when_no_project_linked(self):
+        ProjectOnboarding.objects.create(vtex_account="noproject")
+
+        dto = InstallChannelAgentsDTO(
+            vtex_account="noproject",
+            channel="wpp-cloud",
+            channel_data={"auth_code": "x"},
+        )
+
+        with self.assertRaises(InstallChannelAgentsError) as ctx:
+            self.usecase.execute(dto)
+
+        self.assertIn("no project linked", str(ctx.exception))
+
+    def test_raises_error_on_unsupported_channel(self):
+        dto = InstallChannelAgentsDTO(
+            vtex_account="mystore",
+            channel="telegram",
+            channel_data={},
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            self.usecase.execute(dto)
+
+        self.assertIn("Unsupported channel", str(ctx.exception))
+
+    def test_raises_error_when_onboarding_not_found(self):
+        dto = InstallChannelAgentsDTO(
+            vtex_account="nonexistent",
+            channel="wpp-cloud",
+            channel_data={},
+        )
+
+        with self.assertRaises(ProjectOnboarding.DoesNotExist):
+            self.usecase.execute(dto)
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[StubAgent("uuid-1", "Agent A")],
+    )
+    def test_raises_error_when_channel_creation_fails(self, _mock_agents):
+        self.usecase.integrations_service.create_channel_app.return_value = None
+
+        with self.assertRaises(InstallChannelAgentsError) as ctx:
+            self.usecase.execute(self._build_dto())
+
+        self.assertIn("Failed to create", str(ctx.exception))
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[StubAgent("uuid-1", "Agent A")],
+    )
+    def test_raises_error_when_agent_integration_fails(self, _mock_agents):
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.integrate_agent.return_value = None
+
+        with self.assertRaises(InstallChannelAgentsError) as ctx:
+            self.usecase.execute(self._build_dto())
+
+        self.assertIn("Failed to integrate agent", str(ctx.exception))
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[StubAgent("uuid-1", "Agent A")],
+    )
+    def test_preserves_existing_channels_in_config(self, _mock_agents):
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute(self._build_dto())
+
+        self.onboarding.refresh_from_db()
+        self.assertIn("wwc", self.onboarding.config["channels"])
+        self.assertEqual(
+            self.onboarding.config["channels"]["wwc"]["app_uuid"], "wwc-uuid"
+        )
+        self.assertIn("wpp-cloud", self.onboarding.config["channels"])
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[
+            StubAgent("uuid-1", "Agent A"),
+            StubAgent("uuid-2", "Agent B"),
+        ],
+    )
+    def test_handles_nexus_list_agents_returning_none(self, _mock_agents):
+        """When Nexus list fails (returns None), all agents should be integrated."""
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = None
+        self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute(self._build_dto())
+
+        self.assertEqual(self.usecase.nexus_service.integrate_agent.call_count, 2)
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[StubAgent("uuid-1", "Agent A")],
+    )
+    def test_handles_nexus_list_agents_with_results_key(self, _mock_agents):
+        """Handles Nexus response wrapped in a 'results' key."""
+        self.usecase.integrations_service.create_channel_app.return_value = {
+            "uuid": "wpp-app-uuid"
+        }
+        self.usecase.nexus_service.list_integrated_agents.return_value = {
+            "results": [{"uuid": "uuid-1"}]
+        }
+
+        self.usecase.execute(self._build_dto())
+
+        self.usecase.nexus_service.integrate_agent.assert_not_called()

--- a/retail/projects/tests/test_install_channel_agents.py
+++ b/retail/projects/tests/test_install_channel_agents.py
@@ -22,6 +22,11 @@ class StubAgent(PassiveAgent):
 
 class TestInstallChannelAgentsUseCase(TestCase):
     def setUp(self):
+        self._agentic_patcher = patch(
+            "retail.projects.tasks.task_activate_agentic_cx_script"
+        )
+        self._agentic_patcher.start()
+
         self.project = Project.objects.create(
             name="Test", uuid=uuid4(), vtex_account="mystore"
         )
@@ -39,6 +44,9 @@ class TestInstallChannelAgentsUseCase(TestCase):
         )
         self.usecase.integrations_service = MagicMock()
         self.usecase.nexus_service = MagicMock()
+
+    def tearDown(self):
+        self._agentic_patcher.stop()
 
     def _build_dto(self, channel="wpp-cloud", channel_data=None):
         return InstallChannelAgentsDTO(

--- a/retail/projects/tests/test_integrate_agents.py
+++ b/retail/projects/tests/test_integrate_agents.py
@@ -30,6 +30,7 @@ class TestIntegrateAgentsUseCase(TestCase):
             progress=75,
         )
         self.mock_nexus_service = MagicMock()
+        self.mock_nexus_service.list_integrated_agents.return_value = []
         self.usecase = IntegrateAgentsUseCase(nexus_client=MagicMock())
         self.usecase.nexus_service = self.mock_nexus_service
 
@@ -112,3 +113,43 @@ class TestIntegrateAgentsUseCase(TestCase):
         call_args = self.mock_nexus_service.integrate_agent.call_args
         self.assertEqual(call_args[0][0], str(self.project.uuid))
         self.assertEqual(call_args[0][1], "uuid-1")
+
+    @patch(
+        "retail.projects.usecases.integrate_agents.get_channel_agents",
+        return_value=[
+            StubPassiveAgent("uuid-1", "Agent A"),
+            StubPassiveAgent("uuid-2", "Agent B"),
+            StubPassiveAgent("uuid-3", "Agent C"),
+        ],
+    )
+    def test_skips_already_integrated_agents(self, _mock_agents):
+        self.mock_nexus_service.list_integrated_agents.return_value = [
+            {"uuid": "uuid-1"},
+            {"uuid": "uuid-3"},
+        ]
+        self.mock_nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute("mystore")
+
+        self.mock_nexus_service.integrate_agent.assert_called_once()
+        call_args = self.mock_nexus_service.integrate_agent.call_args
+        self.assertEqual(call_args[0][1], "uuid-2")
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(self.onboarding.progress, AGENT_PROGRESS_END)
+
+    @patch(
+        "retail.projects.usecases.integrate_agents.get_channel_agents",
+        return_value=[
+            StubPassiveAgent("uuid-1", "Agent A"),
+            StubPassiveAgent("uuid-2", "Agent B"),
+        ],
+    )
+    def test_integrates_all_when_nexus_list_returns_none(self, _mock_agents):
+        """When Nexus list fails, all agents should still be integrated."""
+        self.mock_nexus_service.list_integrated_agents.return_value = None
+        self.mock_nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute("mystore")
+
+        self.assertEqual(self.mock_nexus_service.integrate_agent.call_count, 2)

--- a/retail/projects/urls.py
+++ b/retail/projects/urls.py
@@ -44,6 +44,11 @@ urlpatterns = [
         name="onboarding-status",
     ),
     path(
+        "onboard/<str:vtex_account>/<str:channel>/install-agents/",
+        project_views.InstallChannelAgentsView.as_view(),
+        name="onboarding-install-channel-agents",
+    ),
+    path(
         "onboard/<str:vtex_account>/",
         project_views.OnboardingPatchView.as_view(),
         name="onboarding-patch",

--- a/retail/projects/usecases/install_channel_agents.py
+++ b/retail/projects/usecases/install_channel_agents.py
@@ -1,12 +1,15 @@
 import logging
-from typing import Optional, Set
+from typing import Callable, Optional, Set
 
-from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.clients.integrations.client import IntegrationsClient
 from retail.clients.nexus.client import NexusClient
 from retail.interfaces.clients.integrations.interface import IntegrationsClientInterface
 from retail.interfaces.clients.nexus.client import NexusClientInterface
 from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.configure_wwc import (
+    WWC_CREATION_CONFIG,
+    build_wwc_channel_config,
+)
 from retail.projects.usecases.onboarding_agents.agent_mappings import (
     SUPPORTED_CHANNELS,
     get_channel_agents,
@@ -15,11 +18,22 @@ from retail.projects.usecases.onboarding_agents.base import (
     AgentContext,
     OnboardingAgent,
 )
+from retail.projects.usecases.onboarding_agents.integrated_agent_lookup import (
+    get_integrated_agent_uuids,
+)
 from retail.projects.usecases.onboarding_dto import InstallChannelAgentsDTO
 from retail.services.integrations.service import IntegrationsService
 from retail.services.nexus.service import NexusService
 
 logger = logging.getLogger(__name__)
+
+CHANNEL_CREATION_CONFIGS: dict[str, dict] = {
+    "wwc": WWC_CREATION_CONFIG,
+}
+
+CHANNEL_CONFIGURE_BUILDERS: dict[str, Callable[[str], dict]] = {
+    "wwc": build_wwc_channel_config,
+}
 
 
 class InstallChannelAgentsError(Exception):
@@ -35,8 +49,9 @@ class InstallChannelAgentsUseCase:
 
     Flow:
       1. Creates the channel via Integrations API.
-      2. Stores the channel in the onboarding config.
-      3. Integrates agents mapped to that channel, skipping any
+      2. Configures the channel when required (e.g. WWC needs colors/translations).
+      3. Stores the channel in the onboarding config.
+      4. Integrates agents mapped to that channel, skipping any
          that are already integrated in the project.
     """
 
@@ -59,15 +74,18 @@ class InstallChannelAgentsUseCase:
 
         onboarding = self._load_onboarding(dto.vtex_account)
         project_uuid = str(onboarding.project.uuid)
+        language = onboarding.project.language or ""
 
         logger.info(
             f"Starting channel agent installation: "
             f"channel={dto.channel} vtex_account={dto.vtex_account}"
         )
 
-        app_data = self._create_channel(dto.channel, project_uuid, dto.channel_data)
+        creation_config = CHANNEL_CREATION_CONFIGS.get(dto.channel, dto.channel_data)
+        app_data = self._create_channel(dto.channel, project_uuid, creation_config)
         app_uuid = app_data.get("uuid", "")
 
+        self._configure_channel(dto.channel, app_uuid, project_uuid, language)
         self._persist_channel(onboarding, dto.channel, app_uuid)
 
         agents = get_channel_agents(dto.channel)
@@ -79,7 +97,7 @@ class InstallChannelAgentsUseCase:
             )
             return
 
-        integrated_uuids = self._get_integrated_agent_uuids(project_uuid)
+        integrated_uuids = get_integrated_agent_uuids(project_uuid, self.nexus_service)
 
         context = AgentContext(
             project_uuid=project_uuid,
@@ -120,6 +138,30 @@ class InstallChannelAgentsUseCase:
         )
         return response
 
+    def _configure_channel(
+        self, channel: str, app_uuid: str, project_uuid: str, language: str
+    ) -> None:
+        """Applies channel-specific configuration when required (e.g. WWC)."""
+        config_builder = CHANNEL_CONFIGURE_BUILDERS.get(channel)
+        if not config_builder:
+            return
+
+        config = config_builder(language)
+        response = self.integrations_service.configure_channel_app(
+            channel, app_uuid, config
+        )
+
+        if response is None:
+            raise InstallChannelAgentsError(
+                f"Failed to configure {channel} app={app_uuid} "
+                f"for project={project_uuid}"
+            )
+
+        logger.info(
+            f"Channel '{channel}' configured for project={project_uuid}: "
+            f"app_uuid={app_uuid}"
+        )
+
     @staticmethod
     def _persist_channel(
         onboarding: ProjectOnboarding, channel: str, app_uuid: str
@@ -135,40 +177,6 @@ class InstallChannelAgentsUseCase:
             f"Channel '{channel}' stored in onboarding config: "
             f"vtex_account={onboarding.vtex_account} app_uuid={app_uuid}"
         )
-
-    def _get_integrated_agent_uuids(self, project_uuid: str) -> Set[str]:
-        """
-        Fetches UUIDs of agents already integrated in the project.
-
-        Combines both sources:
-          - Nexus (passive agents via app-assign)
-          - Retail DB (active agents via IntegratedAgent)
-        """
-        nexus_uuids = self._get_nexus_integrated_uuids(project_uuid)
-        retail_uuids = self._get_retail_integrated_uuids(project_uuid)
-        return nexus_uuids | retail_uuids
-
-    def _get_nexus_integrated_uuids(self, project_uuid: str) -> Set[str]:
-        """Fetches UUIDs of passive agents integrated via Nexus."""
-        response = self.nexus_service.list_integrated_agents(project_uuid)
-        if not response:
-            return set()
-
-        agents = response if isinstance(response, list) else response.get("results", [])
-        return {str(agent.get("uuid", "")) for agent in agents if agent.get("uuid")}
-
-    @staticmethod
-    def _get_retail_integrated_uuids(project_uuid: str) -> Set[str]:
-        """Fetches UUIDs of active agents integrated via Retail."""
-        return {
-            str(uuid)
-            for uuid in IntegratedAgent.objects.filter(
-                project__uuid=project_uuid,
-                is_active=True,
-            )
-            .values_list("agent__uuid", flat=True)
-            .distinct()
-        }
 
     def _integrate_agents(
         self,

--- a/retail/projects/usecases/install_channel_agents.py
+++ b/retail/projects/usecases/install_channel_agents.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, Set
 
+from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.clients.integrations.client import IntegrationsClient
 from retail.clients.nexus.client import NexusClient
 from retail.interfaces.clients.integrations.interface import IntegrationsClientInterface
@@ -136,13 +137,38 @@ class InstallChannelAgentsUseCase:
         )
 
     def _get_integrated_agent_uuids(self, project_uuid: str) -> Set[str]:
-        """Fetches UUIDs of agents already integrated in the project."""
+        """
+        Fetches UUIDs of agents already integrated in the project.
+
+        Combines both sources:
+          - Nexus (passive agents via app-assign)
+          - Retail DB (active agents via IntegratedAgent)
+        """
+        nexus_uuids = self._get_nexus_integrated_uuids(project_uuid)
+        retail_uuids = self._get_retail_integrated_uuids(project_uuid)
+        return nexus_uuids | retail_uuids
+
+    def _get_nexus_integrated_uuids(self, project_uuid: str) -> Set[str]:
+        """Fetches UUIDs of passive agents integrated via Nexus."""
         response = self.nexus_service.list_integrated_agents(project_uuid)
         if not response:
             return set()
 
         agents = response if isinstance(response, list) else response.get("results", [])
         return {str(agent.get("uuid", "")) for agent in agents if agent.get("uuid")}
+
+    @staticmethod
+    def _get_retail_integrated_uuids(project_uuid: str) -> Set[str]:
+        """Fetches UUIDs of active agents integrated via Retail."""
+        return {
+            str(uuid)
+            for uuid in IntegratedAgent.objects.filter(
+                project__uuid=project_uuid,
+                is_active=True,
+            )
+            .values_list("agent__uuid", flat=True)
+            .distinct()
+        }
 
     def _integrate_agents(
         self,

--- a/retail/projects/usecases/install_channel_agents.py
+++ b/retail/projects/usecases/install_channel_agents.py
@@ -1,0 +1,184 @@
+import logging
+from typing import Optional, Set
+
+from retail.clients.integrations.client import IntegrationsClient
+from retail.clients.nexus.client import NexusClient
+from retail.interfaces.clients.integrations.interface import IntegrationsClientInterface
+from retail.interfaces.clients.nexus.client import NexusClientInterface
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.onboarding_agents.agent_mappings import (
+    SUPPORTED_CHANNELS,
+    get_channel_agents,
+)
+from retail.projects.usecases.onboarding_agents.base import (
+    AgentContext,
+    OnboardingAgent,
+)
+from retail.projects.usecases.onboarding_dto import InstallChannelAgentsDTO
+from retail.services.integrations.service import IntegrationsService
+from retail.services.nexus.service import NexusService
+
+logger = logging.getLogger(__name__)
+
+
+class InstallChannelAgentsError(Exception):
+    """Raised when channel agent installation fails."""
+
+
+class InstallChannelAgentsUseCase:
+    """
+    Installs agents for a specific channel on an existing onboarding.
+
+    Used when a store has completed onboarding for one channel (e.g. WWC)
+    and wants to add another (e.g. WPP-Cloud).
+
+    Flow:
+      1. Creates the channel via Integrations API.
+      2. Stores the channel in the onboarding config.
+      3. Integrates agents mapped to that channel, skipping any
+         that are already integrated in the project.
+    """
+
+    def __init__(
+        self,
+        nexus_client: Optional[NexusClientInterface] = None,
+        integrations_client: Optional[IntegrationsClientInterface] = None,
+    ):
+        self.nexus_service = NexusService(nexus_client=nexus_client or NexusClient())
+        self.integrations_service = IntegrationsService(
+            client=integrations_client or IntegrationsClient()
+        )
+
+    def execute(self, dto: InstallChannelAgentsDTO) -> None:
+        if dto.channel not in SUPPORTED_CHANNELS:
+            raise ValueError(
+                f"Unsupported channel '{dto.channel}'. "
+                f"Supported: {SUPPORTED_CHANNELS}"
+            )
+
+        onboarding = self._load_onboarding(dto.vtex_account)
+        project_uuid = str(onboarding.project.uuid)
+
+        logger.info(
+            f"Starting channel agent installation: "
+            f"channel={dto.channel} vtex_account={dto.vtex_account}"
+        )
+
+        app_data = self._create_channel(dto.channel, project_uuid, dto.channel_data)
+        app_uuid = app_data.get("uuid", "")
+
+        self._persist_channel(onboarding, dto.channel, app_uuid)
+
+        agents = get_channel_agents(dto.channel)
+
+        if not agents:
+            logger.info(
+                f"No agents configured for channel '{dto.channel}', "
+                f"skipping integration."
+            )
+            return
+
+        integrated_uuids = self._get_integrated_agent_uuids(project_uuid)
+
+        context = AgentContext(
+            project_uuid=project_uuid,
+            vtex_account=dto.vtex_account,
+        )
+
+        self._integrate_agents(agents, context, integrated_uuids)
+
+    def _load_onboarding(self, vtex_account: str) -> ProjectOnboarding:
+        """Loads and validates the onboarding record has a linked project."""
+        onboarding = ProjectOnboarding.objects.select_related("project").get(
+            vtex_account=vtex_account
+        )
+
+        if onboarding.project is None:
+            raise InstallChannelAgentsError(
+                f"Onboarding {onboarding.uuid} has no project linked yet."
+            )
+
+        return onboarding
+
+    def _create_channel(
+        self, channel: str, project_uuid: str, channel_data: dict
+    ) -> dict:
+        """Creates the channel app via Integrations API."""
+        response = self.integrations_service.create_channel_app(
+            channel, project_uuid, channel_data
+        )
+
+        if response is None:
+            raise InstallChannelAgentsError(
+                f"Failed to create {channel} channel for project={project_uuid}"
+            )
+
+        logger.info(
+            f"Channel '{channel}' created for project={project_uuid}: "
+            f"app_uuid={response.get('uuid')}"
+        )
+        return response
+
+    @staticmethod
+    def _persist_channel(
+        onboarding: ProjectOnboarding, channel: str, app_uuid: str
+    ) -> None:
+        """Stores the channel app UUID in the onboarding config."""
+        config = onboarding.config or {}
+        channels = config.setdefault("channels", {})
+        channels[channel] = {**channels.get(channel, {}), "app_uuid": app_uuid}
+        onboarding.config = config
+        onboarding.save(update_fields=["config"])
+
+        logger.info(
+            f"Channel '{channel}' stored in onboarding config: "
+            f"vtex_account={onboarding.vtex_account} app_uuid={app_uuid}"
+        )
+
+    def _get_integrated_agent_uuids(self, project_uuid: str) -> Set[str]:
+        """Fetches UUIDs of agents already integrated in the project."""
+        response = self.nexus_service.list_integrated_agents(project_uuid)
+        if not response:
+            return set()
+
+        agents = response if isinstance(response, list) else response.get("results", [])
+        return {str(agent.get("uuid", "")) for agent in agents if agent.get("uuid")}
+
+    def _integrate_agents(
+        self,
+        agents: list[OnboardingAgent],
+        context: AgentContext,
+        integrated_uuids: Set[str],
+    ) -> None:
+        """Integrates agents, skipping those already integrated."""
+        integrated_count = 0
+        skipped_count = 0
+
+        for agent in agents:
+            if agent.uuid in integrated_uuids:
+                logger.info(
+                    f"Agent {agent.name} ({agent.uuid}) already integrated "
+                    f"for project={context.project_uuid}, skipping."
+                )
+                skipped_count += 1
+                continue
+
+            result = agent.integrate(context, self.nexus_service)
+
+            if result is None:
+                raise InstallChannelAgentsError(
+                    f"Failed to integrate agent {agent.name} ({agent.uuid}) "
+                    f"for project={context.project_uuid}"
+                )
+
+            logger.info(
+                f"Agent {agent.name} ({agent.uuid}) integrated "
+                f"for project={context.project_uuid}"
+            )
+            integrated_count += 1
+
+        logger.info(
+            f"Channel agent installation completed for "
+            f"project={context.project_uuid}: "
+            f"{integrated_count} integrated, {skipped_count} skipped."
+        )

--- a/retail/projects/usecases/integrate_agents.py
+++ b/retail/projects/usecases/integrate_agents.py
@@ -1,7 +1,6 @@
 import logging
 from typing import List, Set
 
-from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.clients.nexus.client import NexusClient
 from retail.interfaces.clients.nexus.client import NexusClientInterface
 from retail.projects.models import ProjectOnboarding
@@ -11,6 +10,9 @@ from retail.projects.usecases.onboarding_agents.agent_mappings import (
 from retail.projects.usecases.onboarding_agents.base import (
     AgentContext,
     OnboardingAgent,
+)
+from retail.projects.usecases.onboarding_agents.integrated_agent_lookup import (
+    get_integrated_agent_uuids,
 )
 from retail.services.nexus.service import NexusService
 
@@ -66,7 +68,7 @@ class IntegrateAgentsUseCase:
             onboarding.save(update_fields=["progress"])
             return
 
-        integrated_uuids = self._get_integrated_agent_uuids(project_uuid)
+        integrated_uuids = get_integrated_agent_uuids(project_uuid, self.nexus_service)
 
         context = AgentContext(
             project_uuid=project_uuid,
@@ -74,40 +76,6 @@ class IntegrateAgentsUseCase:
         )
 
         self._integrate_agents(onboarding, context, agents, integrated_uuids)
-
-    def _get_integrated_agent_uuids(self, project_uuid: str) -> Set[str]:
-        """
-        Fetches UUIDs of agents already integrated in the project.
-
-        Combines both sources:
-          - Nexus (passive agents via app-assign)
-          - Retail DB (active agents via IntegratedAgent)
-        """
-        nexus_uuids = self._get_nexus_integrated_uuids(project_uuid)
-        retail_uuids = self._get_retail_integrated_uuids(project_uuid)
-        return nexus_uuids | retail_uuids
-
-    def _get_nexus_integrated_uuids(self, project_uuid: str) -> Set[str]:
-        """Fetches UUIDs of passive agents integrated via Nexus."""
-        response = self.nexus_service.list_integrated_agents(project_uuid)
-        if not response:
-            return set()
-
-        agents = response if isinstance(response, list) else response.get("results", [])
-        return {str(agent.get("uuid", "")) for agent in agents if agent.get("uuid")}
-
-    @staticmethod
-    def _get_retail_integrated_uuids(project_uuid: str) -> Set[str]:
-        """Fetches UUIDs of active agents integrated via Retail."""
-        return {
-            str(uuid)
-            for uuid in IntegratedAgent.objects.filter(
-                project__uuid=project_uuid,
-                is_active=True,
-            )
-            .values_list("agent__uuid", flat=True)
-            .distinct()
-        }
 
     def _integrate_agents(
         self,

--- a/retail/projects/usecases/integrate_agents.py
+++ b/retail/projects/usecases/integrate_agents.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Set
 
 from retail.clients.nexus.client import NexusClient
 from retail.interfaces.clients.nexus.client import NexusClientInterface
@@ -30,6 +30,9 @@ class IntegrateAgentsUseCase:
     The agent list is determined by the channel type stored in the
     onboarding config. Each agent instance knows how to integrate
     itself via its ``integrate(context, nexus_service)`` method.
+
+    Agents already integrated in the project are detected via the
+    Nexus list and skipped to avoid duplicates.
 
     Progress: 75% -> 100%.
     """
@@ -62,25 +65,46 @@ class IntegrateAgentsUseCase:
             onboarding.save(update_fields=["progress"])
             return
 
-        # Carries all data that at least one agent needs for integration;
-        # each agent consumes only the fields relevant to its own flow.
+        integrated_uuids = self._get_integrated_agent_uuids(project_uuid)
+
         context = AgentContext(
             project_uuid=project_uuid,
             vtex_account=vtex_account,
         )
 
-        self._integrate_agents(onboarding, context, agents)
+        self._integrate_agents(onboarding, context, agents, integrated_uuids)
+
+    def _get_integrated_agent_uuids(self, project_uuid: str) -> Set[str]:
+        """Fetches UUIDs of agents already integrated in the project."""
+        response = self.nexus_service.list_integrated_agents(project_uuid)
+        if not response:
+            return set()
+
+        agents = response if isinstance(response, list) else response.get("results", [])
+        return {str(agent.get("uuid", "")) for agent in agents if agent.get("uuid")}
 
     def _integrate_agents(
         self,
         onboarding: ProjectOnboarding,
         context: AgentContext,
         agents: List[OnboardingAgent],
+        integrated_uuids: Set[str],
     ) -> None:
         total = len(agents)
         progress_range = AGENT_PROGRESS_END - AGENT_PROGRESS_START
 
         for index, agent in enumerate(agents):
+            if agent.uuid in integrated_uuids:
+                logger.info(
+                    f"Agent {agent.name} ({agent.uuid}) already integrated "
+                    f"for project={context.project_uuid}, skipping."
+                )
+                onboarding.progress = AGENT_PROGRESS_START + int(
+                    ((index + 1) / total) * progress_range
+                )
+                onboarding.save(update_fields=["progress"])
+                continue
+
             result = agent.integrate(context, self.nexus_service)
 
             if result is None:

--- a/retail/projects/usecases/integrate_agents.py
+++ b/retail/projects/usecases/integrate_agents.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List, Set
 
+from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.clients.nexus.client import NexusClient
 from retail.interfaces.clients.nexus.client import NexusClientInterface
 from retail.projects.models import ProjectOnboarding
@@ -75,13 +76,38 @@ class IntegrateAgentsUseCase:
         self._integrate_agents(onboarding, context, agents, integrated_uuids)
 
     def _get_integrated_agent_uuids(self, project_uuid: str) -> Set[str]:
-        """Fetches UUIDs of agents already integrated in the project."""
+        """
+        Fetches UUIDs of agents already integrated in the project.
+
+        Combines both sources:
+          - Nexus (passive agents via app-assign)
+          - Retail DB (active agents via IntegratedAgent)
+        """
+        nexus_uuids = self._get_nexus_integrated_uuids(project_uuid)
+        retail_uuids = self._get_retail_integrated_uuids(project_uuid)
+        return nexus_uuids | retail_uuids
+
+    def _get_nexus_integrated_uuids(self, project_uuid: str) -> Set[str]:
+        """Fetches UUIDs of passive agents integrated via Nexus."""
         response = self.nexus_service.list_integrated_agents(project_uuid)
         if not response:
             return set()
 
         agents = response if isinstance(response, list) else response.get("results", [])
         return {str(agent.get("uuid", "")) for agent in agents if agent.get("uuid")}
+
+    @staticmethod
+    def _get_retail_integrated_uuids(project_uuid: str) -> Set[str]:
+        """Fetches UUIDs of active agents integrated via Retail."""
+        return {
+            str(uuid)
+            for uuid in IntegratedAgent.objects.filter(
+                project__uuid=project_uuid,
+                is_active=True,
+            )
+            .values_list("agent__uuid", flat=True)
+            .distinct()
+        }
 
     def _integrate_agents(
         self,

--- a/retail/projects/usecases/onboarding_agents/integrated_agent_lookup.py
+++ b/retail/projects/usecases/onboarding_agents/integrated_agent_lookup.py
@@ -1,0 +1,48 @@
+"""
+Shared lookup for agents already integrated in a project.
+
+Combines two sources to build a complete set of integrated agent UUIDs:
+  - Nexus API (passive agents toggled via app-assign)
+  - Retail DB (active agents assigned via IntegratedAgent)
+
+Used by both IntegrateAgentsUseCase (onboarding flow) and
+InstallChannelAgentsUseCase (post-onboarding channel addition)
+to skip agents that are already integrated.
+"""
+
+from typing import Set
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.services.nexus.service import NexusService
+
+
+def get_integrated_agent_uuids(
+    project_uuid: str, nexus_service: NexusService
+) -> Set[str]:
+    """Returns the union of Nexus-integrated and Retail-integrated agent UUIDs."""
+    return _get_nexus_uuids(project_uuid, nexus_service) | _get_retail_uuids(
+        project_uuid
+    )
+
+
+def _get_nexus_uuids(project_uuid: str, nexus_service: NexusService) -> Set[str]:
+    """Fetches UUIDs of passive agents integrated via Nexus."""
+    response = nexus_service.list_integrated_agents(project_uuid)
+    if not response:
+        return set()
+
+    agents = response if isinstance(response, list) else response.get("results", [])
+    return {str(agent.get("uuid", "")) for agent in agents if agent.get("uuid")}
+
+
+def _get_retail_uuids(project_uuid: str) -> Set[str]:
+    """Fetches UUIDs of active agents integrated via Retail."""
+    return {
+        str(uuid)
+        for uuid in IntegratedAgent.objects.filter(
+            project__uuid=project_uuid,
+            is_active=True,
+        )
+        .values_list("agent__uuid", flat=True)
+        .distinct()
+    }

--- a/retail/projects/usecases/onboarding_dto.py
+++ b/retail/projects/usecases/onboarding_dto.py
@@ -20,3 +20,12 @@ class StartOnboardingDTO:
     vtex_account: str
     crawl_url: str
     channel: str
+
+
+@dataclass(frozen=True)
+class InstallChannelAgentsDTO:
+    """Data sent to install agents for a new channel on an existing onboarding."""
+
+    vtex_account: str
+    channel: str
+    channel_data: dict = field(default_factory=dict)

--- a/retail/projects/views.py
+++ b/retail/projects/views.py
@@ -17,15 +17,21 @@ from retail.projects.serializer import (
     ProjectVtexConfigSerializer,
     StartOnboardingSerializer,
     CrawlerWebhookSerializer,
+    InstallChannelAgentsSerializer,
     OnboardingPatchSerializer,
     ProjectOnboardingSerializer,
 )
 from retail.projects.usecases.get_project_vtex_account import (
     GetProjectVtexAccountUseCase,
 )
+from retail.projects.usecases.install_channel_agents import (
+    InstallChannelAgentsError,
+    InstallChannelAgentsUseCase,
+)
 from retail.projects.usecases.onboarding_dto import (
     StartOnboardingDTO,
     CrawlerWebhookDTO,
+    InstallChannelAgentsDTO,
 )
 from retail.projects.usecases.project_vtex import ProjectVtexConfigUseCase
 from retail.projects.usecases.start_crawl import CrawlerStartError
@@ -229,3 +235,37 @@ class OnboardingPatchView(KeycloakAPIView):
             ProjectOnboardingSerializer(onboarding).data,
             status=status.HTTP_200_OK,
         )
+
+
+class InstallChannelAgentsView(KeycloakAPIView):
+    """
+    Installs agents for a specific channel on an existing onboarding.
+
+    Creates the channel via Integrations API and integrates
+    the mapped agents, skipping any already integrated ones.
+    """
+
+    def post(self, request, vtex_account: str, channel: str) -> Response:
+        serializer = InstallChannelAgentsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dto = InstallChannelAgentsDTO(
+            vtex_account=vtex_account,
+            channel=channel,
+            channel_data=serializer.validated_data["channel_data"],
+        )
+
+        try:
+            InstallChannelAgentsUseCase().execute(dto)
+        except ProjectOnboarding.DoesNotExist:
+            return Response(
+                {"detail": f"No onboarding found for vtex_account={vtex_account}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except (InstallChannelAgentsError, ValueError) as e:
+            return Response(
+                {"detail": str(e)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(status=status.HTTP_201_CREATED)

--- a/retail/projects/views.py
+++ b/retail/projects/views.py
@@ -268,4 +268,4 @@ class InstallChannelAgentsView(KeycloakAPIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        return Response(status=status.HTTP_201_CREATED)
+        return Response({"success": True}, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## What
Adds POST /api/onboard/<vtex_account>/<channel>/install-agents/ endpoint that
creates a channel via Integrations API and integrates the mapped agents, skipping
any already integrated ones. Also adds duplicate agent detection to the existing
IntegrateAgentsUseCase as a general safety measure.

## Why
After completing onboarding for one channel (e.g. WWC), users need to install
another channel (e.g. WPP-Cloud) without re-running the full onboarding flow.
Passive agents may already be integrated from the first channel, so a duplicate
check prevents redundant integrations.