### PR TITLE
fix: Shorten payment recovery button text to comply with Meta limit

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/build_payment_recovery_translation.py
+++ b/retail/agents/domains/agent_integration/usecases/build_payment_recovery_translation.py
@@ -35,7 +35,7 @@ class BuildPaymentRecoveryTranslationUseCase:
             "body_example": ["João"],
             "footer_text": "VTEX CX Platform",
             "button_pix_text": "Copiar código Pix",
-            "button_link_text": "Outros métodos de pagamento",
+            "button_link_text": "Outros meios de pagamento",
         },
         "en": {
             "body_text": (


### PR DESCRIPTION
## What
Shorten the pt_BR payment recovery button label from "Outros métodos
de pagamento" (27 chars) to "Outros meios de pagamento" (25 chars)
to comply with Meta's button text character limit.

## Why
Template creation was being rejected by Meta's API with error
"O texto do botão não pode ter mais de 25 caracteres" during the
payment recovery agent assignment flow.