### PR TITLE
refactor: Load passive onboarding agents from environment variables

### DIFF
--- a/retail/projects/usecases/onboarding_agents/agent_mappings.py
+++ b/retail/projects/usecases/onboarding_agents/agent_mappings.py
@@ -4,50 +4,64 @@ Channel-to-agent mappings for onboarding.
 Maps each supported channel code to the list of agent instances
 that must be integrated when that channel is selected.
 
+Passive agents are loaded from environment variables
+(PASSIVE_AGENTS_WWC / PASSIVE_AGENTS_WPP_CLOUD) as JSON dicts
+mapping agent name to UUID. Only active agents — which require
+complex integration logic — are defined as hardcoded classes.
+
 Pattern follows rule_mappings.py from weni-integrations-engine:
 the registry is consumed by IntegrateAgentsUseCase which iterates
 over the agents and calls ``agent.integrate(context, nexus_service)``.
 """
 
-from retail.projects.usecases.onboarding_agents.agents import (
-    AbandonedCartAgent,
-    FeedbackRecorder,
-    OrdersAgentCommerceIO,
-    PaymentAgent,
-    ProductConcierge,
-    SendCatalogAgent,
+from typing import Dict, List
+
+from django.conf import settings
+
+from retail.projects.usecases.onboarding_agents.agents import AbandonedCartAgent
+from retail.projects.usecases.onboarding_agents.base import (
+    OnboardingAgent,
+    PassiveAgent,
 )
 
-CHANNEL_AGENT_MAPPINGS = {
-    "wwc": [
-        OrdersAgentCommerceIO(),
-        FeedbackRecorder(),
-        ProductConcierge(),
-        PaymentAgent(),
-        SendCatalogAgent(),
-    ],
+SUPPORTED_CHANNELS = ["wwc", "wpp-cloud"]
+
+ACTIVE_AGENT_MAPPINGS = {
     "wpp-cloud": [
-        OrdersAgentCommerceIO(),
-        FeedbackRecorder(),
-        ProductConcierge(),
-        PaymentAgent(),
-        SendCatalogAgent(),
         AbandonedCartAgent(),
     ],
 }
 
-SUPPORTED_CHANNELS = list(CHANNEL_AGENT_MAPPINGS.keys())
+
+def _build_passive_agents(agents_map: Dict[str, str]) -> List[PassiveAgent]:
+    """Creates PassiveAgent instances from a name-to-UUID mapping."""
+    return [
+        PassiveAgent(uuid=uuid, name=name) for name, uuid in agents_map.items() if uuid
+    ]
 
 
-def get_channel_agents(channel_code: str) -> list:
+def get_channel_agents(channel_code: str) -> List[OnboardingAgent]:
     """
     Returns the list of OnboardingAgent instances for a channel.
+
+    Combines passive agents (loaded from env vars) with active agents
+    (hardcoded) for the given channel.
 
     Raises:
         ValueError: If channel_code is not supported.
     """
-    if channel_code not in CHANNEL_AGENT_MAPPINGS:
+    if channel_code not in SUPPORTED_CHANNELS:
         raise ValueError(
             f"Unsupported channel '{channel_code}'. " f"Supported: {SUPPORTED_CHANNELS}"
         )
-    return CHANNEL_AGENT_MAPPINGS[channel_code]
+
+    passive_settings = {
+        "wwc": "PASSIVE_AGENTS_WWC",
+        "wpp-cloud": "PASSIVE_AGENTS_WPP_CLOUD",
+    }
+
+    agents_map = getattr(settings, passive_settings[channel_code], {})
+    agents: List[OnboardingAgent] = _build_passive_agents(agents_map)
+    agents.extend(ACTIVE_AGENT_MAPPINGS.get(channel_code, []))
+
+    return agents

--- a/retail/projects/usecases/onboarding_agents/agents.py
+++ b/retail/projects/usecases/onboarding_agents/agents.py
@@ -1,9 +1,10 @@
 """
-Hard-coded onboarding agents.
+Active onboarding agents.
 
