### PR TITLE
feat: Updates WWC config with new titles, subtitle and fullscreen option

### DIFF
--- a/retail/projects/usecases/configure_wwc.py
+++ b/retail/projects/usecases/configure_wwc.py
@@ -22,7 +22,7 @@ WWC_CHANNEL_BASE_CONFIG = {
     "contactTimeout": 0,
     "startFullScreen": False,
     "showCameraButton": False,
-    "showFullScreenButton": False,
+    "showFullScreenButton": True,
     "showVoiceRecordingButton": False,
     "displayUnreadCount": True,
     "addToCart": True,
@@ -39,11 +39,12 @@ WWC_CHANNEL_BASE_CONFIG = {
 
 
 def build_wwc_channel_config(language: str) -> dict:
-    """Builds the full WWC channel config with translated title and placeholder."""
+    """Builds the full WWC channel config with translated title, subtitle and placeholder."""
     translations = get_wwc_translations(language)
     return {
         **WWC_CHANNEL_BASE_CONFIG,
         "title": translations["title"],
+        "subtitle": translations["subtitle"],
         "inputTextFieldHint": translations["inputTextFieldHint"],
     }
 
@@ -89,6 +90,12 @@ class ConfigureWWCUseCase:
         onboarding = self._load_onboarding(vtex_account)
         project_uuid = str(onboarding.project.uuid)
         language = onboarding.project.language or ""
+
+        if not language:
+            logger.warning(
+                f"Project language is empty for project={project_uuid} "
+                f"vtex_account={vtex_account}. WWC will use English defaults."
+            )
 
         onboarding.current_step = "NEXUS_CONFIG"
         onboarding.progress = 0

--- a/retail/projects/usecases/onboarding_defaults.py
+++ b/retail/projects/usecases/onboarding_defaults.py
@@ -7,6 +7,10 @@ Connect's project.language field (e.g. "pt-br" → "pt").
 Falls back to "en" when the prefix is not found.
 """
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 FALLBACK_LANGUAGE = "en"
 
 # ---------------------------------------------------------------------------
@@ -78,21 +82,24 @@ INSTRUCTIONS_BY_LANGUAGE = {
 
 
 # ---------------------------------------------------------------------------
-# WWC channel translated fields (title + input placeholder)
+# WWC channel translated fields (title, subtitle, input placeholder)
 # ---------------------------------------------------------------------------
 
 WWC_TRANSLATIONS = {
     "pt": {
-        "title": "Assistente inteligente",
-        "inputTextFieldHint": "Como posso ajudar?",
+        "title": "Assistente de compras",
+        "subtitle": "Como posso te ajudar hoje?",
+        "inputTextFieldHint": "Digite uma mensagem",
     },
     "en": {
-        "title": "Smart Assistant",
-        "inputTextFieldHint": "How can I help?",
+        "title": "Shopping assistant",
+        "subtitle": "How can I help you today?",
+        "inputTextFieldHint": "Type a message",
     },
     "es": {
-        "title": "Asistente inteligente",
-        "inputTextFieldHint": "¿Cómo posso ajudarte?",
+        "title": "Asistente de compras",
+        "subtitle": "¿Cómo puedo ayudarte hoy?",
+        "inputTextFieldHint": "Escribe un mensaje",
     },
 }
 
@@ -109,18 +116,48 @@ def get_instructions(language: str) -> list[str]:
         language: Connect project language (e.g. "pt-br", "en-us", "es").
     """
     prefix = _resolve_prefix(language)
-    return INSTRUCTIONS_BY_LANGUAGE.get(
-        prefix, INSTRUCTIONS_BY_LANGUAGE[FALLBACK_LANGUAGE]
-    )
+
+    if not prefix:
+        logger.warning(
+            f"Project language is empty or None (received '{language}'). "
+            f"Falling back to '{FALLBACK_LANGUAGE}' for crawler instructions."
+        )
+        return INSTRUCTIONS_BY_LANGUAGE[FALLBACK_LANGUAGE]
+
+    instructions = INSTRUCTIONS_BY_LANGUAGE.get(prefix)
+    if instructions is None:
+        logger.warning(
+            f"Unsupported language prefix '{prefix}' (from '{language}'). "
+            f"Falling back to '{FALLBACK_LANGUAGE}' for crawler instructions."
+        )
+        return INSTRUCTIONS_BY_LANGUAGE[FALLBACK_LANGUAGE]
+
+    return instructions
 
 
 def get_wwc_translations(language: str) -> dict:
     """
-    Returns the translated WWC fields (title, inputTextFieldHint)
+    Returns the translated WWC fields (title, subtitle, inputTextFieldHint)
     for the given project language.
 
     Args:
         language: Connect project language (e.g. "pt-br", "en-us", "es").
     """
     prefix = _resolve_prefix(language)
-    return WWC_TRANSLATIONS.get(prefix, WWC_TRANSLATIONS[FALLBACK_LANGUAGE])
+
+    if not prefix:
+        logger.warning(
+            f"Project language is empty or None (received '{language}'). "
+            f"Falling back to '{FALLBACK_LANGUAGE}' for WWC translations."
+        )
+        return WWC_TRANSLATIONS[FALLBACK_LANGUAGE]
+
+    translations = WWC_TRANSLATIONS.get(prefix)
+    if translations is None:
+        logger.warning(
+            f"Unsupported language prefix '{prefix}' (from '{language}'). "
+            f"Falling back to '{FALLBACK_LANGUAGE}' for WWC translations."
+        )
+        return WWC_TRANSLATIONS[FALLBACK_LANGUAGE]
+
+    return translations


### PR DESCRIPTION
## What
Updates the WWC channel configuration: renames widget title to "Shopping assistant" 
(with PT/ES translations), adds a translated subtitle field ("How can I help you today?"), 
enables `showFullScreenButton`, and adds explicit logging for language fallback scenarios.

## Why
The widget title and placeholder needed to be updated per product requirements. 
The subtitle field was missing from the config, and the fullscreen button needed 
to be enabled. Additionally, the language fallback functions now log warnings 
when the project language is empty or unsupported, improving observability.