### PR TITLE
feat: Add WhatsApp Payment Recovery agent with VTEX hook integration

### DIFF
--- a/retail/agents/api/urls.py
+++ b/retail/agents/api/urls.py
@@ -12,6 +12,7 @@ from retail.agents.domains.agent_integration.views import (
     DeliveredOrderTrackingEnableView,
     DeliveredOrderTrackingDisableView,
     DeliveredOrderTrackingWebhookView,
+    PaymentRecoveryWebhookView,
     TemplateLanguagesView,
 )
 from retail.agents.domains.agent_webhook.views import AgentWebhookView
@@ -56,6 +57,11 @@ urlpatterns = [
         "delivered-order-tracking/<uuid:pk>/",
         DeliveredOrderTrackingWebhookView.as_view(),
         name="delivered-order-tracking-webhook",
+    ),
+    path(
+        "payment-recovery-webhook/<uuid:pk>/",
+        PaymentRecoveryWebhookView.as_view(),
+        name="payment-recovery-webhook",
     ),
 ]
 

--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -33,6 +33,11 @@ from retail.agents.shared.country_code_utils import DEFAULT_TEMPLATE_LANGUAGE
 from retail.agents.domains.agent_integration.usecases.build_abandoned_cart_translation import (
     BuildAbandonedCartTranslationUseCase,
 )
+from retail.agents.domains.agent_integration.usecases.build_payment_recovery_translation import (
+    BuildPaymentRecoveryTranslationUseCase,
+)
+from retail.vtex.usecases.proxy_vtex import ProxyVtexUsecase
+from retail.services.vtex_io.service import VtexIOService
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +158,19 @@ class AssignAgentUseCase:
         abandoned_cart_agent_uuid = getattr(settings, "ABANDONED_CART_AGENT_UUID", "")
         if abandoned_cart_agent_uuid and str(agent.uuid) == abandoned_cart_agent_uuid:
             config["abandoned_cart"] = self._get_abandoned_cart_default_config()
+
+        # Check if this is the payment recovery agent
+        payment_recovery_agent_uuid = getattr(
+            settings, "PAYMENT_RECOVERY_AGENT_UUID", ""
+        )
+        if (
+            payment_recovery_agent_uuid
+            and str(agent.uuid) == payment_recovery_agent_uuid
+        ):
+            config["payment_recovery"] = {
+                "hook_created": False,
+                "delay_minutes": 10,
+            }
 
         return config
 
@@ -377,21 +395,11 @@ class AssignAgentUseCase:
         1) Create IntegratedAgent and credentials (with auto-detected language from VTEX)
         2) Create templates from the agent's PreApprovedTemplate definitions
         3) If the agent is the Abandoned Cart agent (ABANDONED_CART_AGENT_UUID),
-           create a default custom template using the custom template flow
-           (lifecycle PENDING -> APPROVED, versioning, etc.).
+           create a default custom template using the custom template flow.
+        4) If the agent is the Payment Recovery agent (PAYMENT_RECOVERY_AGENT_UUID),
+           create a default custom template and a VTEX hook via proxy.
 
         The initial_template_language is automatically detected from VTEX tenant locale.
