### PR TITLE
feat: Expose template language in metadata serialization

### DIFF
--- a/retail/templates/serializers.py
+++ b/retail/templates/serializers.py
@@ -40,6 +40,7 @@ class TemplateMetadataSerializer(serializers.Serializer):
     footer = serializers.CharField(allow_null=True, required=False)
     buttons = serializers.JSONField(allow_null=True, required=False)
     category = serializers.CharField(allow_null=True, required=False)
+    language = serializers.CharField(allow_null=True, required=False)
 
     def __init__(self, *args, **kwargs):
         self.s3_service = kwargs.pop("s3_service", None)

--- a/retail/templates/tests/serializers/test_template_serializers.py
+++ b/retail/templates/tests/serializers/test_template_serializers.py
@@ -108,6 +108,7 @@ class TestTemplateMetadataSerializer(TestCase):
             "footer": "Footer text",
             "buttons": [{"type": "QUICK_REPLY", "text": "Reply"}],
             "category": "UTILITY",
+            "language": "pt_BR",
         }
 
         serializer = TemplateMetadataSerializer(
@@ -120,6 +121,7 @@ class TestTemplateMetadataSerializer(TestCase):
         self.assertEqual(result["footer"], "Footer text")
         self.assertEqual(result["buttons"], [{"type": "QUICK_REPLY", "text": "Reply"}])
         self.assertEqual(result["category"], "UTILITY")
+        self.assertEqual(result["language"], "pt_BR")
         self.assertIsNotNone(result["header"])
 
     def test_metadata_serialization_with_image_header(self):
@@ -157,6 +159,17 @@ class TestTemplateMetadataSerializer(TestCase):
 
         result = serializer.data
         self.assertIsNone(result["header"])
+
+    def test_metadata_serialization_without_language(self):
+        metadata = {"body": "Test body", "category": "UTILITY"}
+
+        serializer = TemplateMetadataSerializer(
+            metadata, s3_service=self.mock_s3_service
+        )
+
+        result = serializer.data
+        self.assertEqual(result["body"], "Test body")
+        self.assertNotIn("language", result)
 
 
 class TestReadTemplateSerializer(TestCase):


### PR DESCRIPTION
## What
Adds the `language` field to `TemplateMetadataSerializer`, making it available
in the API response of `GET /api/v3/agents/assigneds/<uuid>/` within each
template's `metadata` object.

## Why
The frontend needs the template language to display it properly, and the value
was already stored in `Template.metadata["language"]` but was being discarded
during serialization because the field was not declared in the serializer.