### PR TITLE
fix: Use dedicated endpoint for wpp-cloud channel creation

### DIFF
--- a/retail/projects/tests/test_install_channel_agents.py
+++ b/retail/projects/tests/test_install_channel_agents.py
@@ -68,7 +68,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         ],
     )
     def test_creates_channel_and_integrates_agents(self, _mock_agents):
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = []
@@ -76,10 +76,11 @@ class TestInstallChannelAgentsUseCase(TestCase):
 
         self.usecase.execute(self._build_dto())
 
-        self.usecase.integrations_service.create_channel_app.assert_called_once_with(
-            "wpp-cloud",
-            str(self.project.uuid),
-            {"auth_code": "abc123", "waba_id": "waba-1", "phone_number_id": "phone-1"},
+        self.usecase.integrations_service.create_wpp_cloud_channel.assert_called_once_with(
+            project_uuid=str(self.project.uuid),
+            auth_code="abc123",
+            waba_id="waba-1",
+            phone_number_id="phone-1",
         )
 
         self.onboarding.refresh_from_db()
@@ -98,7 +99,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         ],
     )
     def test_skips_already_integrated_agents(self, _mock_agents):
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = [
@@ -121,7 +122,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         ],
     )
     def test_skips_all_when_all_already_integrated(self, _mock_agents):
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = [
@@ -138,7 +139,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         return_value=[],
     )
     def test_skips_integration_when_no_agents_configured(self, _mock_agents):
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
 
@@ -192,7 +193,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         return_value=[StubAgent("uuid-1", "Agent A")],
     )
     def test_raises_error_when_channel_creation_fails(self, _mock_agents):
-        self.usecase.integrations_service.create_channel_app.return_value = None
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = None
 
         with self.assertRaises(InstallChannelAgentsError) as ctx:
             self.usecase.execute(self._build_dto())
@@ -204,7 +205,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         return_value=[StubAgent("uuid-1", "Agent A")],
     )
     def test_raises_error_when_agent_integration_fails(self, _mock_agents):
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = []
@@ -220,7 +221,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         return_value=[StubAgent("uuid-1", "Agent A")],
     )
     def test_preserves_existing_channels_in_config(self, _mock_agents):
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = []
@@ -244,7 +245,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
     )
     def test_handles_nexus_list_agents_returning_none(self, _mock_agents):
         """When Nexus list fails (returns None), all agents should be integrated."""
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = None
@@ -260,7 +261,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
     )
     def test_handles_nexus_list_agents_with_results_key(self, _mock_agents):
         """Handles Nexus response wrapped in a 'results' key."""
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = {
@@ -293,7 +294,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
             StubAgent(str(retail_agent.uuid), "Active Agent"),
             StubAgent("new-uuid", "New Agent"),
         ]
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = []
@@ -326,7 +327,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         mock_get_agents.return_value = [
             StubAgent(str(retail_agent.uuid), "Inactive Agent"),
         ]
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
         self.usecase.nexus_service.list_integrated_agents.return_value = []
@@ -362,7 +363,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
     )
     def test_wpp_cloud_skips_configure_step(self, _mock_agents):
         """WPP-Cloud channels do not need a separate configure step."""
-        self.usecase.integrations_service.create_channel_app.return_value = {
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "uuid": "wpp-app-uuid"
         }
 

--- a/retail/projects/usecases/install_channel_agents.py
+++ b/retail/projects/usecases/install_channel_agents.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Optional, Set
+from typing import Optional, Protocol, Set
 
 from retail.clients.integrations.client import IntegrationsClient
 from retail.clients.nexus.client import NexusClient
@@ -27,17 +27,83 @@ from retail.services.nexus.service import NexusService
 
 logger = logging.getLogger(__name__)
 
-CHANNEL_CREATION_CONFIGS: dict[str, dict] = {
-    "wwc": WWC_CREATION_CONFIG,
-}
-
-CHANNEL_CONFIGURE_BUILDERS: dict[str, Callable[[str], dict]] = {
-    "wwc": build_wwc_channel_config,
-}
-
 
 class InstallChannelAgentsError(Exception):
     """Raised when channel agent installation fails."""