-
-        Args:
-            agent: The agent to assign.
-            project_uuid: UUID of the project to assign the agent to.
-            app_uuid: UUID of the WhatsApp app.
-            channel_uuid: UUID of the channel.
-            credentials: Agent credentials mapping.
-            include_templates: List of template UUIDs to include.
-
-        Returns:
-            The created IntegratedAgent instance.
         """
         project = self._get_project(project_uuid)
         self._validate_credentials(agent, credentials)
@@ -423,6 +431,28 @@ class AssignAgentUseCase:
                 project_uuid=project_uuid,
                 app_uuid=app_uuid,
             )
+
+        # If this is the payment recovery agent, create template + VTEX hook
+        payment_recovery_agent_uuid = getattr(
+            settings, "PAYMENT_RECOVERY_AGENT_UUID", ""
+        )
+        if (
+            payment_recovery_agent_uuid
+            and str(agent.uuid) == payment_recovery_agent_uuid
+        ):
+            logger.info(f"[AssignAgent] payment recovery agent detected={agent.uuid}")
+            template_created = self._create_default_payment_recovery_template(
+                integrated_agent=integrated_agent,
+                project_uuid=project_uuid,
+                app_uuid=app_uuid,
+            )
+            if template_created:
+                self._create_payment_recovery_hook(integrated_agent)
+            else:
+                logger.warning(
+                    f"[AssignAgent] Skipping hook creation — template failed for "
+                    f"integrated_agent={integrated_agent.uuid}"
+                )
 
         return integrated_agent
 
@@ -559,4 +589,159 @@ class AssignAgentUseCase:
                 "integrated agent %s: %s",
                 integrated_agent.uuid,
                 exc,
+            )
+
+    def _build_payment_recovery_webhook_url(
+        self, integrated_agent: IntegratedAgent
+    ) -> str:
+        domain_url = settings.DOMAIN
+        return (
+            f"{domain_url}/api/v3/agents/"
+            f"payment-recovery-webhook/{integrated_agent.uuid}/"
+        )
+
+    def _create_default_payment_recovery_template(
+        self,
+        integrated_agent: IntegratedAgent,
+        project_uuid: UUID,
+        app_uuid: UUID,
+    ) -> bool:
+        """
+        Create a default custom template for the payment recovery agent.
+
+        Uses the same image placeholder as abandoned cart. The template has
+        PAYMENT_REQUEST buttons with placeholder payment data for approval.
+
+        Returns:
+            True if the template was created (or already exists), False on failure.
+        """
+        template_language = integrated_agent.config.get(
+            "initial_template_language", DEFAULT_TEMPLATE_LANGUAGE
+        )
+
+        try:
+            logger.info(
+                f"[AssignAgent] Payment recovery template flow start for "
+                f"integrated_agent={integrated_agent.uuid}, "
+                f"language={template_language}"
+            )
+
+            placeholder_image_url = settings.ABANDONED_CART_DEFAULT_IMAGE_URL
+            image_converter = ImageUrlToBase64Converter()
+            placeholder_image_base64 = image_converter.convert(placeholder_image_url)
+            if not placeholder_image_base64:
+                raise ValueError(
+                    f"Failed to convert placeholder image URL to base64: "
+                    f"{placeholder_image_url}"
+                )
+
+            template_translation = (
+                BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+                    language_code=template_language,
+                    header_image_base64=placeholder_image_base64,
+                )
+            )
+
+            payload: CreateCustomTemplateData = {
+                "template_translation": template_translation,
+                "category": "UTILITY",
+                "app_uuid": str(app_uuid),
+                "project_uuid": str(project_uuid),
+                "display_name": "Payment Recovery",
+                "start_condition": "If payment_status is pending",
+                "parameters": [
+                    {
+                        "name": "start_condition",
+                        "value": "If payment_status is pending",
+                    },
+                    {
+                        "name": "variables",
+                        "value": [
+                            {
+                                "name": "1",
+                                "type": "text",
+                                "definition": "Client name",
+                                "fallback": "Cliente",
+                            },
+                        ],
+                    },
+                ],
+                "integrated_agent_uuid": integrated_agent.uuid,
+                "use_agent_rule": True,
+            }
+
+            use_case = CreateCustomTemplateUseCase()
+            use_case.execute(payload)
+            logger.info(
+                f"[AssignAgent] Payment recovery template creation completed for "
+                f"integrated_agent={integrated_agent.uuid}, "
+                f"language={template_language}"
+            )
+            return True
+        except CustomTemplateAlreadyExists:
+            logger.info(
+                f"[AssignAgent] Payment recovery template already exists for "
+                f"integrated_agent={integrated_agent.uuid}"
+            )
+            return True
+        except Exception as exc:
+            logger.exception(
+                f"[AssignAgent] Error creating payment recovery template for "
+                f"integrated_agent={integrated_agent.uuid}: {exc}"
+            )
+            return False
+
+    def _create_payment_recovery_hook(self, integrated_agent: IntegratedAgent) -> None:
+        """
+        Create a VTEX hook via proxy to monitor payment-pending orders.
+
+        Uses the proxy route (retail -> IO) so no VTEX app key/token is needed.
+        Saves the webhook URL and hook status in integrated_agent.config.
+        """
+        try:
+            webhook_url = self._build_payment_recovery_webhook_url(integrated_agent)
+
+            logger.info(
+                f"[AssignAgent] Creating payment recovery VTEX hook for "
+                f"integrated_agent={integrated_agent.uuid}, "
+                f"webhook_url={webhook_url}"
+            )
+
+            hook_data = {
+                "filter": {
+                    "type": "FromOrders",
+                    "expression": (
+                        'isCompleted = false and (salesChannel = "1") '
+                        "and (paymentData.transactions.payments"
+                        '[paymentSystem = "125"])'
+                    ),
+                    "disableSingleFire": False,
+                },
+                "hook": {"url": webhook_url},
+            }
+
+            proxy_usecase = ProxyVtexUsecase(vtex_io_service=VtexIOService())
+            proxy_usecase.execute(
+                method="POST",
+                path="/api/orders/hook/config",
+                data=hook_data,
+                project_uuid=str(integrated_agent.project.uuid),
+            )
+
+            current_config = integrated_agent.config.copy()
+            current_config["payment_recovery"] = {
+                "webhook_url": webhook_url,
+                "hook_created": True,
+            }
+            integrated_agent.config = current_config
+            integrated_agent.save(update_fields=["config"])
+
+            logger.info(
+                f"[AssignAgent] Payment recovery VTEX hook created for "
+                f"integrated_agent={integrated_agent.uuid}"
+            )
+        except Exception as exc:
+            logger.exception(
+                f"[AssignAgent] Error creating payment recovery VTEX hook for "
+                f"integrated_agent={integrated_agent.uuid}: {exc}"
             )

--- a/retail/agents/domains/agent_integration/usecases/build_payment_recovery_translation.py
+++ b/retail/agents/domains/agent_integration/usecases/build_payment_recovery_translation.py
@@ -1,0 +1,159 @@
+"""
+Use case for building payment recovery template translations.
+
+This module provides translations for payment recovery templates
+in multiple languages supported by Meta/WhatsApp.
+"""
+
+from typing import Dict, Any, Optional
+
+from retail.agents.shared.country_code_utils import DEFAULT_TEMPLATE_LANGUAGE
+
+
+PAYMENT_RECOVERY_PIX_PLACEHOLDER = (
+    "00020101021226700014br.gov.bcb.pix2548pix.example.com/qr/v3/"
+    "at/4376b932-1234-4abc-8def-1234567890ab5204000053039865802BR"
+)
+PAYMENT_RECOVERY_LINK_PLACEHOLDER = "https://my-payment-link-url"
+
+
+class BuildPaymentRecoveryTranslationUseCase:
+    """
+    Builds payment recovery template translations for Meta/WhatsApp.
+
+    Provides translations in pt_BR, en and es, with PAYMENT_REQUEST
+    buttons (Pix + payment link).
+    """
+
+    _TRANSLATIONS: Dict[str, Dict[str, Any]] = {
+        "pt_BR": {
+            "body_text": (
+                "Olá, {{1}}! Identificamos que o pagamento do seu pedido "
+                "não foi finalizado. Mas não se preocupe — seu carrinho "
+                "ainda está guardado. Escolha como prefere concluir sua compra:"
+            ),
+            "body_example": ["João"],
+            "footer_text": "VTEX CX Platform",
+            "button_pix_text": "Copiar código Pix",
+            "button_link_text": "Outros métodos de pagamento",
+        },
+        "en": {
+            "body_text": (
+                "Hello, {{1}}! We noticed your order payment wasn't "
+                "completed. Don't worry — your cart is still saved. "
+                "Choose how you'd like to finish your purchase:"
+            ),
+            "body_example": ["John"],
+            "footer_text": "VTEX CX Platform",
+            "button_pix_text": "Copy Pix code",
+            "button_link_text": "Other payment methods",
+        },
+        "es": {
+            "body_text": (
+                "Hola, {{1}}! Identificamos que el pago de tu pedido "
+                "no fue finalizado. No te preocupes — tu carrito "
+                "aún está guardado. Elige cómo prefieres completar tu compra:"
+            ),
+            "body_example": ["Juan"],
+            "footer_text": "VTEX CX Platform",
+            "button_pix_text": "Copiar código Pix",
+            "button_link_text": "Otros métodos de pago",
+        },
+    }
+
+    @classmethod
+    def _normalize_language_code(cls, language_code: str) -> str:
+        """
+        Normalize language code to match available translations.
+
+        Tries exact match first, then falls back to base language code.
+        Example: 'en_US' -> 'en', 'es_MX' -> 'es'
+        """
+        if language_code in cls._TRANSLATIONS:
+            return language_code
+
+        if "_" in language_code:
+            base_code = language_code.split("_")[0]
+            if base_code in cls._TRANSLATIONS:
+                return base_code
+
+        return language_code
+
+    @classmethod
+    def get_translation(cls, language_code: str) -> Optional[Dict[str, Any]]:
+        """Get translation data for a specific language."""
+        normalized_code = cls._normalize_language_code(language_code)
+        return cls._TRANSLATIONS.get(normalized_code)
+
+    @classmethod
+    def get_translation_or_default(cls, language_code: str) -> Dict[str, Any]:
+        """Get translation data, falling back to default (pt_BR) if not found."""
+        translation = cls.get_translation(language_code)
+        if translation is None:
+            translation = cls._TRANSLATIONS[DEFAULT_TEMPLATE_LANGUAGE]
+        return translation
+
+    @classmethod
+    def build_template_translation(
+        cls,
+        language_code: str,
+        header_image_base64: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Build a complete template translation payload for template creation.
+
+        Uses PAYMENT_REQUEST buttons with placeholder payment data
+        for template approval. Real payment data is provided at send time.
+
+        Args:
+            language_code: The Meta language code (e.g., 'pt_BR', 'en_US', 'es_MX')
+            header_image_base64: Optional base64 encoded header image
+
+        Returns:
+            Translation dictionary ready for CreateCustomTemplateUseCase.
+        """
+        normalized_code = cls._normalize_language_code(language_code)
+        translation_data = cls.get_translation_or_default(language_code)
+
+        template_translation: Dict[str, Any] = {
+            "template_body": translation_data["body_text"],
+            "template_body_params": translation_data["body_example"],
+            "template_footer": translation_data["footer_text"],
+            "template_button": [
+                {
+                    "type": "PAYMENT_REQUEST",
+                    "text": translation_data["button_pix_text"],
+                    "payment_setting": {
+                        "type": "pix_dynamic_code",
+                        "pix_dynamic_code": {
+                            "code": PAYMENT_RECOVERY_PIX_PLACEHOLDER,
+                        },
+                    },
+                },
+                {
+                    "type": "PAYMENT_REQUEST",
+                    "text": translation_data["button_link_text"],
+                    "payment_setting": {
+                        "type": "payment_link",
+                        "payment_link": {
+                            "uri": PAYMENT_RECOVERY_LINK_PLACEHOLDER,
+                        },
+                    },
+                },
+            ],
+            "category": "UTILITY",
+            "language": normalized_code,
+        }
+
+        if header_image_base64:
+            template_translation["template_header"] = {
+                "header_type": "IMAGE",
+                "text": header_image_base64,
+            }
+
+        return template_translation
+
+    @classmethod
+    def get_available_language_codes(cls) -> list:
+        """Get list of language codes that have translations available."""
+        return list(cls._TRANSLATIONS.keys())

