### PR TITLE
fix: Add Sentry capture and error observability to VTEX proxy flow

### DIFF
--- a/retail/clients/base.py
+++ b/retail/clients/base.py
@@ -1,6 +1,7 @@
 import requests
 import logging
 
+import sentry_sdk
 from django.conf import settings
 
 from retail.clients.exceptions import CustomAPIException
@@ -46,21 +47,27 @@ class RequestClient:
                 params=params,
                 files=files,
             )
+            sentry_sdk.capture_exception(e)
             raise CustomAPIException(
                 detail=f"Base request error: {str(e)}",
                 status_code=getattr(e.response, "status_code", None),
             ) from e
 
         if response.status_code >= 400:
-            self._generate_log(
+            self._log_http_error(
                 response, url, method, headers, json, data, params, files
             )
+
             detail = ""
             try:
                 detail = response.json()
             except ValueError:
                 detail = response.text
-            raise CustomAPIException(detail=detail, status_code=response.status_code)
+
+            exc = CustomAPIException(detail=detail, status_code=response.status_code)
+            if response.status_code >= 500:
+                sentry_sdk.capture_exception(exc)
+            raise exc
 
         # Handle empty responses to prevent JSON parsing errors
         if not response.text.strip():
@@ -70,33 +77,32 @@ class RequestClient:
 
         return response
 
-    def _generate_log(self, response, url, method, headers, json, data, params, files):
+    def _log_http_error(
+        self, response, url, method, headers, json, data, params, files
+    ):
         if response is None:
             logger.error("Response object is None, request failed.")
             return
 
-        request_details = {
-            "method": method,
-            "url": url,
-            "headers": headers,
-            "json": json,
-            "data": data,
-            "params": params,
-            "files": files,
-        }
-        response_details = {
-            "status_code": response.status_code,
-            "headers": dict(response.headers),
-            "body": response.text,
-            "url": response.url,
-        }
-
+        body = response.text[:1000] if response.text else ""
         logger.error(
-            f"Response:[{str(response.status_code)}] Error on request url {url}",
-            stack_info=False,
+            f"HTTP {response.status_code} {method.upper()} {url} — body={body}",
             extra={
-                "request_details": request_details,
-                "response_details": response_details,
+                "request_details": {
+                    "method": method,
+                    "url": url,
+                    "headers": headers,
+                    "json": json,
+                    "data": data,
+                    "params": params,
+                    "files": files,
+                },
+                "response_details": {
+                    "status_code": response.status_code,
+                    "headers": dict(response.headers),
+                    "body": response.text,
+                    "url": response.url,
+                },
             },
         )
 
@@ -128,9 +134,9 @@ class RequestClient:
             )
 
         logger.error(
-            f"Request exception for URL {url}",
+            f"Request exception {type(exception).__name__} "
+            f"{method.upper()} {url}: {exception}",
             exc_info=True,
-            stack_info=False,
             extra={
                 "request_details": request_details,
                 "exception_details": exception_details,

--- a/retail/clients/vtex_io/client.py
+++ b/retail/clients/vtex_io/client.py
@@ -1,12 +1,16 @@
 """Client for connection with Vtex IO"""
 
+import logging
 from typing import Optional, Union
 
 from django.conf import settings
 
 from retail.clients.base import RequestClient
+from retail.clients.exceptions import CustomAPIException
 from retail.interfaces.clients.vtex_io.interface import VtexIOClientInterface
 from retail.jwt_keys.usecases.generate_jwt import JWTUsecase
+
+logger = logging.getLogger(__name__)
 
 
 JWT_EXPIRATION_MINUTES = 1
@@ -63,6 +67,7 @@ class VtexIOClient(RequestClient, VtexIOClientInterface):
         )
         return {
             "Content-Type": "application/json; charset: utf-8",
+            "Accept-Encoding": "identity",
             "X-Weni-Auth": token,
         }
 
@@ -267,7 +272,18 @@ class VtexIOClient(RequestClient, VtexIOClientInterface):
             url, method="POST", json=payload, headers=jwt_headers
         )
 