-Each class represents a Nexus agent that must be integrated
-during the onboarding flow. UUIDs are resolved automatically
-from ONBOARDING_AGENT_UUIDS using the class name as key.
+Passive agents are loaded dynamically from environment variables
+(PASSIVE_AGENTS_WWC / PASSIVE_AGENTS_WPP_CLOUD) via agent_mappings.py.
+Only active agents — which require complex integration logic — are
+defined as explicit classes here.
 """
 
 import logging
@@ -15,31 +16,10 @@ from retail.agents.domains.agent_management.models import Agent
 from retail.projects.usecases.onboarding_agents.base import (
     ActiveAgent,
     AgentContext,
-    PassiveAgent,
 )
 from retail.services.nexus.service import NexusService
 
 logger = logging.getLogger(__name__)
-
-
-class OrdersAgentCommerceIO(PassiveAgent):
-    name = "Orders Agent Commerce IO"
-
-
-class FeedbackRecorder(PassiveAgent):
-    name = "Feedback Recorder 2.0"
-
-
-class ProductConcierge(PassiveAgent):
-    name = "Product Concierge"
-
-
-class PaymentAgent(PassiveAgent):
-    name = "Payment Agent (without catalog)"
-
-
-class SendCatalogAgent(PassiveAgent):
-    name = "Send Catalog Agent"
 
 
 class AbandonedCartAgent(ActiveAgent):

--- a/retail/projects/usecases/onboarding_agents/base.py
+++ b/retail/projects/usecases/onboarding_agents/base.py
@@ -2,8 +2,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
 
-from django.conf import settings
-
 from retail.services.nexus.service import NexusService
 
 
@@ -30,24 +28,16 @@ class OnboardingAgent(ABC):
     logic following the rule_mappings pattern: a registry maps channel
     codes to lists of agent instances, and each agent knows how to
     integrate itself.
-
-    The UUID is resolved automatically from ONBOARDING_AGENT_UUIDS
-    using the class name as key.
     """
 
     uuid: str = ""
     name: str
 
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        agent_uuids = getattr(settings, "ONBOARDING_AGENT_UUIDS", {})
-        cls.uuid = agent_uuids.get(cls.__name__, cls.uuid)
-
     def _validate_uuid(self) -> None:
         if not self.uuid:
             raise ValueError(
                 f"Agent '{self.name}' ({self.__class__.__name__}) has no UUID "
-                f"configured. Check ONBOARDING_AGENT_UUIDS in environment variables."
+                f"configured."
             )
 
     @abstractmethod
@@ -56,7 +46,18 @@ class OnboardingAgent(ABC):
 
 
 class PassiveAgent(OnboardingAgent):
-    """Integrated via Nexus app-assign endpoint (simple toggle)."""
+    """Integrated via Nexus app-assign endpoint (simple toggle).
+
+    Instantiated directly with a UUID loaded from environment variables.
+    """
+
+    name = "Passive Agent"
+
+    def __init__(self, uuid: str = "", name: str = ""):
+        if uuid:
+            self.uuid = uuid
+        if name:
+            self.name = name
 
     def integrate(self, context: AgentContext, nexus_service: NexusService) -> dict:
         self._validate_uuid()

--- a/retail/settings.py
+++ b/retail/settings.py
@@ -277,9 +277,10 @@ CRAWLER_REST_ENDPOINT = env.str("CRAWLER_REST_ENDPOINT", "")
 # WWC (Weni Web Chat) default profile avatar
 WWC_PROFILE_AVATAR_URL = env.str("WWC_PROFILE_AVATAR_URL", "")
 
-# Onboarding agent UUIDs — passive and active (vary between staging and production)
-# Format: {"OrdersAgentCommerceIO": "uuid", "FeedbackRecorder": "uuid", ...}
-ONBOARDING_AGENT_UUIDS = env.json("ONBOARDING_AGENT_UUIDS", default={})
+# Passive agent UUIDs per channel — JSON dict mapping agent name to UUID
+# Format: {"Order Status": "136eb450-...", "Product Concierge": "3e51cf10-...", ...}
+PASSIVE_AGENTS_WWC = env.json("PASSIVE_AGENTS_WWC", default={})
+PASSIVE_AGENTS_WPP_CLOUD = env.json("PASSIVE_AGENTS_WPP_CLOUD", default={})
 
 
 # VTEX IO workspace configuration


### PR DESCRIPTION
## What
Refactors the onboarding agent mappings so that passive agents are
configured via environment variables instead of hardcoded classes.

## Why
All passive agents share the same behavior (install-only via Nexus),
making individual classes unnecessary. Moving their configuration to
env vars (PASSIVE_AGENTS_WWC / PASSIVE_AGENTS_WPP_CLOUD as JSON dicts)
allows adding or removing agents without code changes, improving
scalability and reducing deploy friction.