--- a/retail/agents/domains/agent_integration/usecases/payment_recovery.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery.py
@@ -1,0 +1,103 @@
+import logging
+from typing import Dict, Any
+from uuid import UUID
+
+from rest_framework.exceptions import NotFound, ValidationError
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_webhook.usecases.order_status import (
+    AgentOrderStatusUpdateUsecase,
+)
+from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_DELAY_MINUTES = 10
+
+
+class PaymentRecoveryWebhookUseCase:
+    """Use case for processing payment recovery webhook notifications from VTEX."""
+
+    def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
+        try:
+            return IntegratedAgent.objects.get(uuid=integrated_agent_uuid)
+        except IntegratedAgent.DoesNotExist:
+            raise NotFound(f"Integrated agent not found: {integrated_agent_uuid}")
+
+    def get_delay_seconds(self, integrated_agent_uuid: UUID) -> int:
+        """
+        Get the configured delay in seconds for scheduling the processing task.
+
+        Reads delay_minutes from integrated_agent.config["payment_recovery"].
+        Falls back to DEFAULT_DELAY_MINUTES if agent or config is not found.
+        """
+        try:
+            integrated_agent = IntegratedAgent.objects.get(
+                uuid=integrated_agent_uuid, is_active=True
+            )
+            payment_config = integrated_agent.config.get("payment_recovery", {})
+            delay_minutes = payment_config.get("delay_minutes", DEFAULT_DELAY_MINUTES)
+            return int(delay_minutes) * 60
+        except IntegratedAgent.DoesNotExist:
+            return DEFAULT_DELAY_MINUTES * 60
+
+    def validate_payment_recovery_enabled(
+        self, integrated_agent: IntegratedAgent
+    ) -> None:
+        payment_config = integrated_agent.config.get("payment_recovery", {})
+        if not payment_config.get("hook_created", False):
+            raise ValidationError("Payment recovery hook not configured")
+
+    def process_webhook_notification(
+        self, integrated_agent: IntegratedAgent, webhook_data: Dict[str, Any]
+    ) -> Dict[str, str]:
+        """
+        Process a VTEX payment recovery webhook notification.
+
+        Validates that payment recovery is enabled, builds an OrderStatusDTO
+        and delegates to AgentOrderStatusUpdateUsecase — same pattern as
+        DeliveredOrderTrackingWebhookUseCase.
+        """
+        self.validate_payment_recovery_enabled(integrated_agent)
+
+        logger.info(
+            f"[PaymentRecovery] Processing webhook for "
+            f"agent={integrated_agent.uuid}: {webhook_data}"
+        )
+
+        self._process_payment_recovery_notification(integrated_agent, webhook_data)
+
+        return {
+            "status": "success",
+            "message": "Payment recovery notification processed",
+        }
+
+    def _process_payment_recovery_notification(
+        self, integrated_agent: IntegratedAgent, webhook_data: Dict[str, Any]
+    ) -> None:
+        vtex_account = integrated_agent.project.vtex_account
+
+        order_status_dto = OrderStatusDTO(
+            recorder={},
+            domain="OrdersDocumentUpdated",
+            orderId=webhook_data.get("OrderId"),
+            currentState="payment-pending",
+            lastState=webhook_data.get("State"),
+            currentChangeDate=webhook_data.get("CurrentChange"),
+            lastChangeDate=webhook_data.get("LastChange"),
+            vtexAccount=vtex_account,
+        )
+
+        logger.info(
+            f"[PaymentRecovery] OrderStatusDTO built: "
+            f"order_id={order_status_dto.orderId} agent={integrated_agent.uuid}"
+        )
+
+        order_status_usecase = AgentOrderStatusUpdateUsecase()
+        order_status_usecase.execute(integrated_agent, order_status_dto)
+
+        logger.info(
+            f"[PaymentRecovery] Processing completed for "
+            f"agent={integrated_agent.uuid} order={order_status_dto.orderId}"
+        )