-        return response.json()
+        try:
+            return response.json()
+        except (ValueError, TypeError) as exc:
+            logger.error(
+                f"Failed to parse VTEX IO proxy response as JSON: "
+                f"url={url} status={response.status_code} "
+                f"body={response.text[:500]}"
+            )
+            raise CustomAPIException(
+                detail="VTEX IO returned a non-JSON response",
+                status_code=502,
+            ) from exc
 
     def proxy_payment_gateway(
         self,

--- a/retail/vtex/usecases/proxy_vtex.py
+++ b/retail/vtex/usecases/proxy_vtex.py
@@ -1,7 +1,14 @@
+import logging
 from typing import Union
 
+import sentry_sdk
+from rest_framework.exceptions import ValidationError
+
+from retail.clients.exceptions import CustomAPIException
 from retail.services.vtex_io.service import VtexIOService
 from retail.vtex.usecases.base import BaseVtexUseCase
+
+logger = logging.getLogger(__name__)
 
 
 class ProxyVtexUsecase(BaseVtexUseCase):
@@ -40,14 +47,46 @@ class ProxyVtexUsecase(BaseVtexUseCase):
 
         Returns:
             dict: Response data from VTEX platform.
+
+        Raises:
+            ValidationError: When the project or VTEX account context is invalid.
+            CustomAPIException: When the upstream VTEX IO request fails.
         """
-        vtex_account, account_domain = self._get_vtex_context(project_uuid)
-        return self.vtex_io_service.proxy_vtex(
-            account_domain=account_domain,
-            vtex_account=vtex_account,
-            method=method,
-            path=path,
-            headers=headers,
-            data=data,
-            params=params,
+        try:
+            vtex_account, account_domain = self._get_vtex_context(project_uuid)
+        except ValueError as exc:
+            logger.error(f"VTEX context error for project_uuid={project_uuid}: {exc}")
+            raise ValidationError({"detail": str(exc)}) from exc
+
+        logger.info(
+            f"Proxying VTEX request: method={method} path={path} "
+            f"project_uuid={project_uuid} vtex_account={vtex_account}"
         )
+
+        try:
+            return self.vtex_io_service.proxy_vtex(
+                account_domain=account_domain,
+                vtex_account=vtex_account,
+                method=method,
+                path=path,
+                headers=headers,
+                data=data,
+                params=params,
+            )
+        except CustomAPIException:
+            logger.error(
+                f"VTEX IO proxy error: method={method} path={path} "
+                f"project_uuid={project_uuid} vtex_account={vtex_account}"
+            )
+            raise
+        except Exception as exc:
+            logger.error(
+                f"Unexpected error proxying VTEX: method={method} path={path} "
+                f"project_uuid={project_uuid} vtex_account={vtex_account}: {exc}",
+                exc_info=True,
+            )
+            sentry_sdk.capture_exception(exc)
+            raise CustomAPIException(
+                detail=f"Unexpected proxy error: {exc}",
+                status_code=502,
+            ) from exc


### PR DESCRIPTION
**What**
Adds explicit Sentry capture to RequestClient.make_request() for connection errors and HTTP 5xx, improves log messages with inline response body, protects VtexIOClient.proxy_vtex() against non-JSON responses, adds Accept-Encoding: identity to VTEX IO headers to prevent Brotli decompression failures on error responses, and adds business-context logging (project_uuid, vtex_account) to ProxyVtexUsecase.
**Why**
The /vtex/proxy/ endpoint returned 500 errors for some clients with no Sentry traces and no actionable log details. CustomAPIException (a DRF APIException subclass) was silently handled by DRF's exception handler, preventing Sentry's DjangoIntegration from capturing it. Additionally, VTEX upstream error responses (403, 400) with Content-Encoding: br and empty/malformed bodies caused decompression errors (Z_BUF_ERROR) that masked the real HTTP status codes — Accept-Encoding: identity eliminates this class of failures in server-to-server communication.