### PR TITLE
feat: Update WWC channel config with addToCart and simplified widget colors

### DIFF
--- a/retail/projects/usecases/configure_wwc.py
+++ b/retail/projects/usecases/configure_wwc.py
@@ -1,7 +1,5 @@
 import logging
 
-from django.conf import settings
-
 from retail.clients.integrations.client import IntegrationsClient
 from retail.interfaces.clients.integrations.interface import IntegrationsClientInterface
 from retail.projects.models import ProjectOnboarding
@@ -27,6 +25,7 @@ WWC_CHANNEL_BASE_CONFIG = {
     "showFullScreenButton": False,
     "showVoiceRecordingButton": False,
     "displayUnreadCount": True,
+    "addToCart": True,
     "timeBetweenMessages": 1,
     "navigateIfSameDomain": False,
     "conversationStartersPDP": True,
@@ -37,14 +36,8 @@ WWC_CHANNEL_BASE_CONFIG = {
         "storage": "local",
     },
     "customizeWidget": {
-        "launcherColor": "#3d3d3d",
-        "headerBackgroundColor": "#3d3d3d",
-        "quickRepliesFontColor": "#3d3d3d",
-        "userMessageBubbleColor": "#3d3d3d",
-        "quickRepliesBorderColor": "#3d3d3d",
-        "quickRepliesBackgroundColor": "#3d3d3d33",
+        "mainColor": "#0366DD",
     },
-    "profileAvatar": settings.WWC_PROFILE_AVATAR_URL,
 }
 
 


### PR DESCRIPTION
##What:
Updates the default WWC channel configuration during onboarding: removes profileAvatar (now handled by the front-end), adds addToCart, and simplifies customizeWidget to use a single mainColor.
##Why:
The profileAvatar should no longer be set by the backend, and the widget needs the new properties (addToCart and default color #0366DD) to match current product requirements.
Observations:
WWC_PROFILE_AVATAR_URL in settings.py (line 278) is now orphaned — no longer referenced anywhere. Can be removed in a separate cleanup commit (chore: Remove unused WWC_PROFILE_AVATAR_URL setting).