--- a/retail/agents/domains/agent_integration/views.py
+++ b/retail/agents/domains/agent_integration/views.py
@@ -40,7 +40,13 @@ from retail.agents.domains.agent_integration.usecases.update import (
 from retail.agents.domains.agent_integration.usecases.delivered_order_tracking import (
     DeliveredOrderTrackingConfigUseCase,
 )
-from retail.agents.tasks import task_delivered_order_tracking_webhook
+from retail.agents.tasks import (
+    task_delivered_order_tracking_webhook,
+    task_payment_recovery_webhook,
+)
+from retail.agents.domains.agent_integration.usecases.payment_recovery import (
+    PaymentRecoveryWebhookUseCase,
+)
 
 from retail.internal.permissions import HasProjectPermission
 
@@ -338,4 +344,37 @@ class DeliveredOrderTrackingWebhookView(APIView):
                 f"Error queuing delivered order tracking webhook for agent {pk}: {e}"
             )
 
+            return Response({"message": "Webhook received"}, status=status.HTTP_200_OK)
+
+
+class PaymentRecoveryWebhookView(APIView):
+    """Webhook endpoint for receiving VTEX payment recovery notifications."""
+
+    permission_classes = [AllowAny]
+
+    def post(self, request: Request, pk: UUID) -> Response:
+        if request.data.get("hookConfig") == "ping":
+            logger.info(f"VTEX ping received for payment recovery webhook - agent {pk}")
+            return Response({"message": "Webhook available"}, status=status.HTTP_200_OK)
+
+        try:
+            use_case = PaymentRecoveryWebhookUseCase()
+            countdown = use_case.get_delay_seconds(pk)
+
+            task_payment_recovery_webhook.apply_async(
+                args=[pk, request.data],
+                countdown=countdown,
+                queue="vtex-io-orders-update-events",
+            )
+
+            logger.info(
+                f"Payment recovery webhook scheduled for processing - agent {pk} "
+                f"countdown={countdown}s"
+            )
+            return Response({"message": "Webhook received"}, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            logger.exception(
+                f"Error queuing payment recovery webhook for agent {pk}: {e}"
+            )
             return Response({"message": "Webhook received"}, status=status.HTTP_200_OK)

--- a/retail/agents/tasks.py
+++ b/retail/agents/tasks.py
@@ -6,6 +6,9 @@ from celery import shared_task
 from retail.agents.domains.agent_integration.usecases.delivered_order_tracking import (
     DeliveredOrderTrackingWebhookUseCase,
 )
+from retail.agents.domains.agent_integration.usecases.payment_recovery import (
+    PaymentRecoveryWebhookUseCase,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -46,5 +49,35 @@ def task_delivered_order_tracking_webhook(
         logger.exception(
             f"Error processing delivered order tracking webhook task for agent {integrated_agent_uuid}: {e}"
         )
-        # Don't re-raise to avoid Celery retries
-        # The webhook was already acknowledged to VTEX
+
+
+@shared_task
+def task_payment_recovery_webhook(
+    integrated_agent_uuid: str, webhook_data: Dict[str, Any]
+) -> None:
+    """
+    Process payment recovery webhook notification asynchronously.
+
+    Args:
+        integrated_agent_uuid: UUID of the integrated agent
+        webhook_data: Data received from VTEX webhook
+    """
+    try:
+        logger.info(
+            f"Processing payment recovery webhook task for agent {integrated_agent_uuid}"
+        )
+
+        use_case = PaymentRecoveryWebhookUseCase()
+        integrated_agent = use_case.get_integrated_agent(integrated_agent_uuid)
+        result = use_case.process_webhook_notification(integrated_agent, webhook_data)
+
+        logger.info(
+            f"Successfully processed payment recovery webhook for "
+            f"agent {integrated_agent_uuid}: {result}"
+        )
+
+    except Exception as e:
+        logger.exception(
+            f"Error processing payment recovery webhook task for "
+            f"agent {integrated_agent_uuid}: {e}"
+        )

--- a/retail/agents/tests/tasks/test_payment_recovery_task.py
+++ b/retail/agents/tests/tasks/test_payment_recovery_task.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from retail.agents.tasks import task_payment_recovery_webhook
+
+
+class TaskPaymentRecoveryWebhookTest(TestCase):
+    def setUp(self):
+        self.agent_uuid = str(uuid4())
+        self.webhook_data = {
+            "OrderId": "v1234567-01",
+            "State": "payment-pending",
+        }
+
+    @patch("retail.agents.tasks.PaymentRecoveryWebhookUseCase")
+    def test_task_processes_webhook_successfully(self, mock_usecase_cls):
+        mock_usecase = MagicMock()
+        mock_usecase_cls.return_value = mock_usecase
+        mock_agent = MagicMock()
+        mock_usecase.get_integrated_agent.return_value = mock_agent
+        mock_usecase.process_webhook_notification.return_value = {"status": "success"}
+
+        task_payment_recovery_webhook(self.agent_uuid, self.webhook_data)
+
+        mock_usecase.get_integrated_agent.assert_called_once_with(self.agent_uuid)
+        mock_usecase.process_webhook_notification.assert_called_once_with(
+            mock_agent, self.webhook_data
+        )
+
+    @patch("retail.agents.tasks.PaymentRecoveryWebhookUseCase")
+    def test_task_handles_exception_gracefully(self, mock_usecase_cls):
+        mock_usecase = MagicMock()
+        mock_usecase_cls.return_value = mock_usecase
+        mock_usecase.get_integrated_agent.side_effect = Exception("Agent not found")
+
+        task_payment_recovery_webhook(self.agent_uuid, self.webhook_data)
+
+    @patch("retail.agents.tasks.PaymentRecoveryWebhookUseCase")
+    def test_task_handles_process_exception_gracefully(self, mock_usecase_cls):
+        mock_usecase = MagicMock()
+        mock_usecase_cls.return_value = mock_usecase
+        mock_agent = MagicMock()
+        mock_usecase.get_integrated_agent.return_value = mock_agent
+        mock_usecase.process_webhook_notification.side_effect = Exception(
+            "Processing error"
+        )
+
+        task_payment_recovery_webhook(self.agent_uuid, self.webhook_data)

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -1,0 +1,239 @@
+import uuid
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from retail.agents.domains.agent_management.models import Agent
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.assign import AssignAgentUseCase
+from retail.agents.domains.agent_integration.usecases.fetch_country_phone_code import (
+    FetchCountryPhoneCodeUseCase,
+    VtexLocaleInfo,
+)
+from retail.projects.models import Project
+
+
+PAYMENT_RECOVERY_UUID = str(uuid.uuid4())
+
+
+class AssignPaymentRecoveryBuildConfigTest(TestCase):
+    def setUp(self):
+        self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
+        self.mock_fetch_phone_code.fetch_locale_info.return_value = VtexLocaleInfo(
+            country_phone_code="55",
+            meta_language="pt_BR",
+            vtex_locale="pt-BR",
+        )
+        self.use_case = AssignAgentUseCase(
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
+        )
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_UUID)
+    def test_build_initial_config_sets_payment_recovery(self):
+        agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_UUID,
+            name="Payment Recovery",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        config = self.use_case._build_initial_config(agent, self.project)
+        self.assertIn("payment_recovery", config)
+        self.assertFalse(config["payment_recovery"]["hook_created"])
+        self.assertEqual(config["payment_recovery"]["delay_minutes"], 10)
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID="")
+    def test_build_initial_config_skips_payment_recovery_when_no_uuid(self):
+        agent = Agent.objects.create(
+            name="Generic Agent",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        config = self.use_case._build_initial_config(agent, self.project)
+        self.assertNotIn("payment_recovery", config)
+
+
+class AssignPaymentRecoveryTemplateTest(TestCase):
+    def setUp(self):
+        self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
+        self.mock_fetch_phone_code.fetch_locale_info.return_value = VtexLocaleInfo(
+            country_phone_code="55",
+            meta_language="pt_BR",
+            vtex_locale="pt-BR",
+        )
+        self.use_case = AssignAgentUseCase(
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
+        )
+        self.integrated_agent = MagicMock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid.uuid4()
+        self.integrated_agent.config = {
+            "initial_template_language": "pt_BR",
+            "payment_recovery": {"hook_created": False},
+        }
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateCustomTemplateUseCase"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.ImageUrlToBase64Converter"
+    )
+    @override_settings(
+        ABANDONED_CART_DEFAULT_IMAGE_URL="https://placehold.co/1200x628/png?text=Test"
+    )
+    def test_create_default_payment_recovery_template_returns_true(
+        self, mock_converter_cls, mock_custom_template_cls
+    ):
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = "data:image/png;base64,abc"
+        mock_converter_cls.return_value = mock_converter
+
+        mock_template_usecase = MagicMock()
+        mock_custom_template_cls.return_value = mock_template_usecase
+
+        result = self.use_case._create_default_payment_recovery_template(
+            integrated_agent=self.integrated_agent,
+            project_uuid=uuid.uuid4(),
+            app_uuid=uuid.uuid4(),
+        )
+
+        self.assertTrue(result)
+        mock_template_usecase.execute.assert_called_once()
+        payload = mock_template_usecase.execute.call_args[0][0]
+        self.assertEqual(payload["category"], "UTILITY")
+        self.assertEqual(payload["display_name"], "Payment Recovery")
+        self.assertTrue(payload["use_agent_rule"])
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateCustomTemplateUseCase"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.ImageUrlToBase64Converter"
+    )
+    @override_settings(
+        ABANDONED_CART_DEFAULT_IMAGE_URL="https://placehold.co/1200x628/png?text=Test"
+    )
+    def test_create_default_payment_recovery_template_uses_correct_language(
+        self, mock_converter_cls, mock_custom_template_cls
+    ):
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = "data:image/png;base64,abc"
+        mock_converter_cls.return_value = mock_converter
+
+        mock_template_usecase = MagicMock()
+        mock_custom_template_cls.return_value = mock_template_usecase
+
+        self.integrated_agent.config["initial_template_language"] = "en"
+
+        self.use_case._create_default_payment_recovery_template(
+            integrated_agent=self.integrated_agent,
+            project_uuid=uuid.uuid4(),
+            app_uuid=uuid.uuid4(),
+        )
+
+        payload = mock_template_usecase.execute.call_args[0][0]
+        translation = payload["template_translation"]
+        self.assertEqual(translation["language"], "en")
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateCustomTemplateUseCase"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.ImageUrlToBase64Converter"
+    )
+    @override_settings(
+        ABANDONED_CART_DEFAULT_IMAGE_URL="https://placehold.co/1200x628/png?text=Test"
+    )
+    def test_create_default_payment_recovery_template_image_failure_returns_false(
+        self, mock_converter_cls, mock_custom_template_cls
+    ):
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = None
+        mock_converter_cls.return_value = mock_converter
+
+        mock_template_usecase = MagicMock()
+        mock_custom_template_cls.return_value = mock_template_usecase
+
+        result = self.use_case._create_default_payment_recovery_template(
+            integrated_agent=self.integrated_agent,
+            project_uuid=uuid.uuid4(),
+            app_uuid=uuid.uuid4(),
+        )
+
+        self.assertFalse(result)
+        mock_template_usecase.execute.assert_not_called()
+
+
+class AssignPaymentRecoveryHookTest(TestCase):
+    def setUp(self):
+        self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
+        self.mock_fetch_phone_code.fetch_locale_info.return_value = VtexLocaleInfo(
+            country_phone_code="55",
+            meta_language="pt_BR",
+            vtex_locale="pt-BR",
+        )
+        self.use_case = AssignAgentUseCase(
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
+        )
+        self.integrated_agent = MagicMock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid.uuid4()
+        self.integrated_agent.project = self.project
+        self.integrated_agent.config = {
+            "payment_recovery": {"hook_created": False},
+        }
+
+    @patch("retail.agents.domains.agent_integration.usecases.assign.ProxyVtexUsecase")
+    @patch("retail.agents.domains.agent_integration.usecases.assign.VtexIOService")
+    @override_settings(DOMAIN="https://retail.example.com")
+    def test_create_payment_recovery_hook_success(
+        self, mock_vtex_service_cls, mock_proxy_cls
+    ):
+        mock_proxy = MagicMock()
+        mock_proxy_cls.return_value = mock_proxy
+
+        self.use_case._create_payment_recovery_hook(self.integrated_agent)
+
+        mock_proxy.execute.assert_called_once()
+        call_kwargs = mock_proxy.execute.call_args[1]
+        self.assertEqual(call_kwargs["method"], "POST")
+        self.assertEqual(call_kwargs["path"], "/api/orders/hook/config")
+        self.assertIn("filter", call_kwargs["data"])
+        self.assertIn("hook", call_kwargs["data"])
+
+        self.integrated_agent.save.assert_called()
+        saved_config = self.integrated_agent.config
+        self.assertTrue(saved_config["payment_recovery"]["hook_created"])
+        self.assertIn("webhook_url", saved_config["payment_recovery"])
+
+    @override_settings(DOMAIN="https://retail.example.com")
+    def test_build_payment_recovery_webhook_url(self):
+        url = self.use_case._build_payment_recovery_webhook_url(self.integrated_agent)
+        expected = (
+            f"https://retail.example.com/api/v3/agents/"
+            f"payment-recovery-webhook/{self.integrated_agent.uuid}/"
+        )
+        self.assertEqual(url, expected)
+
+    @patch("retail.agents.domains.agent_integration.usecases.assign.ProxyVtexUsecase")
+    @patch("retail.agents.domains.agent_integration.usecases.assign.VtexIOService")
+    @override_settings(DOMAIN="https://retail.example.com")
+    def test_create_payment_recovery_hook_proxy_failure_does_not_raise(
+        self, mock_vtex_service_cls, mock_proxy_cls
+    ):
+        mock_proxy = MagicMock()
+        mock_proxy_cls.return_value = mock_proxy
+        mock_proxy.execute.side_effect = Exception("Proxy error")
+
+        self.use_case._create_payment_recovery_hook(self.integrated_agent)
+
+        self.integrated_agent.save.assert_not_called()

