### PR TITLE
fix: Restrict needs_button_edit flag to URL-type buttons only

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -233,12 +233,17 @@ class AssignAgentUseCase:
 
             template, version = create_library_use_case.execute(data)
 
-            if not metadata.get("buttons"):
+            buttons = metadata.get("buttons", [])
+            has_url_button = any(button.get("type") == "URL" for button in buttons)
+
+            if has_url_button:
+                template.needs_button_edit = True
+            else:
+                # Submit template to Meta via integrations-engine (Celery task).
+                # Skipped for URL buttons because the URL must be customized first.
                 create_library_use_case.notify_integrations(
                     version.template_name, version.uuid, data
                 )
-            else:
-                template.needs_button_edit = True
 
             template.metadata = pre_approved.metadata
             template.config = pre_approved.config or {}

--- a/retail/agents/tests/usecases/test_assign_agent.py
+++ b/retail/agents/tests/usecases/test_assign_agent.py
@@ -300,6 +300,134 @@ class AssignAgentUseCaseTest(TestCase):
         mock_use_case_instance.execute.assert_called_once()
         mock_use_case_instance.notify_integrations.assert_called_once()
 
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateLibraryTemplateUseCase"
+    )
+    def test_create_templates_with_url_button_sets_needs_button_edit(
+        self, mock_create_library_use_case
+    ):
+        mock_integrations_service = MagicMock()
+        mock_integrations_service.fetch_templates_from_user.return_value = {}
+        use_case = AssignAgentUseCase(
+            integrations_service=mock_integrations_service,
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+
+        integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid.uuid4(),
+            is_active=True,
+        )
+
+        pre_approved = MagicMock()
+        pre_approved.is_valid = True
+        pre_approved.metadata = {
+            "name": "Test Template",
+            "category": "UTILITY",
+            "language": "pt_BR",
+            "buttons": [
+                {
+                    "type": "URL",
+                    "text": "Gerir encomenda",
+                    "url": "https://www.example.com",
+                }
+            ],
+        }
+        pre_approved.start_condition = "test_condition"
+        pre_approved.slug = "test-template"
+        pre_approved.config = {}
+
+        pre_approveds = MagicMock()
+        filtered_queryset = MagicMock()
+        filtered_queryset.filter.side_effect = lambda is_valid: (
+            [pre_approved] if is_valid else []
+        )
+        pre_approveds.exclude.return_value = filtered_queryset
+
+        mock_template = MagicMock()
+        mock_version = MagicMock()
+        mock_version.template_name = "Test Template"
+        mock_version.uuid = uuid.uuid4()
+
+        mock_use_case_instance = mock_create_library_use_case.return_value
+        mock_use_case_instance.execute.return_value = (mock_template, mock_version)
+
+        use_case._create_templates(
+            integrated_agent=integrated_agent,
+            pre_approveds=pre_approveds,
+            project_uuid=self.project.uuid,
+            app_uuid=uuid.uuid4(),
+            ignore_templates=[],
+        )
+
+        mock_use_case_instance.execute.assert_called_once()
+        mock_use_case_instance.notify_integrations.assert_not_called()
+        self.assertTrue(mock_template.needs_button_edit)
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateLibraryTemplateUseCase"
+    )
+    def test_create_templates_with_non_url_button_notifies_integrations(
+        self, mock_create_library_use_case
+    ):
+        mock_integrations_service = MagicMock()
+        mock_integrations_service.fetch_templates_from_user.return_value = {}
+        use_case = AssignAgentUseCase(
+            integrations_service=mock_integrations_service,
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+
+        integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid.uuid4(),
+            is_active=True,
+        )
+
+        pre_approved = MagicMock()
+        pre_approved.is_valid = True
+        pre_approved.metadata = {
+            "name": "Test Template",
+            "category": "UTILITY",
+            "language": "pt_BR",
+            "buttons": [
+                {
+                    "type": "QUICK_REPLY",
+                    "text": "Confirmar",
+                }
+            ],
+        }
+        pre_approved.start_condition = "test_condition"
+        pre_approved.slug = "test-template"
+        pre_approved.config = {}
+
+        pre_approveds = MagicMock()
+        filtered_queryset = MagicMock()
+        filtered_queryset.filter.side_effect = lambda is_valid: (
+            [pre_approved] if is_valid else []
+        )
+        pre_approveds.exclude.return_value = filtered_queryset
+
+        mock_template = MagicMock()
+        mock_version = MagicMock()
+        mock_version.template_name = "Test Template"
+        mock_version.uuid = uuid.uuid4()
+
+        mock_use_case_instance = mock_create_library_use_case.return_value
+        mock_use_case_instance.execute.return_value = (mock_template, mock_version)
+
+        use_case._create_templates(
+            integrated_agent=integrated_agent,
+            pre_approveds=pre_approveds,
+            project_uuid=self.project.uuid,
+            app_uuid=uuid.uuid4(),
+            ignore_templates=[],
+        )
+
+        mock_use_case_instance.execute.assert_called_once()
+        mock_use_case_instance.notify_integrations.assert_called_once()
+
     def test_get_ignore_templates(self):
         template1 = PreApprovedTemplate.objects.create(
             agent=self.agent,


### PR DESCRIPTION
## What
Restrict the `needs_button_edit` flag to only be set when the template 
has buttons of type `URL`. Non-URL buttons (e.g. `QUICK_REPLY`, 
`PHONE_NUMBER`) now follow the normal flow and are submitted to Meta 
via integrations-engine immediately.

## Why
Previously, any template with buttons was flagged as needing manual 
editing, blocking submission to Meta. Only URL-type buttons actually 
require customization (the URL must be adjusted per project), so 
non-URL buttons were being unnecessarily held back.