### PR TITLE
feat: Add Payment Gateway proxy endpoint (retail → IO)

### DIFF
--- a/retail/clients/vtex_io/client.py
+++ b/retail/clients/vtex_io/client.py
@@ -269,6 +269,56 @@ class VtexIOClient(RequestClient, VtexIOClientInterface):
 
         return response.json()
 
+    def proxy_payment_gateway(
+        self,
+        account_domain: str,
+        vtex_account: str,
+        method: str,
+        path: str,
+        headers: dict = None,
+        data: Union[dict, list] = None,
+        params: dict = None,
+    ) -> dict:
+        """
+        Proxies requests to the VTEX IO Payment Gateway proxy route.
+
+        Forwards method, path and optional headers/params/data to the
+        /_v/proxy-payment-gateway route, which calls the VTEX Payment
+        Gateway API ({account}.vtexpayments.com.br).
+
+        Args:
+            account_domain (str): VTEX account domain.
+            vtex_account (str): VTEX account for JWT token generation.
+            method (str): HTTP method (GET, POST, PUT).
+            path (str): Payment Gateway API path.
+            headers (dict, optional): Additional headers.
+            data (Union[dict, list], optional): Request body data.
+            params (dict, optional): Query parameters.
+
+        Returns:
+            dict: Response from the VTEX IO proxy-payment-gateway route.
+        """
+        url = self._get_url(account_domain, "/proxy-payment-gateway")
+
+        payload = {
+            "method": method.upper(),
+            "path": path,
+        }
+
+        if headers:
+            payload["headers"] = headers
+        if data:
+            payload["data"] = data
+        if params:
+            payload["params"] = params
+
+        jwt_headers = self._get_jwt_headers(vtex_account)
+        response = self.make_request(
+            url, method="POST", json=payload, headers=jwt_headers
+        )
+
+        return response.json()
+
     def proxy_payment_transaction(
         self,
         account_domain: str,

--- a/retail/interfaces/clients/vtex_io/interface.py
+++ b/retail/interfaces/clients/vtex_io/interface.py
@@ -150,3 +150,31 @@ class VtexIOClientInterface(ABC):
             dict: Response from the VTEX IO proxy-payment-transaction route.
         """
         pass
+
+    @abstractmethod
+    def proxy_payment_gateway(
+        self,
+        account_domain: str,
+        vtex_account: str,
+        method: str,
+        path: str,
+        headers: dict = None,
+        data: Union[dict, list] = None,
+        params: dict = None,
+    ) -> dict:
+        """
+        Proxies requests to the VTEX IO Payment Gateway proxy route.
+
+        Args:
+            account_domain (str): VTEX account domain.
+            vtex_account (str): VTEX account for JWT token generation.
+            method (str): HTTP method (GET, POST, PUT).
+            path (str): Payment Gateway API path.
+            headers (dict, optional): Additional headers.
+            data (Union[dict, list], optional): Request body data.
+            params (dict, optional): Query parameters.
+
+        Returns:
+            dict: Response from the VTEX IO proxy-payment-gateway route.
+        """
+        pass

--- a/retail/services/tests/test_vtex_io.py
+++ b/retail/services/tests/test_vtex_io.py
@@ -133,3 +133,47 @@ class TestVtexIOService(TestCase):
             vtex_account=self.vtex_account,
         )
         self.assertEqual(result, expected_response)
+
+    def test_proxy_payment_gateway_delegates_to_client(self):
+        self.mock_client.proxy_payment_gateway.return_value = {"status": 200}
+
+        result = self.service.proxy_payment_gateway(
+            account_domain=self.account_domain,
+            vtex_account=self.vtex_account,
+            method="GET",
+            path="/api/pvt/transactions/ABC123/interactions",
+            headers={"X-Custom": "value"},
+            data={"key": "value"},
+            params={"an": "teststore"},
+        )
+
+        self.mock_client.proxy_payment_gateway.assert_called_once_with(
+            account_domain=self.account_domain,
+            vtex_account=self.vtex_account,
+            method="GET",
+            path="/api/pvt/transactions/ABC123/interactions",
+            headers={"X-Custom": "value"},
+            data={"key": "value"},
+            params={"an": "teststore"},
+        )
+        self.assertEqual(result, {"status": 200})
+
+    def test_proxy_payment_gateway_with_minimal_params(self):
+        self.mock_client.proxy_payment_gateway.return_value = {}
+
+        self.service.proxy_payment_gateway(
+            account_domain=self.account_domain,
+            vtex_account=self.vtex_account,
+            method="GET",
+            path="/api/pvt/transactions/ABC123",
+        )
+
+        self.mock_client.proxy_payment_gateway.assert_called_once_with(
+            account_domain=self.account_domain,
+            vtex_account=self.vtex_account,
+            method="GET",
+            path="/api/pvt/transactions/ABC123",
+            headers=None,
+            data=None,
+            params=None,
+        )

--- a/retail/services/vtex_io/service.py
+++ b/retail/services/vtex_io/service.py
@@ -160,6 +160,41 @@ class VtexIOService:
             params=params,
         )
 
+    def proxy_payment_gateway(
+        self,
+        account_domain: str,
+        vtex_account: str,
+        method: str,
+        path: str,
+        headers: dict = None,
+        data: Union[dict, list] = None,
+        params: dict = None,
+    ) -> dict:
+        """
+        Proxies requests to the VTEX IO Payment Gateway proxy route.
+
+        Args:
+            account_domain (str): VTEX account domain.
+            vtex_account (str): VTEX account for JWT token generation.
+            method (str): HTTP method (GET, POST, PUT).
+            path (str): Payment Gateway API path.
+            headers (dict, optional): Additional headers.
+            data (Union[dict, list], optional): Request body data.
+            params (dict, optional): Query parameters.
+
+        Returns:
+            dict: Response from the VTEX IO proxy-payment-gateway route.
+        """
+        return self.client.proxy_payment_gateway(
+            account_domain=account_domain,
+            vtex_account=vtex_account,
+            method=method,
+            path=path,
+            headers=headers,
+            data=data,
+            params=params,
+        )
+
     def proxy_payment_transaction(
         self,
         account_domain: str,

--- a/retail/vtex/dtos/proxy_payment_gateway_dto.py
+++ b/retail/vtex/dtos/proxy_payment_gateway_dto.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Optional, Union
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyPaymentGatewayDTO:
+    """Immutable transport object for the Payment Gateway proxy use case."""
+
+    method: str
+    path: str
+    headers: Optional[dict] = None
+    data: Optional[Union[dict, list]] = None
+    params: Optional[dict] = None

--- a/retail/vtex/serializers.py
+++ b/retail/vtex/serializers.py
@@ -58,3 +58,13 @@ class ProxyPaymentTransactionSerializer(serializers.Serializer):
         required=True,
         allow_empty=False,
     )
+
+
+class PaymentGatewayProxySerializer(serializers.Serializer):
+    """Validates the payload for proxying requests to the VTEX Payment Gateway."""
+
+    method = serializers.ChoiceField(choices=["GET", "POST", "PUT"], required=True)
+    path = serializers.CharField(required=True)
+    headers = serializers.DictField(required=False, allow_null=True)
+    data = serializers.JSONField(required=False, allow_null=True)
+    params = serializers.DictField(required=False, allow_null=True)

--- a/retail/vtex/tests/test_payment_gateway_proxy_serializer.py
+++ b/retail/vtex/tests/test_payment_gateway_proxy_serializer.py
@@ -1,0 +1,111 @@
+from django.test import TestCase
+
+from retail.vtex.serializers import PaymentGatewayProxySerializer
+
+
+class TestPaymentGatewayProxySerializer(TestCase):
+    def test_valid_minimal_payload(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/api/pvt/transactions/ABC123"}
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_valid_full_payload(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={
+                "method": "POST",
+                "path": "/api/pvt/transactions/ABC123/payments",
+                "headers": {"X-Custom": "value"},
+                "data": {"key": "value"},
+                "params": {"an": "teststore"},
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_accepts_get_method(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/some/path"}
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_accepts_post_method(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "POST", "path": "/some/path"}
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_accepts_put_method(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "PUT", "path": "/some/path"}
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_rejects_patch_method(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "PATCH", "path": "/some/path"}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("method", serializer.errors)
+
+    def test_rejects_delete_method(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "DELETE", "path": "/some/path"}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("method", serializer.errors)
+
+    def test_method_is_required(self):
+        serializer = PaymentGatewayProxySerializer(data={"path": "/some/path"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("method", serializer.errors)
+
+    def test_path_is_required(self):
+        serializer = PaymentGatewayProxySerializer(data={"method": "GET"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("path", serializer.errors)
+
+    def test_headers_is_optional(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/some/path"}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("headers"))
+
+    def test_data_is_optional(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/some/path"}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("data"))
+
+    def test_params_is_optional(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/some/path"}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("params"))
+
+    def test_headers_accepts_null(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/some/path", "headers": None}
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_data_accepts_null(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/some/path", "data": None}
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_data_accepts_list(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "POST", "path": "/some/path", "data": [1, 2, 3]}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["data"], [1, 2, 3])
+
+    def test_empty_payload_fails(self):
+        serializer = PaymentGatewayProxySerializer(data={})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("method", serializer.errors)
+        self.assertIn("path", serializer.errors)

--- a/retail/vtex/tests/test_payment_gateway_proxy_view.py
+++ b/retail/vtex/tests/test_payment_gateway_proxy_view.py
@@ -1,0 +1,141 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from retail.vtex.views import PaymentGatewayProxyView
+
+
+def _jwt_auth_bypass(project_uuid: str):
+    """
+    Patches JWTModuleAuthentication so the request carries
+    project_uuid without a real JWT token.
+    """
+
+    def side_effect(request):
+        request.project_uuid = project_uuid
+        request.vtex_account = None
+        request.jwt_payload = {"project_uuid": project_uuid}
+        return (None, None)
+
+    return patch(
+        "retail.internal.jwt_authenticators.JWTModuleAuthentication.authenticate",
+        side_effect=side_effect,
+    )
+
+
+class TestPaymentGatewayProxyView(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view = PaymentGatewayProxyView.as_view()
+        self.url = "/vtex/payments/gateway-proxy/"
+        self.valid_payload = {
+            "method": "GET",
+            "path": "/api/pvt/transactions/ABC123/interactions",
+        }
+
+    @_jwt_auth_bypass("test-uuid")
+    @patch("retail.vtex.views.ProxyPaymentGatewayUseCase")
+    def test_returns_200_with_upstream_response(self, mock_cls, _auth):
+        mock_cls.return_value.execute.return_value = {
+            "transactions": [{"id": "ABC123"}]
+        }
+
+        request = self.factory.post(self.url, self.valid_payload, format="json")
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["transactions"][0]["id"], "ABC123")
+
+    @_jwt_auth_bypass("test-uuid")
+    @patch("retail.vtex.views.ProxyPaymentGatewayUseCase")
+    def test_passes_correct_dto(self, mock_cls, _auth):
+        mock_cls.return_value.execute.return_value = {}
+
+        payload = {
+            "method": "POST",
+            "path": "/api/pvt/transactions/ABC123/payments",
+            "headers": {"X-Custom": "value"},
+            "data": {"key": "value"},
+            "params": {"an": "teststore"},
+        }
+        request = self.factory.post(self.url, payload, format="json")
+        self.view(request)
+
+        call_kwargs = mock_cls.return_value.execute.call_args[1]
+        dto = call_kwargs["dto"]
+        self.assertEqual(dto.method, "POST")
+        self.assertEqual(dto.path, "/api/pvt/transactions/ABC123/payments")
+        self.assertEqual(dto.headers, {"X-Custom": "value"})
+        self.assertEqual(dto.data, {"key": "value"})
+        self.assertEqual(dto.params, {"an": "teststore"})
+        self.assertEqual(call_kwargs["project_uuid"], "test-uuid")
+
+    @_jwt_auth_bypass("test-uuid")
+    def test_returns_400_when_method_missing(self, _auth):
+        request = self.factory.post(
+            self.url,
+            {"path": "/api/pvt/transactions/ABC123"},
+            format="json",
+        )
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("method", response.data)
+
+    @_jwt_auth_bypass("test-uuid")
+    def test_returns_400_when_path_missing(self, _auth):
+        request = self.factory.post(
+            self.url,
+            {"method": "GET"},
+            format="json",
+        )
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("path", response.data)
+
+    @_jwt_auth_bypass("test-uuid")
+    def test_returns_400_for_unsupported_method_patch(self, _auth):
+        request = self.factory.post(
+            self.url,
+            {"method": "PATCH", "path": "/api/pvt/transactions/ABC123"},
+            format="json",
+        )
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("method", response.data)
+
+    @_jwt_auth_bypass("test-uuid")
+    @patch("retail.vtex.views.ProxyPaymentGatewayUseCase")
+    def test_accepts_get_post_put_methods(self, mock_cls, _auth):
+        mock_cls.return_value.execute.return_value = {}
+
+        for method in ["GET", "POST", "PUT"]:
+            request = self.factory.post(
+                self.url,
+                {"method": method, "path": "/api/pvt/transactions/ABC123"},
+                format="json",
+            )
+            response = self.view(request)
+            self.assertEqual(response.status_code, 200, f"Failed for method {method}")
+
+    @_jwt_auth_bypass("test-uuid")
+    @patch("retail.vtex.views.ProxyPaymentGatewayUseCase")
+    def test_optional_fields_default_to_none(self, mock_cls, _auth):
+        mock_cls.return_value.execute.return_value = {}
+
+        request = self.factory.post(self.url, self.valid_payload, format="json")
+        self.view(request)
+
+        dto = mock_cls.return_value.execute.call_args[1]["dto"]
+        self.assertIsNone(dto.headers)
+        self.assertIsNone(dto.data)
+        self.assertIsNone(dto.params)
+
+    def test_returns_401_without_auth(self):
+        request = self.factory.post(self.url, self.valid_payload, format="json")
+        response = self.view(request)
+
+        self.assertIn(response.status_code, [401, 403])

--- a/retail/vtex/tests/usecases/test_proxy_payment_gateway.py
+++ b/retail/vtex/tests/usecases/test_proxy_payment_gateway.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from retail.vtex.dtos.proxy_payment_gateway_dto import ProxyPaymentGatewayDTO
+from retail.vtex.usecases.proxy_payment_gateway import ProxyPaymentGatewayUseCase
+
+
+class TestProxyPaymentGatewayUseCase(TestCase):
+    def setUp(self):
+        self.mock_service = MagicMock()
+        self.usecase = ProxyPaymentGatewayUseCase(vtex_io_service=self.mock_service)
+        self.dto = ProxyPaymentGatewayDTO(
+            method="GET",
+            path="/api/pvt/transactions/ABC123/interactions",
+        )
+
+    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
+    def test_execute_calls_service_with_correct_params(self, mock_context):
+        mock_context.return_value = ("teststore", "teststore.myvtex.com")
+        self.mock_service.proxy_payment_gateway.return_value = {"data": []}
+
+        result = self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
+
+        self.mock_service.proxy_payment_gateway.assert_called_once_with(
+            account_domain="teststore.myvtex.com",
+            vtex_account="teststore",
+            method="GET",
+            path="/api/pvt/transactions/ABC123/interactions",
+            headers=None,
+            data=None,
+            params=None,
+        )
+        self.assertEqual(result, {"data": []})
+
+    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
+    def test_execute_forwards_optional_fields(self, mock_context):
+        mock_context.return_value = ("teststore", "teststore.myvtex.com")
+        self.mock_service.proxy_payment_gateway.return_value = {}
+
+        dto = ProxyPaymentGatewayDTO(
+            method="POST",
+            path="/api/pvt/transactions/ABC123/payments",
+            headers={"X-Custom": "value"},
+            data={"key": "value"},
+            params={"an": "teststore"},
+        )
+        self.usecase.execute(dto=dto, project_uuid="test-uuid")
+
+        call_kwargs = self.mock_service.proxy_payment_gateway.call_args[1]
+        self.assertEqual(call_kwargs["headers"], {"X-Custom": "value"})
+        self.assertEqual(call_kwargs["data"], {"key": "value"})
+        self.assertEqual(call_kwargs["params"], {"an": "teststore"})
+
+    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
+    def test_execute_raises_when_project_not_found(self, mock_context):
+        mock_context.side_effect = ValueError("Project not found for given UUID.")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.usecase.execute(dto=self.dto, project_uuid="invalid-uuid")
+
+        self.assertIn("Project not found", str(ctx.exception))
+
+    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
+    def test_execute_raises_when_vtex_account_missing(self, mock_context):
+        mock_context.side_effect = ValueError("VTEX account not defined for project.")
+
+        with self.assertRaises(ValueError):
+            self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
+
+    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
+    def test_execute_returns_service_response(self, mock_context):
+        mock_context.return_value = ("teststore", "teststore.myvtex.com")
+        expected = {
+            "status": 200,
+            "data": [{"transactionId": "ABC123", "payments": []}],
+        }
+        self.mock_service.proxy_payment_gateway.return_value = expected
+
+        result = self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
+
+        self.assertEqual(result, expected)

--- a/retail/vtex/urls.py
+++ b/retail/vtex/urls.py
@@ -6,6 +6,7 @@ from retail.vtex.views import (
     OrderFormTrackingView,
     OrderDetailsProxyView,
     OrdersProxyView,
+    PaymentGatewayProxyView,
     PaymentTransactionProxyView,
     StoreUrlView,
     VtexProxyView,
@@ -43,6 +44,11 @@ urlpatterns = [
         "payments/send-transaction/",
         PaymentTransactionProxyView.as_view(),
         name="vtex-payment-transaction-proxy",
+    ),
+    path(
+        "payments/gateway-proxy/",
+        PaymentGatewayProxyView.as_view(),
+        name="vtex-payment-gateway-proxy",
     ),
     path(
         "account/<str:vtex_account>/project-user/",

--- a/retail/vtex/usecases/proxy_payment_gateway.py
+++ b/retail/vtex/usecases/proxy_payment_gateway.py
@@ -1,0 +1,45 @@
+import logging
+
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.dtos.proxy_payment_gateway_dto import ProxyPaymentGatewayDTO
+from retail.vtex.usecases.base import BaseVtexUseCase
+
+logger = logging.getLogger(__name__)
+
+
+class ProxyPaymentGatewayUseCase(BaseVtexUseCase):
+    """
+    Use case for proxying requests to the VTEX IO Payment Gateway
+    proxy route (/_v/proxy-payment-gateway).
+    """
+
+    def __init__(self, vtex_io_service: VtexIOService):
+        self.vtex_io_service = vtex_io_service
+
+    def execute(self, dto: ProxyPaymentGatewayDTO, project_uuid: str) -> dict:
+        """
+        Forwards a Payment Gateway request to VTEX IO.
+
+        Args:
+            dto: Validated proxy request data.
+            project_uuid: Project UUID to resolve VTEX context.
+
+        Returns:
+            dict: Response from the VTEX IO proxy-payment-gateway route.
+        """
+        vtex_account, account_domain = self._get_vtex_context(project_uuid)
+
+        logger.info(
+            f"Proxying payment gateway request for "
+            f"vtex_account={vtex_account} method={dto.method} path={dto.path}"
+        )
+
+        return self.vtex_io_service.proxy_payment_gateway(
+            account_domain=account_domain,
+            vtex_account=vtex_account,
+            method=dto.method,
+            path=dto.path,
+            headers=dto.headers,
+            data=dto.data,
+            params=dto.params,
+        )

--- a/retail/vtex/views.py
+++ b/retail/vtex/views.py
@@ -15,6 +15,7 @@ from retail.vtex.serializers import (
     LeadSerializer,
     OrderFormTrackingSerializer,
     OrdersQueryParamsSerializer,
+    PaymentGatewayProxySerializer,
     ProxyPaymentTransactionSerializer,
     VtexProxySerializer,
 )
@@ -36,7 +37,9 @@ from retail.vtex.usecases.proxy_vtex import ProxyVtexUsecase
 from retail.vtex.usecases.proxy_payment_transaction import (
     ProxyPaymentTransactionUseCase,
 )
+from retail.vtex.usecases.proxy_payment_gateway import ProxyPaymentGatewayUseCase
 from retail.vtex.dtos.proxy_payment_transaction_dto import ProxyPaymentTransactionDTO
+from retail.vtex.dtos.proxy_payment_gateway_dto import ProxyPaymentGatewayDTO
 from retail.vtex.tasks import task_notify_lead
 
 logger = logging.getLogger(__name__)
@@ -332,6 +335,52 @@ class PaymentTransactionProxyView(BaseVtexProxyView):
         dto = ProxyPaymentTransactionDTO(
             transaction_id=serializer.validated_data["transaction_id"],
             payments=tuple(serializer.validated_data["payments"]),
+        )
+
+        result = self.usecase.execute(dto=dto, project_uuid=self.project_uuid)
+        return Response(result, status=status.HTTP_200_OK)
+
+
+class PaymentGatewayProxyView(BaseVtexProxyView):
+    """
+    POST endpoint that proxies requests to the VTEX IO Payment Gateway
+    proxy route (/_v/proxy-payment-gateway).
+
+    Targets the {account}.vtexpayments.com.br host for read operations
+    on transactions, interactions, payments and settlements.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._usecase = None
+
+    @property
+    def usecase(self) -> ProxyPaymentGatewayUseCase:
+        if not self._usecase:
+            self._usecase = ProxyPaymentGatewayUseCase(vtex_io_service=VtexIOService())
+        return self._usecase
+
+    def post(self, request: Request) -> Response:
+        """
+        Forwards a Payment Gateway request to the VTEX IO proxy-payment-gateway route.
+
+        Args:
+            request (Request): The incoming request with method, path, and optional params.
+
+        Returns:
+            Response: The response from VTEX IO.
+        """
+        serializer = PaymentGatewayProxySerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        validated = serializer.validated_data
+
+        dto = ProxyPaymentGatewayDTO(
+            method=validated["method"],
+            path=validated["path"],
+            headers=validated.get("headers"),
+            data=validated.get("data"),
+            params=validated.get("params"),
         )
 
         result = self.usecase.execute(dto=dto, project_uuid=self.project_uuid)


### PR DESCRIPTION
## What
Adds a new proxy endpoint `POST /vtex/payments/gateway-proxy/` that
forwards requests to the VTEX IO `/_v/proxy-payment-gateway` route,
targeting the Payment Gateway API (`{account}.vtexpayments.com.br`).

## Why
The intelligent agent needs to read payment transaction data
(interactions, settlements, payments) from the VTEX Payment Gateway.
This proxy allows the agent to call retail, which handles JWT
authentication and VTEX context resolution, forwarding the request
transparently to the IO app.