### PR TITLE
fix: Unifies WWC widget color using mainColor instead of custom

### DIFF
--- a/retail/projects/usecases/configure_wwc.py
+++ b/retail/projects/usecases/configure_wwc.py
@@ -18,7 +18,7 @@ WWC_CHANNEL_BASE_CONFIG = {
     "version": "2",
     "selector": "#wwc",
     "embedded": False,
-    "mainColor": "#3d3d3d",
+    "mainColor": "#0366DD",
     "contactTimeout": 0,
     "startFullScreen": False,
     "showCameraButton": False,
@@ -34,9 +34,6 @@ WWC_CHANNEL_BASE_CONFIG = {
     "params": {
         "images": {"dims": {"width": 300, "height": 200}},
         "storage": "local",
-    },
-    "customizeWidget": {
-        "mainColor": "#0366DD",
     },
 }
 


### PR DESCRIPTION
## What
Removes the explicit `customizeWidget` block from the WWC base config and updates 
`mainColor` from `#3d3d3d` to `#0366DD`. The Integrations service already derives 
the full `customizeWidget` (headerBackgroundColor, launcherColor, userMessageBubbleColor, 
etc.) from `mainColor`, making the explicit block redundant.

## Why
Having both `mainColor` and `customizeWidget.mainColor` with different values 
(`#3d3d3d` vs `#0366DD`) caused an inconsistency — the widget colors were being 
overridden by the explicit `customizeWidget` block instead of following the intended 
`mainColor`. Removing it ensures a single source of truth for the widget color and 
avoids visual mismatches.