### PR TITLE
feat: Add payment transaction proxy endpoint for agentic-cx

### DIFF
--- a/retail/clients/vtex_io/client.py
+++ b/retail/clients/vtex_io/client.py
@@ -268,3 +268,35 @@ class VtexIOClient(RequestClient, VtexIOClientInterface):
         )
 
         return response.json()
+
+    def proxy_payment_transaction(
+        self,
+        account_domain: str,
+        vtex_account: str,
+        transaction_id: str,
+        payments: list,
+    ) -> dict:
+        """
+        Proxies a payment transaction request to the VTEX IO agentic-cx app.
+
+        Forwards transactionId and payments to the /_v/proxy-payment-transaction
+        route, which in turn calls the VTEX Vault payments API.
+
+        Args:
+            account_domain (str): VTEX account domain.
+            vtex_account (str): VTEX account for JWT token generation.
+            transaction_id (str): The payment transaction ID.
+            payments (list): Non-empty list of payment objects.
+
+        Returns:
+            dict: Response from the VTEX IO proxy-payment-transaction route.
+        """
+        url = self._get_url(account_domain, "/proxy-payment-transaction")
+        payload = {
+            "transactionId": transaction_id,
+            "payments": payments,
+        }
+        headers = self._get_jwt_headers(vtex_account)
+        response = self.make_request(url, method="POST", json=payload, headers=headers)
+
+        return response.json()

