### PR TITLE
feat: Implement storefront type detection and initiate crawl use case

### DIFF
--- a/retail/clients/connect/client.py
+++ b/retail/clients/connect/client.py
@@ -70,7 +70,7 @@ class ConnectClient(RequestClient, ConnectClientInterface):
     ) -> Dict:
         url = (
             f"{self.base_url}/v2/commerce/projects/"
-            f"{project_uuid}/config"
+            f"{project_uuid}/config/"
         )
 
         response = self.make_request(

--- a/retail/clients/connect/client.py
+++ b/retail/clients/connect/client.py
@@ -63,20 +63,20 @@ class ConnectClient(RequestClient, ConnectClientInterface):
         )
         return response.json()
 
-    def set_vtex_host_store(
+    def update_project_config(
         self,
         project_uuid: str,
-        vtex_host_store: str,
+        config: Dict,
     ) -> Dict:
         url = (
             f"{self.base_url}/v2/commerce/projects/"
-            f"{project_uuid}/set-vtex-host-store/"
+            f"{project_uuid}/config"
         )
 
         response = self.make_request(
             url=url,
             method="PATCH",
-            json={"vtex_host_store": vtex_host_store},
+            json=config,
             headers=self.internal_authentication.headers,
         )
         return response.json()

--- a/retail/clients/connect/client.py
+++ b/retail/clients/connect/client.py
@@ -76,7 +76,7 @@ class ConnectClient(RequestClient, ConnectClientInterface):
         response = self.make_request(
             url=url,
             method="PATCH",
-            json=config,
+            json={"config": config},
             headers=self.internal_authentication.headers,
         )
         return response.json()

--- a/retail/clients/crawler/client.py
+++ b/retail/clients/crawler/client.py
@@ -46,3 +46,21 @@ class CrawlerClient(RequestClient, CrawlerClientInterface):
             json=payload,
         )
         return response.json()
+
+    def detect_storefront_type(self, store_url: str) -> Dict:
+        """
+        Detects which VTEX storefront platform a store is running.
+
+        Args:
+            store_url: The store URL to inspect (must start with http:// or https://).
+
+        Returns:
+            Dict with ``store_url`` and ``storefront_type``.
+        """
+        url = f"{self.base_url}/api/storefront-type"
+        response = self.make_request(
+            url,
+            method="GET",
+            params={"store_url": store_url},
+        )
+        return response.json()

--- a/retail/interfaces/clients/connect/interface.py
+++ b/retail/interfaces/clients/connect/interface.py
@@ -17,9 +17,9 @@ class ConnectClientInterface(Protocol):
     ) -> Dict:
         ...
 