--- a/retail/agents/tests/usecases/test_build_payment_recovery_translation.py
+++ b/retail/agents/tests/usecases/test_build_payment_recovery_translation.py
@@ -1,0 +1,181 @@
+import unittest
+
+from retail.agents.domains.agent_integration.usecases.build_payment_recovery_translation import (
+    BuildPaymentRecoveryTranslationUseCase,
+    PAYMENT_RECOVERY_PIX_PLACEHOLDER,
+    PAYMENT_RECOVERY_LINK_PLACEHOLDER,
+)
+
+
+class TestNormalizeLanguageCode(unittest.TestCase):
+    def test_exact_match_pt_BR(self):
+        result = BuildPaymentRecoveryTranslationUseCase._normalize_language_code(
+            "pt_BR"
+        )
+        self.assertEqual(result, "pt_BR")
+
+    def test_exact_match_en(self):
+        result = BuildPaymentRecoveryTranslationUseCase._normalize_language_code("en")
+        self.assertEqual(result, "en")
+
+    def test_exact_match_es(self):
+        result = BuildPaymentRecoveryTranslationUseCase._normalize_language_code("es")
+        self.assertEqual(result, "es")
+
+    def test_fallback_en_US_to_en(self):
+        result = BuildPaymentRecoveryTranslationUseCase._normalize_language_code(
+            "en_US"
+        )
+        self.assertEqual(result, "en")
+
+    def test_fallback_es_MX_to_es(self):
+        result = BuildPaymentRecoveryTranslationUseCase._normalize_language_code(
+            "es_MX"
+        )
+        self.assertEqual(result, "es")
+
+    def test_unknown_language_returns_as_is(self):
+        result = BuildPaymentRecoveryTranslationUseCase._normalize_language_code(
+            "fr_FR"
+        )
+        self.assertEqual(result, "fr_FR")
+
+
+class TestGetTranslation(unittest.TestCase):
+    def test_get_translation_pt_BR(self):
+        result = BuildPaymentRecoveryTranslationUseCase.get_translation("pt_BR")
+        self.assertIsNotNone(result)
+        self.assertIn("João", result["body_example"])
+        self.assertEqual(result["footer_text"], "VTEX CX Platform")
+
+    def test_get_translation_en(self):
+        result = BuildPaymentRecoveryTranslationUseCase.get_translation("en")
+        self.assertIsNotNone(result)
+        self.assertIn("John", result["body_example"])
+
+    def test_get_translation_es(self):
+        result = BuildPaymentRecoveryTranslationUseCase.get_translation("es")
+        self.assertIsNotNone(result)
+        self.assertIn("Juan", result["body_example"])
+
+    def test_get_translation_en_US_uses_en(self):
+        result = BuildPaymentRecoveryTranslationUseCase.get_translation("en_US")
+        self.assertIsNotNone(result)
+        self.assertIn("John", result["body_example"])
+
+    def test_get_translation_unknown_returns_none(self):
+        result = BuildPaymentRecoveryTranslationUseCase.get_translation("fr_FR")
+        self.assertIsNone(result)
+
+
+class TestGetTranslationOrDefault(unittest.TestCase):
+    def test_known_language_returns_translation(self):
+        result = BuildPaymentRecoveryTranslationUseCase.get_translation_or_default("en")
+        self.assertIn("John", result["body_example"])
+
+    def test_unknown_language_returns_default_pt_BR(self):
+        result = BuildPaymentRecoveryTranslationUseCase.get_translation_or_default(
+            "fr_FR"
+        )
+        self.assertIn("João", result["body_example"])
+
+
+class TestBuildTemplateTranslation(unittest.TestCase):
+    def test_build_translation_pt_BR(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+        )
+        self.assertEqual(result["language"], "pt_BR")
+        self.assertEqual(result["category"], "UTILITY")
+        self.assertEqual(result["template_footer"], "VTEX CX Platform")
+        self.assertIn("pagamento", result["template_body"])
+
+    def test_build_translation_en_US_normalizes_to_en(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="en_US",
+        )
+        self.assertEqual(result["language"], "en")
+        self.assertIn("payment", result["template_body"])
+
+    def test_build_translation_es_MX_normalizes_to_es(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="es_MX",
+        )
+        self.assertEqual(result["language"], "es")
+        self.assertIn("pago", result["template_body"])
+
+    def test_build_translation_with_header_image(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+            header_image_base64="data:image/png;base64,abc123",
+        )
+        self.assertIn("template_header", result)
+        self.assertEqual(result["template_header"]["header_type"], "IMAGE")
+        self.assertEqual(
+            result["template_header"]["text"], "data:image/png;base64,abc123"
+        )
+
+    def test_build_translation_without_header_image(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+        )
+        self.assertNotIn("template_header", result)
+
+    def test_build_translation_buttons_are_payment_request(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+        )
+        buttons = result["template_button"]
+        self.assertEqual(len(buttons), 2)
+        self.assertEqual(buttons[0]["type"], "PAYMENT_REQUEST")
+        self.assertEqual(buttons[1]["type"], "PAYMENT_REQUEST")
+
+    def test_build_translation_pix_button_has_payment_setting(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+        )
+        pix_button = result["template_button"][0]
+        self.assertEqual(pix_button["payment_setting"]["type"], "pix_dynamic_code")
+        self.assertEqual(
+            pix_button["payment_setting"]["pix_dynamic_code"]["code"],
+            PAYMENT_RECOVERY_PIX_PLACEHOLDER,
+        )
+
+    def test_build_translation_link_button_has_payment_setting(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+        )
+        link_button = result["template_button"][1]
+        self.assertEqual(link_button["payment_setting"]["type"], "payment_link")
+        self.assertEqual(
+            link_button["payment_setting"]["payment_link"]["uri"],
+            PAYMENT_RECOVERY_LINK_PLACEHOLDER,
+        )
+
+    def test_body_contains_variable_placeholder(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+        )
+        self.assertIn("{{1}}", result["template_body"])
+
+    def test_body_params_has_example_name(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+        )
+        self.assertEqual(result["template_body_params"], ["João"])
+
+    def test_unknown_language_uses_default_content(self):
+        result = BuildPaymentRecoveryTranslationUseCase.build_template_translation(
+            language_code="de_DE",
+        )
+        self.assertIn("pagamento", result["template_body"])
+        self.assertEqual(result["language"], "de_DE")
+
+
+class TestGetAvailableLanguageCodes(unittest.TestCase):
+    def test_returns_all_available_codes(self):
+        result = BuildPaymentRecoveryTranslationUseCase.get_available_language_codes()
+        self.assertIn("pt_BR", result)
+        self.assertIn("en", result)
+        self.assertIn("es", result)
+        self.assertEqual(len(result), 3)