--- a/retail/interfaces/clients/vtex_io/interface.py
+++ b/retail/interfaces/clients/vtex_io/interface.py
@@ -128,3 +128,25 @@ class VtexIOClientInterface(ABC):
             dict: Response data from VTEX platform.
         """
         pass
+
+    @abstractmethod
+    def proxy_payment_transaction(
+        self,
+        account_domain: str,
+        vtex_account: str,
+        transaction_id: str,
+        payments: list,
+    ) -> dict:
+        """
+        Proxies a payment transaction request to the VTEX IO agentic-cx app.
+
+        Args:
+            account_domain (str): VTEX account domain.
+            vtex_account (str): VTEX account for JWT token generation.
+            transaction_id (str): The payment transaction ID.
+            payments (list): Non-empty list of payment objects.
+
+        Returns:
+            dict: Response from the VTEX IO proxy-payment-transaction route.
+        """
+        pass

--- a/retail/services/vtex_io/service.py
+++ b/retail/services/vtex_io/service.py
@@ -159,3 +159,29 @@ class VtexIOService:
             data=data,
             params=params,
         )
+
+    def proxy_payment_transaction(
+        self,
+        account_domain: str,
+        vtex_account: str,
+        transaction_id: str,
+        payments: list,
+    ) -> dict:
+        """
+        Proxies a payment transaction request to VTEX IO.
+
+        Args:
+            account_domain (str): The domain of the VTEX account.
+            vtex_account (str): VTEX account for JWT token generation.
+            transaction_id (str): The payment transaction ID.
+            payments (list): Non-empty list of payment objects.
+
+        Returns:
+            dict: Response from the VTEX IO proxy-payment-transaction route.
+        """
+        return self.client.proxy_payment_transaction(
+            account_domain=account_domain,
+            vtex_account=vtex_account,
+            transaction_id=transaction_id,
+            payments=payments,
+        )

--- a/retail/vtex/dtos/proxy_payment_transaction_dto.py
+++ b/retail/vtex/dtos/proxy_payment_transaction_dto.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyPaymentTransactionDTO:
+    """Immutable transport object for the payment transaction proxy use case."""
+
+    transaction_id: str
+    payments: tuple

--- a/retail/vtex/serializers.py
+++ b/retail/vtex/serializers.py
@@ -47,3 +47,14 @@ class LeadSerializer(serializers.Serializer):
     plan = serializers.CharField(max_length=100, required=True)
     vtex_account = serializers.CharField(max_length=100, required=True)
     data = serializers.DictField(required=False, default=dict)
+
+
+class ProxyPaymentTransactionSerializer(serializers.Serializer):
+    """Validates the payload for proxying a payment transaction to VTEX IO."""
+
+    transaction_id = serializers.CharField(required=True)
+    payments = serializers.ListField(
+        child=serializers.DictField(),
+        required=True,
+        allow_empty=False,
+    )

--- a/retail/vtex/urls.py
+++ b/retail/vtex/urls.py
@@ -6,6 +6,7 @@ from retail.vtex.views import (
     OrderFormTrackingView,
     OrderDetailsProxyView,
     OrdersProxyView,
+    PaymentTransactionProxyView,
     StoreUrlView,
     VtexProxyView,
 )
@@ -37,6 +38,11 @@ urlpatterns = [
         "proxy/",
         VtexProxyView.as_view(),
         name="vtex-proxy",
+    ),
+    path(
+        "payments/send-transaction/",
+        PaymentTransactionProxyView.as_view(),
+        name="vtex-payment-transaction-proxy",
     ),
     path(
         "account/<str:vtex_account>/project-user/",

--- a/retail/vtex/usecases/proxy_payment_transaction.py
+++ b/retail/vtex/usecases/proxy_payment_transaction.py
@@ -1,0 +1,42 @@
+import logging
+
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.dtos.proxy_payment_transaction_dto import ProxyPaymentTransactionDTO
+from retail.vtex.usecases.base import BaseVtexUseCase
+
+logger = logging.getLogger(__name__)
+
+
+class ProxyPaymentTransactionUseCase(BaseVtexUseCase):
+    """
+    Use case for proxying payment transaction requests to the VTEX IO
+    agentic-cx proxy-payment-transaction route.
+    """
+
+    def __init__(self, vtex_io_service: VtexIOService):
+        self.vtex_io_service = vtex_io_service
+
+    def execute(self, dto: ProxyPaymentTransactionDTO, project_uuid: str) -> dict:
+        """
+        Forwards a payment transaction to VTEX IO.
+
+        Args:
+            dto: Validated payment transaction data.
+            project_uuid: Project UUID to resolve VTEX context.
+
+        Returns:
+            dict: Response from the VTEX IO proxy-payment-transaction route.
+        """
+        vtex_account, account_domain = self._get_vtex_context(project_uuid)
+
+        logger.info(
+            f"Proxying payment transaction for "
+            f"vtex_account={vtex_account} transaction_id={dto.transaction_id}"
+        )
+
+        return self.vtex_io_service.proxy_payment_transaction(
+            account_domain=account_domain,
+            vtex_account=vtex_account,
+            transaction_id=dto.transaction_id,
+            payments=list(dto.payments),
+        )

--- a/retail/vtex/views.py
+++ b/retail/vtex/views.py
@@ -15,6 +15,7 @@ from retail.vtex.serializers import (
     LeadSerializer,
     OrderFormTrackingSerializer,
     OrdersQueryParamsSerializer,
+    ProxyPaymentTransactionSerializer,
     VtexProxySerializer,
 )
 from retail.services.vtex_io.service import VtexIOService
@@ -32,6 +33,10 @@ from retail.vtex.usecases.register_lead import (
     RegisterLeadUseCase,
 )
 from retail.vtex.usecases.proxy_vtex import ProxyVtexUsecase
+from retail.vtex.usecases.proxy_payment_transaction import (
+    ProxyPaymentTransactionUseCase,
+)
+from retail.vtex.dtos.proxy_payment_transaction_dto import ProxyPaymentTransactionDTO
 from retail.vtex.tasks import task_notify_lead
 
 logger = logging.getLogger(__name__)
@@ -290,6 +295,46 @@ class VtexProxyView(BaseVtexProxyView):
             project_uuid=self.project_uuid,
         )
 
+        return Response(result, status=status.HTTP_200_OK)
+
+
+class PaymentTransactionProxyView(BaseVtexProxyView):
+    """
+    POST endpoint that proxies payment transaction data to the VTEX IO
+    agentic-cx proxy-payment-transaction route.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._usecase = None
+
+    @property
+    def usecase(self) -> ProxyPaymentTransactionUseCase:
+        if not self._usecase:
+            self._usecase = ProxyPaymentTransactionUseCase(
+                vtex_io_service=VtexIOService()
+            )
+        return self._usecase
+
+    def post(self, request: Request) -> Response:
+        """
+        Forwards a payment transaction to the VTEX IO proxy-payment-transaction route.
+
+        Args:
+            request (Request): The incoming request with transactionId and payments.
+
+        Returns:
+            Response: The response from VTEX IO.
+        """
+        serializer = ProxyPaymentTransactionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dto = ProxyPaymentTransactionDTO(
+            transaction_id=serializer.validated_data["transaction_id"],
+            payments=tuple(serializer.validated_data["payments"]),
+        )
+
+        result = self.usecase.execute(dto=dto, project_uuid=self.project_uuid)
         return Response(result, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
## What
Adds a new POST endpoint `/vtex/payments/send-transaction/` that proxies
payment transaction requests from the intelligent agent to the VTEX IO
agentic-cx `/_v/proxy-payment-transaction` route.

## Why
The agentic-cx VTEX IO app exposes a payment transaction proxy route that
forwards payment data to the VTEX Vault API. The retail backend needs an
endpoint so the intelligent agent can call this route using the existing
JWT authentication flow, without directly accessing the IO app.