+
+
+class ChannelInstaller(Protocol):
+    def install(
+        self,
+        service: IntegrationsService,
+        project_uuid: str,
+        channel_data: dict,
+        language: str,
+    ) -> dict:
+        ...
+
+
+class WWCChannelInstaller:
+    def install(
+        self,
+        service: IntegrationsService,
+        project_uuid: str,
+        channel_data: dict,
+        language: str,
+    ) -> dict:
+        app_data = service.create_channel_app("wwc", project_uuid, WWC_CREATION_CONFIG)
+        if app_data is None:
+            raise InstallChannelAgentsError(
+                f"Failed to create wwc channel for project={project_uuid}"
+            )
+
+        app_uuid = app_data.get("uuid", "")
+        logger.info(
+            f"Channel 'wwc' created for project={project_uuid}: app_uuid={app_uuid}"
+        )
+
+        config = build_wwc_channel_config(language)
+        if service.configure_channel_app("wwc", app_uuid, config) is None:
+            raise InstallChannelAgentsError(
+                f"Failed to configure wwc app={app_uuid} for project={project_uuid}"
+            )
+
+        logger.info(
+            f"Channel 'wwc' configured for project={project_uuid}: app_uuid={app_uuid}"
+        )
+        return app_data
+
+
+class WppCloudChannelInstaller:
+    def install(
+        self,
+        service: IntegrationsService,
+        project_uuid: str,
+        channel_data: dict,
+        language: str,
+    ) -> dict:
+        app_data = service.create_wpp_cloud_channel(
+            project_uuid=project_uuid,
+            auth_code=channel_data.get("auth_code", ""),
+            waba_id=channel_data.get("waba_id", ""),
+            phone_number_id=channel_data.get("phone_number_id", ""),
+        )
+        if app_data is None:
+            raise InstallChannelAgentsError(
+                f"Failed to create wpp-cloud channel for project={project_uuid}"
+            )
+
+        logger.info(
+            f"Channel 'wpp-cloud' created for project={project_uuid}: "
+            f"app_uuid={app_data.get('uuid')}"
+        )
+        return app_data
+
+
+CHANNEL_INSTALLERS: dict[str, ChannelInstaller] = {
+    "wwc": WWCChannelInstaller(),
+    "wpp-cloud": WppCloudChannelInstaller(),
+}
 
 
 class InstallChannelAgentsUseCase:
@@ -81,11 +147,11 @@ class InstallChannelAgentsUseCase:
             f"channel={dto.channel} vtex_account={dto.vtex_account}"
         )
 
-        creation_config = CHANNEL_CREATION_CONFIGS.get(dto.channel, dto.channel_data)
-        app_data = self._create_channel(dto.channel, project_uuid, creation_config)
+        installer = CHANNEL_INSTALLERS[dto.channel]
+        app_data = installer.install(
+            self.integrations_service, project_uuid, dto.channel_data, language
+        )
         app_uuid = app_data.get("uuid", "")
-
-        self._configure_channel(dto.channel, app_uuid, project_uuid, language)
         self._persist_channel(onboarding, dto.channel, app_uuid)
 
         agents = get_channel_agents(dto.channel)
@@ -118,49 +184,6 @@ class InstallChannelAgentsUseCase:
             )
 
         return onboarding
-
-    def _create_channel(
-        self, channel: str, project_uuid: str, channel_data: dict
-    ) -> dict:
-        """Creates the channel app via Integrations API."""
-        response = self.integrations_service.create_channel_app(
-            channel, project_uuid, channel_data
-        )
-
-        if response is None:
-            raise InstallChannelAgentsError(
-                f"Failed to create {channel} channel for project={project_uuid}"
-            )
-
-        logger.info(
-            f"Channel '{channel}' created for project={project_uuid}: "
-            f"app_uuid={response.get('uuid')}"
-        )
-        return response
-
-    def _configure_channel(
-        self, channel: str, app_uuid: str, project_uuid: str, language: str
-    ) -> None:
-        """Applies channel-specific configuration when required (e.g. WWC)."""
-        config_builder = CHANNEL_CONFIGURE_BUILDERS.get(channel)
-        if not config_builder:
-            return
-
-        config = config_builder(language)
-        response = self.integrations_service.configure_channel_app(
-            channel, app_uuid, config
-        )
-
-        if response is None:
-            raise InstallChannelAgentsError(
-                f"Failed to configure {channel} app={app_uuid} "
-                f"for project={project_uuid}"
-            )
-
-        logger.info(
-            f"Channel '{channel}' configured for project={project_uuid}: "
-            f"app_uuid={app_uuid}"
-        )
 
     @staticmethod
     def _persist_channel(

--- a/retail/projects/usecases/manager_defaults.py
+++ b/retail/projects/usecases/manager_defaults.py
@@ -34,7 +34,7 @@ MANAGER_DEFAULTS = {
     },
 }
 
-MANAGER_PERSONALITY = "Amigável"
+MANAGER_PERSONALITY = "friendly"
 
 FALLBACK_LANGUAGE = "en"
 


### PR DESCRIPTION
## What
Uses the dedicated `create_wpp_cloud_channel` service method for
wpp-cloud channels instead of the generic `create_channel_app`, and
introduces a ChannelInstaller pattern where each channel declares
its own installation steps.

## Why
The generic `create_channel_app` wraps all fields inside a `config`
key, but the wpp-cloud endpoint in integrations-engine expects
`auth_code`, `waba_id`, and `phone_number_id` as top-level fields.
This caused 400 errors in production when installing wpp-cloud
channels via the onboarding flow.