--- a/retail/agents/tests/usecases/test_payment_recovery_webhook.py
+++ b/retail/agents/tests/usecases/test_payment_recovery_webhook.py
@@ -1,0 +1,131 @@
+from django.test import TestCase
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from rest_framework.exceptions import NotFound, ValidationError
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.payment_recovery import (
+    PaymentRecoveryWebhookUseCase,
+    DEFAULT_DELAY_MINUTES,
+)
+
+
+class PaymentRecoveryWebhookUseCaseTest(TestCase):
+    def setUp(self):
+        self.use_case = PaymentRecoveryWebhookUseCase()
+        self.agent_uuid = uuid4()
+        self.mock_integrated_agent = MagicMock(spec=IntegratedAgent)
+        self.mock_integrated_agent.uuid = self.agent_uuid
+        self.mock_integrated_agent.project.vtex_account = "testaccount"
+        self.mock_integrated_agent.config = {
+            "payment_recovery": {
+                "webhook_url": "https://example.com/webhook/",
+                "hook_created": True,
+            }
+        }
+        self.webhook_data = {
+            "OrderId": "v1234567-01",
+            "State": "payment-pending",
+            "CurrentChange": "2026-04-10T12:00:00Z",
+            "LastChange": "2026-04-10T11:00:00Z",
+        }
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.IntegratedAgent"
+    )
+    def test_get_integrated_agent_found(self, mock_model):
+        mock_model.objects.get.return_value = self.mock_integrated_agent
+        result = self.use_case.get_integrated_agent(self.agent_uuid)
+        self.assertEqual(result, self.mock_integrated_agent)
+        mock_model.objects.get.assert_called_once_with(uuid=self.agent_uuid)
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.IntegratedAgent"
+    )
+    def test_get_integrated_agent_not_found(self, mock_model):
+        mock_model.DoesNotExist = IntegratedAgent.DoesNotExist
+        mock_model.objects.get.side_effect = IntegratedAgent.DoesNotExist
+        with self.assertRaises(NotFound):
+            self.use_case.get_integrated_agent(self.agent_uuid)
+
+    def test_validate_payment_recovery_enabled_succeeds(self):
+        self.use_case.validate_payment_recovery_enabled(self.mock_integrated_agent)
+
+    def test_validate_payment_recovery_disabled_raises(self):
+        self.mock_integrated_agent.config = {
+            "payment_recovery": {"hook_created": False}
+        }
+        with self.assertRaises(ValidationError):
+            self.use_case.validate_payment_recovery_enabled(self.mock_integrated_agent)
+
+    def test_validate_payment_recovery_missing_config_raises(self):
+        self.mock_integrated_agent.config = {}
+        with self.assertRaises(ValidationError):
+            self.use_case.validate_payment_recovery_enabled(self.mock_integrated_agent)
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
+    )
+    def test_process_webhook_notification_success(self, mock_order_usecase_cls):
+        mock_order_usecase = MagicMock()
+        mock_order_usecase_cls.return_value = mock_order_usecase
+
+        result = self.use_case.process_webhook_notification(
+            self.mock_integrated_agent, self.webhook_data
+        )
+
+        self.assertEqual(result["status"], "success")
+        mock_order_usecase.execute.assert_called_once()
+
+        call_args = mock_order_usecase.execute.call_args
+        dto = call_args[0][1]
+        self.assertEqual(dto.orderId, "v1234567-01")
+        self.assertEqual(dto.currentState, "payment-pending")
+        self.assertEqual(dto.vtexAccount, "testaccount")
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
+    )
+    def test_process_webhook_notification_disabled_raises(self, mock_order_usecase_cls):
+        self.mock_integrated_agent.config = {}
+
+        with self.assertRaises(ValidationError):
+            self.use_case.process_webhook_notification(
+                self.mock_integrated_agent, self.webhook_data
+            )
+
+        mock_order_usecase_cls.return_value.execute.assert_not_called()
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.IntegratedAgent"
+    )
+    def test_get_delay_seconds_from_config(self, mock_model):
+        self.mock_integrated_agent.config = {"payment_recovery": {"delay_minutes": 15}}
+        mock_model.objects.get.return_value = self.mock_integrated_agent
+
+        result = self.use_case.get_delay_seconds(self.agent_uuid)
+
+        self.assertEqual(result, 15 * 60)
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.IntegratedAgent"
+    )
+    def test_get_delay_seconds_uses_default_when_not_configured(self, mock_model):
+        self.mock_integrated_agent.config = {"payment_recovery": {}}
+        mock_model.objects.get.return_value = self.mock_integrated_agent
+
+        result = self.use_case.get_delay_seconds(self.agent_uuid)
+
+        self.assertEqual(result, DEFAULT_DELAY_MINUTES * 60)
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.IntegratedAgent"
+    )
+    def test_get_delay_seconds_uses_default_when_agent_not_found(self, mock_model):
+        mock_model.DoesNotExist = IntegratedAgent.DoesNotExist
+        mock_model.objects.get.side_effect = IntegratedAgent.DoesNotExist
+
+        result = self.use_case.get_delay_seconds(self.agent_uuid)
+
+        self.assertEqual(result, DEFAULT_DELAY_MINUTES * 60)