-    def set_vtex_host_store(
+    def update_project_config(
         self,
         project_uuid: str,
-        vtex_host_store: str,
+        config: Dict,
     ) -> Dict:
         ...

--- a/retail/interfaces/clients/crawler/client.py
+++ b/retail/interfaces/clients/crawler/client.py
@@ -21,3 +21,16 @@ class CrawlerClientInterface(Protocol):
             Dict: Response data from the crawler service (initial status).
         """
         ...
+
+    def detect_storefront_type(self, store_url: str) -> Dict:
+        """
+        Detects the storefront technology used by a VTEX store.
+
+        Args:
+            store_url: The store URL to inspect (must start with http:// or https://).
+
+        Returns:
+            Dict with ``store_url`` and ``storefront_type``
+            (one of: faststore, vtex_io, legacy, unknown).
+        """
+        ...

--- a/retail/interfaces/services/connect.py
+++ b/retail/interfaces/services/connect.py
@@ -17,9 +17,9 @@ class ConnectServiceInterface(Protocol):
     ) -> Dict:
         ...
 
-    def set_vtex_host_store(
+    def update_project_config(
         self,
         project_uuid: str,
-        vtex_host_store: str,
+        config: Dict,
     ) -> Dict:
         ...

--- a/retail/projects/tasks.py
+++ b/retail/projects/tasks.py
@@ -4,10 +4,10 @@ from celery import shared_task
 from django.core.cache import cache
 
 from retail.projects.models import ProjectOnboarding
-from retail.services.connect.service import ConnectService
+from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_orchestrator import OnboardingOrchestrator
-from retail.projects.usecases.start_crawl import CrawlerStartError, StartCrawlUseCase
+from retail.projects.usecases.start_crawl import CrawlerStartError
 from retail.services.vtex_io.service import VtexIOService
 
 logger = logging.getLogger(__name__)
@@ -71,18 +71,9 @@ def task_wait_and_start_crawl(self, vtex_account: str, crawl_url: str) -> None:
     logger.info(f"Project linked for vtex_account={vtex_account}. Starting crawl.")
 
     try:
-        ConnectService().set_vtex_host_store(
-            project_uuid=str(onboarding.project.uuid),
-            vtex_host_store=crawl_url,
+        InitiateCrawlUseCase().execute(
+            onboarding.project, vtex_account, crawl_url
         )
-    except Exception:
-        logger.exception(
-            f"Failed to send vtex_host_store to Connect for "
-            f"project={onboarding.project.uuid}"
-        )
-
-    try:
-        StartCrawlUseCase().execute(vtex_account, crawl_url)
     except CrawlerStartError as e:
         logger.error(f"Crawl start failed for vtex_account={vtex_account}: {e}")
         raise

--- a/retail/projects/tests/test_detect_storefront_type.py
+++ b/retail/projects/tests/test_detect_storefront_type.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project
+from retail.projects.usecases.detect_storefront_type import (
+    DetectStorefrontTypeUseCase,
+)
+
+
+class TestDetectStorefrontTypeUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project",
+            uuid=uuid4(),
+            vtex_account="mystore",
+            language="pt-br",
+        )
+        self.mock_crawler_service = MagicMock()
+        self.usecase = DetectStorefrontTypeUseCase(crawler_client=MagicMock())
+        self.usecase.crawler_service = self.mock_crawler_service
+
+    def test_stores_storefront_type_in_project_config(self):
+        self.mock_crawler_service.detect_storefront_type.return_value = {
+            "store_url": "https://www.mystore.com.br/",
+            "storefront_type": "vtex_io",
+        }
+
+        self.usecase.execute(self.project, "https://www.mystore.com.br/")
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.config["storefront_type"], "vtex_io")
+
+    def test_does_not_raise_on_service_failure(self):
+        self.mock_crawler_service.detect_storefront_type.return_value = None
+
+        self.usecase.execute(self.project, "https://www.mystore.com.br/")
+
+        self.project.refresh_from_db()
+        self.assertNotIn("storefront_type", self.project.config)
+
+    def test_does_not_raise_on_exception(self):
+        self.mock_crawler_service.detect_storefront_type.side_effect = RuntimeError(
+            "connection error"
+        )
+
+        self.usecase.execute(self.project, "https://www.mystore.com.br/")
+
+        self.project.refresh_from_db()
+        self.assertNotIn("storefront_type", self.project.config)
+
+    def test_preserves_existing_project_config(self):
+        self.project.config = {"existing_key": "value"}
+        self.project.save(update_fields=["config"])
+
+        self.mock_crawler_service.detect_storefront_type.return_value = {
+            "store_url": "https://www.mystore.com.br/",
+            "storefront_type": "faststore",
+        }
+
+        self.usecase.execute(self.project, "https://www.mystore.com.br/")
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.config["storefront_type"], "faststore")
+        self.assertEqual(self.project.config["existing_key"], "value")
+
+    def test_skipped_when_project_is_none(self):
+        self.usecase.execute(None, "https://www.mystore.com.br/")
+
+        self.mock_crawler_service.detect_storefront_type.assert_not_called()
+
+    def test_no_write_when_response_missing_storefront_type(self):
+        self.mock_crawler_service.detect_storefront_type.return_value = {
+            "store_url": "https://www.mystore.com.br/",
+        }
+
+        self.usecase.execute(self.project, "https://www.mystore.com.br/")
+
+        self.project.refresh_from_db()
+        self.assertNotIn("storefront_type", self.project.config)

--- a/retail/projects/tests/test_detect_storefront_type.py
+++ b/retail/projects/tests/test_detect_storefront_type.py
@@ -18,10 +18,15 @@ class TestDetectStorefrontTypeUseCase(TestCase):
             language="pt-br",
         )
         self.mock_crawler_service = MagicMock()
-        self.usecase = DetectStorefrontTypeUseCase(crawler_client=MagicMock())
+        self.mock_connect_service = MagicMock()
+        self.usecase = DetectStorefrontTypeUseCase(
+            crawler_client=MagicMock(),
+            connect_client=MagicMock(),
+        )
         self.usecase.crawler_service = self.mock_crawler_service
+        self.usecase.connect_service = self.mock_connect_service
 
-    def test_stores_storefront_type_in_project_config(self):
+    def test_sends_storefront_type_to_connect(self):
         self.mock_crawler_service.detect_storefront_type.return_value = {
             "store_url": "https://www.mystore.com.br/",
             "storefront_type": "vtex_io",
@@ -29,53 +34,51 @@ class TestDetectStorefrontTypeUseCase(TestCase):
 
         self.usecase.execute(self.project, "https://www.mystore.com.br/")
 
-        self.project.refresh_from_db()
-        self.assertEqual(self.project.config["storefront_type"], "vtex_io")
+        self.mock_connect_service.update_project_config.assert_called_once_with(
+            project_uuid=str(self.project.uuid),
+            config={"storefront_type": "vtex_io"},
+        )
 
-    def test_does_not_raise_on_service_failure(self):
+    def test_does_not_call_connect_on_service_failure(self):
         self.mock_crawler_service.detect_storefront_type.return_value = None
 
         self.usecase.execute(self.project, "https://www.mystore.com.br/")
 
-        self.project.refresh_from_db()
-        self.assertNotIn("storefront_type", self.project.config)
+        self.mock_connect_service.update_project_config.assert_not_called()
 
-    def test_does_not_raise_on_exception(self):
+    def test_does_not_raise_on_crawler_exception(self):
         self.mock_crawler_service.detect_storefront_type.side_effect = RuntimeError(
             "connection error"
         )
 
         self.usecase.execute(self.project, "https://www.mystore.com.br/")
 
-        self.project.refresh_from_db()
-        self.assertNotIn("storefront_type", self.project.config)
+        self.mock_connect_service.update_project_config.assert_not_called()
 
-    def test_preserves_existing_project_config(self):
-        self.project.config = {"existing_key": "value"}
-        self.project.save(update_fields=["config"])
-
+    def test_does_not_raise_on_connect_exception(self):
         self.mock_crawler_service.detect_storefront_type.return_value = {
             "store_url": "https://www.mystore.com.br/",
-            "storefront_type": "faststore",
+            "storefront_type": "vtex_io",
         }
+        self.mock_connect_service.update_project_config.side_effect = RuntimeError(
+            "connect down"
+        )
 
         self.usecase.execute(self.project, "https://www.mystore.com.br/")
 
-        self.project.refresh_from_db()
-        self.assertEqual(self.project.config["storefront_type"], "faststore")
-        self.assertEqual(self.project.config["existing_key"], "value")
+        self.mock_connect_service.update_project_config.assert_called_once()
 
     def test_skipped_when_project_is_none(self):
         self.usecase.execute(None, "https://www.mystore.com.br/")
 
         self.mock_crawler_service.detect_storefront_type.assert_not_called()
+        self.mock_connect_service.update_project_config.assert_not_called()
 
-    def test_no_write_when_response_missing_storefront_type(self):
+    def test_no_call_when_response_missing_storefront_type(self):
         self.mock_crawler_service.detect_storefront_type.return_value = {
             "store_url": "https://www.mystore.com.br/",
         }
 
         self.usecase.execute(self.project, "https://www.mystore.com.br/")
 
-        self.project.refresh_from_db()
-        self.assertNotIn("storefront_type", self.project.config)
+        self.mock_connect_service.update_project_config.assert_not_called()

--- a/retail/projects/tests/test_initiate_crawl.py
+++ b/retail/projects/tests/test_initiate_crawl.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock, Mock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
+from retail.projects.usecases.start_crawl import CrawlerStartError
+
+
+class TestInitiateCrawlUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project",
+            uuid=uuid4(),
+            vtex_account="mystore",
+            language="pt-br",
+        )
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+        )
+        self.mock_connect = Mock()
+        self.mock_start_crawl = MagicMock()
+        self.mock_detect_storefront = MagicMock()
+
+        self.usecase = InitiateCrawlUseCase(connect_service=self.mock_connect)
+        self.usecase.start_crawl_usecase = self.mock_start_crawl
+        self.usecase.detect_storefront_usecase = self.mock_detect_storefront
+
+    def test_runs_full_sequence(self):
+        self.usecase.execute(
+            self.project, "mystore", "https://www.mystore.com.br/"
+        )
+
+        self.mock_connect.set_vtex_host_store.assert_called_once()
+        self.mock_start_crawl.execute.assert_called_once_with(
+            "mystore", "https://www.mystore.com.br/"
+        )
+        self.mock_detect_storefront.execute.assert_called_once_with(
+            self.project, "https://www.mystore.com.br/"
+        )
+
+    def test_sends_vtex_host_store_with_correct_args(self):
+        self.usecase.execute(
+            self.project, "mystore", "https://www.mystore.com.br/"
+        )
+
+        call_kwargs = self.mock_connect.set_vtex_host_store.call_args
+        self.assertEqual(
+            call_kwargs.kwargs["vtex_host_store"],
+            "https://www.mystore.com.br/",
+        )
+        self.assertEqual(
+            call_kwargs.kwargs["project_uuid"],
+            str(self.project.uuid),
+        )
+
+    def test_crawl_proceeds_when_connect_fails(self):
+        self.mock_connect.set_vtex_host_store.side_effect = Exception(
+            "connect down"
+        )
+
+        self.usecase.execute(
+            self.project, "mystore", "https://www.mystore.com.br/"
+        )
+
+        self.mock_start_crawl.execute.assert_called_once()
+        self.mock_detect_storefront.execute.assert_called_once()
+
+    def test_storefront_detection_skipped_when_crawl_fails(self):
+        self.mock_start_crawl.execute.side_effect = CrawlerStartError(
+            "crawler down"
+        )
+
+        with self.assertRaises(CrawlerStartError):
+            self.usecase.execute(
+                self.project, "mystore", "https://www.mystore.com.br/"
+            )
+
+        self.mock_detect_storefront.execute.assert_not_called()

--- a/retail/projects/tests/test_initiate_crawl.py
+++ b/retail/projects/tests/test_initiate_crawl.py
@@ -33,7 +33,7 @@ class TestInitiateCrawlUseCase(TestCase):
             self.project, "mystore", "https://www.mystore.com.br/"
         )
 
-        self.mock_connect.set_vtex_host_store.assert_called_once()
+        self.mock_connect.update_project_config.assert_called_once()
         self.mock_start_crawl.execute.assert_called_once_with(
             "mystore", "https://www.mystore.com.br/"
         )
@@ -46,18 +46,13 @@ class TestInitiateCrawlUseCase(TestCase):
             self.project, "mystore", "https://www.mystore.com.br/"
         )
 
-        call_kwargs = self.mock_connect.set_vtex_host_store.call_args
-        self.assertEqual(
-            call_kwargs.kwargs["vtex_host_store"],
-            "https://www.mystore.com.br/",
-        )
-        self.assertEqual(
-            call_kwargs.kwargs["project_uuid"],
-            str(self.project.uuid),
+        self.mock_connect.update_project_config.assert_called_once_with(
+            project_uuid=str(self.project.uuid),
+            config={"vtex_host_store": "https://www.mystore.com.br/"},
         )
 
     def test_crawl_proceeds_when_connect_fails(self):
-        self.mock_connect.set_vtex_host_store.side_effect = Exception(
+        self.mock_connect.update_project_config.side_effect = Exception(
             "connect down"
         )
 

--- a/retail/projects/tests/test_start_onboarding.py
+++ b/retail/projects/tests/test_start_onboarding.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.test import TestCase
@@ -31,25 +31,21 @@ class TestStartSetupUseCase(TestCase):
             "mystore", "https://www.mystore.com.br/"
         )
 
-    @patch("retail.projects.usecases.start_setup.StartCrawlUseCase")
-    def test_starts_crawl_immediately_when_project_exists(self, mock_crawl_cls):
-        """When a project is linked, should start crawl immediately."""
+    def test_initiates_crawl_immediately_when_project_exists(self):
+        """When a project is linked, should call InitiateCrawlUseCase."""
         project = Project.objects.create(
             name="Test", uuid=uuid4(), vtex_account="mystore"
         )
 
-        mock_crawl_instance = MagicMock()
-        mock_crawl_cls.return_value = mock_crawl_instance
-
-        usecase = StartSetupUseCase()
-        usecase.start_crawl_usecase = mock_crawl_instance
+        mock_initiate_crawl = MagicMock()
+        usecase = StartSetupUseCase(initiate_crawl_usecase=mock_initiate_crawl)
 
         usecase.execute(self.dto)
 
         onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
         self.assertEqual(onboarding.project, project)
-        mock_crawl_instance.execute.assert_called_once_with(
-            "mystore", "https://www.mystore.com.br/"
+        mock_initiate_crawl.execute.assert_called_once_with(
+            project, "mystore", "https://www.mystore.com.br/"
         )
 
     @patch("retail.projects.usecases.start_setup.task_wait_and_start_crawl")
@@ -112,47 +108,6 @@ class TestStartSetupUseCase(TestCase):
 
         with self.assertRaises(Project.MultipleObjectsReturned):
             StartSetupUseCase._try_link_project(onboarding)
-
-    @patch("retail.projects.usecases.start_setup.StartCrawlUseCase")
-    def test_sends_vtex_host_store_when_project_linked(self, mock_crawl_cls):
-        """When a project is linked, should call set_vtex_host_store on ConnectService."""
-        Project.objects.create(name="Test", uuid=uuid4(), vtex_account="mystore")
-
-        mock_crawl = MagicMock()
-        mock_crawl_cls.return_value = mock_crawl
-
-        mock_connect = Mock()
-        usecase = StartSetupUseCase(connect_service=mock_connect)
-        usecase.start_crawl_usecase = mock_crawl
-
-        usecase.execute(self.dto)
-
-        mock_connect.set_vtex_host_store.assert_called_once()
-        call_kwargs = mock_connect.set_vtex_host_store.call_args
-        self.assertEqual(
-            call_kwargs.kwargs["vtex_host_store"],
-            "https://www.mystore.com.br/",
-        )
-
-    @patch("retail.projects.usecases.start_setup.StartCrawlUseCase")
-    def test_continues_crawl_if_vtex_host_store_fails(self, mock_crawl_cls):
-        """If set_vtex_host_store fails, the crawl should still proceed."""
-        Project.objects.create(name="Test", uuid=uuid4(), vtex_account="mystore")
-
-        mock_crawl = MagicMock()
-        mock_crawl_cls.return_value = mock_crawl
-
-        mock_connect = Mock()
-        mock_connect.set_vtex_host_store.side_effect = Exception("connect down")
-
-        usecase = StartSetupUseCase(connect_service=mock_connect)
-        usecase.start_crawl_usecase = mock_crawl
-
-        usecase.execute(self.dto)
-
-        mock_crawl.execute.assert_called_once_with(
-            "mystore", "https://www.mystore.com.br/"
-        )
 
     @patch("retail.projects.usecases.start_setup.task_wait_and_start_crawl")
     def test_stores_channel_data_in_config(self, mock_task):

--- a/retail/projects/tests/test_tasks.py
+++ b/retail/projects/tests/test_tasks.py
@@ -52,72 +52,25 @@ class TestTaskWaitAndStartCrawl(TestCase):
             name="Test", uuid=uuid4(), vtex_account="mystore"
         )
 
-    @patch("retail.projects.tasks.ConnectService")
-    @patch("retail.projects.tasks.StartCrawlUseCase")
-    def test_starts_crawl_when_project_linked(self, mock_crawl_cls, mock_connect_cls):
+    @patch("retail.projects.tasks.InitiateCrawlUseCase")
+    def test_delegates_to_initiate_crawl_when_project_linked(
+        self, mock_initiate_cls
+    ):
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
         )
 
         mock_instance = MagicMock()
-        mock_crawl_cls.return_value = mock_instance
+        mock_initiate_cls.return_value = mock_instance
 
         from retail.projects.tasks import task_wait_and_start_crawl
 
         task_wait_and_start_crawl("mystore", "https://mystore.com.br/")
 
         mock_instance.execute.assert_called_once_with(
-            "mystore", "https://mystore.com.br/"
+            self.project, "mystore", "https://mystore.com.br/"
         )
-
-    @patch("retail.projects.tasks.ConnectService")
-    @patch("retail.projects.tasks.StartCrawlUseCase")
-    def test_sends_vtex_host_store_when_project_linked(
-        self, mock_crawl_cls, mock_connect_cls
-    ):
-        """Should call set_vtex_host_store before starting the crawl."""
-        ProjectOnboarding.objects.create(
-            vtex_account="mystore",
-            project=self.project,
-        )
-
-        mock_connect = MagicMock()
-        mock_connect_cls.return_value = mock_connect
-        mock_crawl_cls.return_value = MagicMock()
-
-        from retail.projects.tasks import task_wait_and_start_crawl
-
-        task_wait_and_start_crawl("mystore", "https://mystore.com.br/")
-
-        mock_connect.set_vtex_host_store.assert_called_once_with(
-            project_uuid=str(self.project.uuid),
-            vtex_host_store="https://mystore.com.br/",
-        )
-
-    @patch("retail.projects.tasks.ConnectService")
-    @patch("retail.projects.tasks.StartCrawlUseCase")
-    def test_crawl_proceeds_if_vtex_host_store_fails(
-        self, mock_crawl_cls, mock_connect_cls
-    ):
-        """If set_vtex_host_store fails, the crawl should still run."""
-        ProjectOnboarding.objects.create(
-            vtex_account="mystore",
-            project=self.project,
-        )
-
-        mock_connect = MagicMock()
-        mock_connect.set_vtex_host_store.side_effect = Exception("connect down")
-        mock_connect_cls.return_value = mock_connect
-
-        mock_crawl = MagicMock()
-        mock_crawl_cls.return_value = mock_crawl
-
-        from retail.projects.tasks import task_wait_and_start_crawl
-
-        task_wait_and_start_crawl("mystore", "https://mystore.com.br/")
-
-        mock_crawl.execute.assert_called_once()
 
     def test_retries_when_project_not_linked(self):
         ProjectOnboarding.objects.create(vtex_account="mystore")

--- a/retail/projects/usecases/detect_storefront_type.py
+++ b/retail/projects/usecases/detect_storefront_type.py
@@ -1,8 +1,11 @@
 import logging
 
+from retail.clients.connect.client import ConnectClient
 from retail.clients.crawler.client import CrawlerClient
+from retail.interfaces.clients.connect.interface import ConnectClientInterface
 from retail.interfaces.clients.crawler.client import CrawlerClientInterface
 from retail.projects.models import Project
+from retail.services.connect.service import ConnectService
 from retail.services.crawler.service import CrawlerService
 
 logger = logging.getLogger(__name__)
@@ -10,16 +13,23 @@ logger = logging.getLogger(__name__)
 
 class DetectStorefrontTypeUseCase:
     """
-    Detects the storefront technology for a store and persists it
-    in the project config.
+    Detects the storefront technology for a store and sends it
+    to Connect so it flows back via EDA into the local project config.
 
     Non-blocking by design: failures are logged but never propagated,
     so callers can fire-and-forget without risking the main flow.
     """
 
-    def __init__(self, crawler_client: CrawlerClientInterface = None):
+    def __init__(
+        self,
+        crawler_client: CrawlerClientInterface = None,
+        connect_client: ConnectClientInterface = None,
+    ):
         self.crawler_service = CrawlerService(
             crawler_client=crawler_client or CrawlerClient()
+        )
+        self.connect_service = ConnectService(
+            connect_client=connect_client or ConnectClient()
         )
 
     def execute(self, project: Project, store_url: str) -> None:
@@ -45,12 +55,19 @@ class DetectStorefrontTypeUseCase:
         if not storefront_type:
             return
 
-        config = project.config or {}
-        config["storefront_type"] = storefront_type
-        project.config = config
-        project.save(update_fields=["config"])
+        try:
+            self.connect_service.update_project_config(
+                project_uuid=str(project.uuid),
+                config={"storefront_type": storefront_type},
+            )
+        except Exception:
+            logger.exception(
+                f"Failed to send storefront_type to Connect "
+                f"for project={project.uuid}"
+            )
+            return
 
         logger.info(
-            f"Storefront type '{storefront_type}' stored "
+            f"Storefront type '{storefront_type}' sent to Connect "
             f"for project={project.uuid}"
         )

--- a/retail/projects/usecases/detect_storefront_type.py
+++ b/retail/projects/usecases/detect_storefront_type.py
@@ -1,0 +1,56 @@
+import logging
+
+from retail.clients.crawler.client import CrawlerClient
+from retail.interfaces.clients.crawler.client import CrawlerClientInterface
+from retail.projects.models import Project
+from retail.services.crawler.service import CrawlerService
+
+logger = logging.getLogger(__name__)
+
+
+class DetectStorefrontTypeUseCase:
+    """
+    Detects the storefront technology for a store and persists it
+    in the project config.
+
+    Non-blocking by design: failures are logged but never propagated,
+    so callers can fire-and-forget without risking the main flow.
+    """
+
+    def __init__(self, crawler_client: CrawlerClientInterface = None):
+        self.crawler_service = CrawlerService(
+            crawler_client=crawler_client or CrawlerClient()
+        )
+
+    def execute(self, project: Project, store_url: str) -> None:
+        if project is None:
+            return
+
+        try:
+            result = self.crawler_service.detect_storefront_type(store_url)
+        except Exception:
+            logger.exception(
+                f"Unexpected error detecting storefront type "
+                f"for project={project.uuid}"
+            )
+            return
+
+        if result is None:
+            logger.warning(
+                f"Could not detect storefront type for project={project.uuid}"
+            )
+            return
+
+        storefront_type = result.get("storefront_type")
+        if not storefront_type:
+            return
+
+        config = project.config or {}
+        config["storefront_type"] = storefront_type
+        project.config = config
+        project.save(update_fields=["config"])
+
+        logger.info(
+            f"Storefront type '{storefront_type}' stored "
+            f"for project={project.uuid}"
+        )

--- a/retail/projects/usecases/initiate_crawl.py
+++ b/retail/projects/usecases/initiate_crawl.py
@@ -1,0 +1,48 @@
+import logging
+from typing import Optional
+
+from retail.projects.models import Project
+from retail.projects.usecases.detect_storefront_type import (
+    DetectStorefrontTypeUseCase,
+)
+from retail.projects.usecases.start_crawl import StartCrawlUseCase
+from retail.services.connect.service import ConnectService
+
+logger = logging.getLogger(__name__)
+
+
+class InitiateCrawlUseCase:
+    """
+    Runs the full crawl initiation sequence once a project is linked:
+      1. Sends the store URL to Connect (non-blocking).
+      2. Starts the crawl via the Crawler MS (critical).
+      3. Detects the storefront type (non-blocking).
+
+    Used by both StartSetupUseCase (immediate path) and
+    task_wait_and_start_crawl (deferred path) to avoid
+    duplicating the same orchestration.
+    """
+
+    def __init__(self, connect_service: Optional[ConnectService] = None):
+        self.connect_service = connect_service or ConnectService()
+        self.start_crawl_usecase = StartCrawlUseCase()
+        self.detect_storefront_usecase = DetectStorefrontTypeUseCase()
+
+    def execute(
+        self, project: Project, vtex_account: str, crawl_url: str
+    ) -> None:
+        self._send_vtex_host_store(project, crawl_url)
+        self.start_crawl_usecase.execute(vtex_account, crawl_url)
+        self.detect_storefront_usecase.execute(project, crawl_url)
+
+    def _send_vtex_host_store(self, project: Project, crawl_url: str) -> None:
+        try:
+            self.connect_service.set_vtex_host_store(
+                project_uuid=str(project.uuid),
+                vtex_host_store=crawl_url,
+            )
+        except Exception:
+            logger.exception(
+                f"Failed to send vtex_host_store to Connect "
+                f"for project={project.uuid}"
+            )

--- a/retail/projects/usecases/initiate_crawl.py
+++ b/retail/projects/usecases/initiate_crawl.py
@@ -37,9 +37,9 @@ class InitiateCrawlUseCase:
 
     def _send_vtex_host_store(self, project: Project, crawl_url: str) -> None:
         try:
-            self.connect_service.set_vtex_host_store(
+            self.connect_service.update_project_config(
                 project_uuid=str(project.uuid),
-                vtex_host_store=crawl_url,
+                config={"vtex_host_store": crawl_url},
             )
         except Exception:
             logger.exception(

--- a/retail/projects/usecases/start_setup.py
+++ b/retail/projects/usecases/start_setup.py
@@ -3,11 +3,10 @@ from typing import Optional
 
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.tasks import task_wait_and_start_crawl
+from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_agents.agent_mappings import SUPPORTED_CHANNELS
 from retail.projects.usecases.onboarding_dto import StartSetupDTO
-from retail.projects.usecases.start_crawl import StartCrawlUseCase
-from retail.services.connect.service import ConnectService
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +21,8 @@ class StartSetupUseCase:
     task to wait for the link.
     """
 
-    def __init__(self, connect_service: Optional[ConnectService] = None):
-        self.start_crawl_usecase = StartCrawlUseCase()
-        self.connect_service = connect_service or ConnectService()
+    def __init__(self, initiate_crawl_usecase: Optional[InitiateCrawlUseCase] = None):
+        self.initiate_crawl_usecase = initiate_crawl_usecase or InitiateCrawlUseCase()
 
     def execute(self, dto: StartSetupDTO) -> None:
         onboarding, created = ProjectOnboarding.objects.get_or_create(
@@ -62,8 +60,9 @@ class StartSetupUseCase:
             raise
 
         if onboarding.project is not None:
-            self._send_vtex_host_store(onboarding.project, dto.crawl_url)
-            self.start_crawl_usecase.execute(dto.vtex_account, dto.crawl_url)
+            self.initiate_crawl_usecase.execute(
+                onboarding.project, dto.vtex_account, dto.crawl_url
+            )
             return
 
         task_wait_and_start_crawl.delay(dto.vtex_account, dto.crawl_url)
@@ -114,17 +113,3 @@ class StartSetupUseCase:
 
         onboarding.project = project
         onboarding.save(update_fields=["project"])
-
-    def _send_vtex_host_store(self, project: Project, crawl_url: str) -> None:
-        """Sends the crawl URL as vtex_host_store to Connect. Failures are
-        logged but do not interrupt the onboarding flow."""
-        try:
-            self.connect_service.set_vtex_host_store(
-                project_uuid=str(project.uuid),
-                vtex_host_store=crawl_url,
-            )
-        except Exception:
-            logger.exception(
-                f"Failed to send vtex_host_store to Connect for "
-                f"project={project.uuid}"
-            )

--- a/retail/services/connect/service.py
+++ b/retail/services/connect/service.py
@@ -32,12 +32,12 @@ class ConnectService(ConnectServiceInterface):
             project_name=project_name,
         )
 
-    def set_vtex_host_store(
+    def update_project_config(
         self,
         project_uuid: str,
-        vtex_host_store: str,
+        config: Dict,
     ) -> Dict:
-        return self.connect_client.set_vtex_host_store(
+        return self.connect_client.update_project_config(
             project_uuid=project_uuid,
-            vtex_host_store=vtex_host_store,
+            config=config,
         )

--- a/retail/services/crawler/service.py
+++ b/retail/services/crawler/service.py
@@ -40,3 +40,22 @@ class CrawlerService:
                 f"Error {e.status_code} starting crawl for crawl_url={crawl_url}: {e}"
             )
             return None
+
+    def detect_storefront_type(self, store_url: str) -> Optional[Dict]:
+        """
+        Detects the storefront technology for a given store URL.
+
+        Args:
+            store_url: The store URL to inspect.
+
+        Returns:
+            Dict with ``store_url`` and ``storefront_type``, or None on failure.
+        """
+        try:
+            return self.crawler_client.detect_storefront_type(store_url)
+        except CustomAPIException as e:
+            logger.error(
+                f"Error {e.status_code} detecting storefront type "
+                f"for store_url={store_url}: {e}"
+            )
+            return None


### PR DESCRIPTION
### Why

During onboarding, we need to know which VTEX storefront technology a store is running (FastStore, VTEX IO, or Legacy) so downstream steps can adapt their behavior accordingly. The Crawler MS now exposes a `GET /api/storefront-type` endpoint for this, and we need to call it during the crawl step and persist the result in the project config.

### What

**New feature: storefront type detection during crawl initiation.**

Adds a call to the Crawler MS storefront detection endpoint as part of the crawl step, storing the result in `project.config["storefront_type"]`. The detection is non-blocking — failures are logged but never interrupt the crawl flow.

**Refactor: extracted `InitiateCrawlUseCase` to eliminate pre-existing duplication.**

Both `StartSetupUseCase` (immediate path) and `task_wait_and_start_crawl` (deferred path) previously duplicated the same connect → crawl sequence. Adding a third step (storefront detection) made this duplication worse, so the shared sequence was extracted into `InitiateCrawlUseCase`. This also removed `_send_vtex_host_store` from `StartSetupUseCase` and the inline connect/crawl logic from the Celery task.
