### PR TITLE
feat: Add payment_request button support in broadcast message builder

### DIFF
--- a/retail/agents/domains/agent_webhook/services/broadcast.py
+++ b/retail/agents/domains/agent_webhook/services/broadcast.py
@@ -72,6 +72,9 @@ class Broadcast:
         # Extract order_details for Meta WhatsApp payment flows
         order_details = template_variables.pop("order_details", None)
 
+        # Extract payment_buttons for PAYMENT_REQUEST template buttons
+        payment_buttons = template_variables.pop("payment_buttons", None)
+
         # Extract image s3 key if present
         header = template.metadata.get("header", None)
         s3_key = None
@@ -146,6 +149,9 @@ class Broadcast:
         if order_details:
             self._apply_order_details(order_details, message)
 
+        if payment_buttons:
+            self._apply_payment_buttons(payment_buttons, message)
+
         return message
 
     def _resolve_language(
@@ -193,6 +199,45 @@ class Broadcast:
         logger.info(
             f"Applied order_details with reference_id="
             f"{order_details.get('reference_id', 'N/A')}"
+        )
+
+    def _apply_payment_buttons(
+        self, payment_buttons: list, message: Dict[str, Any]
+    ) -> None:
+        """
+        Apply PAYMENT_REQUEST buttons to the message payload.
+
+        Expects the Lambda to provide a list of button dicts, each with:
+        - type: payment type (e.g., "pix_dynamic_code", "payment_link", "boleto")
+        - text: the payment data (PIX code, URL, or boleto line)
+
+        Transforms into the Flows Broadcast API format with sub_type "payment_request".
+
+        Args:
+            payment_buttons: List of payment button dicts from the Lambda.
+            message: The broadcast message dict being built (mutated in place).
+        """
+        buttons = []
+        for pb in payment_buttons:
+            buttons.append(
+                {
+                    "sub_type": "payment_request",
+                    "parameters": [
+                        {
+                            "type": pb.get("type"),
+                            "text": pb.get("text"),
+                        }
+                    ],
+                }
+            )
+
+        if buttons:
+            existing_buttons = message["msg"].get("buttons", [])
+            existing_buttons.extend(buttons)
+            message["msg"]["buttons"] = existing_buttons
+
+        logger.info(
+            f"Applied {len(buttons)} payment_request buttons to broadcast message"
         )
 
     def _build_image_attachment_from_url(self, image_url: str) -> str:

--- a/retail/agents/tests/services/test_broadcast.py
+++ b/retail/agents/tests/services/test_broadcast.py
@@ -406,6 +406,104 @@ class BroadcastHandlerTest(TestCase):
         self.assertNotIn("interaction_type", result["msg"])
         self.assertNotIn("order_details", result["msg"])
 
+    def test_build_broadcast_template_message_with_payment_buttons(self):
+        """Includes payment_request buttons in msg when payment_buttons provided."""
+        mock_template = MagicMock()
+        mock_template.current_version.template_name = "payment_recovery"
+        mock_template.metadata = {}
+
+        payment_buttons = [
+            {
+                "type": "pix_dynamic_code",
+                "text": "00020126580014br.gov.bcb.pix",
+            },
+            {
+                "type": "payment_link",
+                "text": "https://example.com/pay",
+            },
+        ]
+
+        data = {
+            "template_variables": {
+                "1": "Roberta",
+                "payment_buttons": payment_buttons,
+            },
+            "contact_urn": "whatsapp:5584999999999",
+            "language": "pt-BR",
+        }
+
+        result = self.handler.build_broadcast_template_message(
+            data=data,
+            channel_uuid="channel-uuid",
+            project_uuid="project-uuid",
+            template=mock_template,
+        )
+
+        self.assertIn("buttons", result["msg"])
+        buttons = result["msg"]["buttons"]
+        self.assertEqual(len(buttons), 2)
+        self.assertEqual(buttons[0]["sub_type"], "payment_request")
+        self.assertEqual(buttons[0]["parameters"][0]["type"], "pix_dynamic_code")
+        self.assertEqual(
+            buttons[0]["parameters"][0]["text"], "00020126580014br.gov.bcb.pix"
+        )
+        self.assertEqual(buttons[1]["sub_type"], "payment_request")
+        self.assertEqual(buttons[1]["parameters"][0]["type"], "payment_link")
+        self.assertEqual(buttons[1]["parameters"][0]["text"], "https://example.com/pay")
+        self.assertEqual(result["msg"]["template"]["variables"], ["Roberta"])
+
+    def test_build_broadcast_template_message_without_payment_buttons(self):
+        """Does not include payment buttons when not provided."""
+        mock_template = MagicMock()
+        mock_template.current_version.template_name = "order_update"
+        mock_template.metadata = {}
+
+        data = {
+            "template_variables": {"1": "Value1"},
+            "contact_urn": "whatsapp:123",
+        }
+
+        result = self.handler.build_broadcast_template_message(
+            data=data,
+            channel_uuid="channel-uuid",
+            project_uuid="project-uuid",
+            template=mock_template,
+        )
+
+        self.assertNotIn("buttons", result["msg"])
+
+    def test_build_broadcast_template_message_payment_buttons_with_three_types(self):
+        """Supports pix, boleto and payment_link buttons together."""
+        mock_template = MagicMock()
+        mock_template.current_version.template_name = "payment_recovery"
+        mock_template.metadata = {}
+
+        payment_buttons = [
+            {"type": "pix_dynamic_code", "text": "PIX_CODE_HERE"},
+            {"type": "boleto", "text": "BOLETO_LINE_HERE"},
+            {"type": "payment_link", "text": "https://pay.example.com"},
+        ]
+
+        data = {
+            "template_variables": {
+                "1": "Carlos",
+                "payment_buttons": payment_buttons,
+            },
+            "contact_urn": "whatsapp:5584999999999",
+        }
+
+        result = self.handler.build_broadcast_template_message(
+            data=data,
+            channel_uuid="channel-uuid",
+            project_uuid="project-uuid",
+            template=mock_template,
+        )
+
+        buttons = result["msg"]["buttons"]
+        self.assertEqual(len(buttons), 3)
+        types = [b["parameters"][0]["type"] for b in buttons]
+        self.assertEqual(types, ["pix_dynamic_code", "boleto", "payment_link"])
+
     def test_resolve_language_from_lambda_payload(self):
         """Language from Lambda payload takes priority."""
         mock_template = MagicMock()


### PR DESCRIPTION
## What
Add support for PAYMENT_REQUEST buttons (Pix, boleto, payment_link)
in the WhatsApp broadcast message builder. The Lambda can now return
a payment_buttons list in template_variables, which gets transformed
into the Flows Broadcast API format with sub_type "payment_request".

## Why
Required for the Payment Recovery agent to send WhatsApp messages
with payment buttons (Pix code, boleto line, payment link) through
the existing broadcast pipeline.