--- a/retail/settings.py
+++ b/retail/settings.py
@@ -330,6 +330,7 @@ ABANDONED_CART_DEFAULT_IMAGE_URL = env.str(
     "ABANDONED_CART_DEFAULT_IMAGE_URL",
     default="https://placehold.co/1200x628/png?text=Your+Product",
 )
+PAYMENT_RECOVERY_AGENT_UUID = env.str("PAYMENT_RECOVERY_AGENT_UUID", default="")
 
 CONNECT_REST_ENDPOINT = env.str("CONNECT_REST_ENDPOINT", default="")
 

--- a/retail/templates/adapters/template_library_to_custom_adapter.py
+++ b/retail/templates/adapters/template_library_to_custom_adapter.py
@@ -158,6 +158,10 @@ class ButtonTransformer(ComponentTransformer):
                 button["phone_number"] = btn["phone_number"]
                 button["country_code"] = btn.get("country_code", "55")
 
+            elif btn["type"] == "PAYMENT_REQUEST":
+                if btn.get("payment_setting"):
+                    button["payment_setting"] = btn["payment_setting"]
+
             buttons_data.append(button)
 
         return buttons_data


### PR DESCRIPTION
## What
Add support for the WhatsApp Payment Recovery agent. When assigned,
the agent creates a template with PAYMENT_REQUEST buttons (Pix + payment link)
in 3 languages, registers a VTEX hook via proxy, and exposes a delayed webhook
endpoint (configurable, default 10 min) for processing payment-pending order
notifications through the Lambda pipeline.

## Why
Enables automated payment recovery notifications via WhatsApp for orders
with pending payments, following the same active agent pattern used by
abandoned cart and delivered order tracking.