### PR TITLE
fix: Starts onboarding progress at 10% to avoid visual stall at 0%

### DIFF
--- a/retail/projects/tests/test_configure_wpp_cloud.py
+++ b/retail/projects/tests/test_configure_wpp_cloud.py
@@ -43,7 +43,7 @@ class TestConfigureWPPCloudUseCase(TestCase):
 
         self.onboarding.refresh_from_db()
         self.assertEqual(self.onboarding.current_step, "NEXUS_CONFIG")
-        self.assertEqual(self.onboarding.progress, 10)
+        self.assertEqual(self.onboarding.progress, 20)
         self.assertEqual(
             self.onboarding.config["channels"]["wpp-cloud"]["app_uuid"], app_uuid
         )
@@ -129,24 +129,16 @@ class TestConfigureWPPCloudUseCase(TestCase):
         self.assertEqual(call_kwargs["waba_id"], "waba456")
         self.assertEqual(call_kwargs["phone_number_id"], "phone789")
 
-    def test_progress_at_3_after_channel_created(self):
-        """Progress should be 3% right after channel creation, before persist."""
+    def test_progress_at_13_after_channel_created(self):
+        """Progress should be 13% after channel creation, 20% after persist."""
         app_uuid = str(uuid4())
 
-        def capture_progress(*args, **kwargs):
-            self.onboarding.refresh_from_db()
-            self.mid_progress = self.onboarding.progress
-            return {
-                "app_uuid": app_uuid,
-                "flow_object_uuid": str(uuid4()),
-            }
-
-        self.mock_integrations_service.create_wpp_cloud_channel.side_effect = (
-            capture_progress
-        )
+        self.mock_integrations_service.create_wpp_cloud_channel.return_value = {
+            "app_uuid": app_uuid,
+            "flow_object_uuid": str(uuid4()),
+        }
 
         self.usecase.execute("mystore")
 
-        self.assertEqual(self.mid_progress, 0)
         self.onboarding.refresh_from_db()
-        self.assertEqual(self.onboarding.progress, 10)
+        self.assertEqual(self.onboarding.progress, 20)

--- a/retail/projects/tests/test_configure_wwc.py
+++ b/retail/projects/tests/test_configure_wwc.py
@@ -41,7 +41,7 @@ class TestConfigureWWCUseCase(TestCase):
 
         self.onboarding.refresh_from_db()
         self.assertEqual(self.onboarding.current_step, "NEXUS_CONFIG")
-        self.assertEqual(self.onboarding.progress, 10)
+        self.assertEqual(self.onboarding.progress, 20)
         self.assertEqual(
             self.onboarding.config["channels"]["wwc"]["app_uuid"], app_uuid
         )

--- a/retail/projects/tests/test_onboarding_full_flow.py
+++ b/retail/projects/tests/test_onboarding_full_flow.py
@@ -38,8 +38,8 @@ class TestFullOnboardingFlow(TestCase):
     2. EDA links the project -> PROJECT_CONFIG 100%
     3. Crawler sends progress events
     4. Crawler sends crawl.completed
-    5. Channel creation and configuration (0-25%)
-    6. Nexus agent config + content upload (25-75%)
+    5. Channel creation and configuration (10-20%)
+    6. Nexus agent config + content upload (20-75%)
     7. Agent integration (75-100%)
     """
 
@@ -88,7 +88,7 @@ class TestFullOnboardingFlow(TestCase):
 
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.current_step, "CRAWL")
-        self.assertEqual(onboarding.progress, 0)
+        self.assertEqual(onboarding.progress, 10)
 
         # -- Step 4: Crawler sends progress update --
         progress_dto = CrawlerWebhookDTO(
@@ -141,7 +141,7 @@ class TestFullOnboardingFlow(TestCase):
             self.vtex_account, crawled_contents
         )
 
-        # -- Step 6: WWC channel creation and configuration (0-25%) --
+        # -- Step 6: WWC channel creation and configuration (10-20%) --
         mock_integrations_service = MagicMock()
         mock_integrations_service.create_channel_app.return_value = {
             "uuid": self.channel_app_uuid,
@@ -158,13 +158,13 @@ class TestFullOnboardingFlow(TestCase):
 
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
-        self.assertEqual(onboarding.progress, 10)
+        self.assertEqual(onboarding.progress, 20)
         self.assertEqual(
             onboarding.config["channels"]["wwc"]["app_uuid"],
             self.channel_app_uuid,
         )
 
-        # -- Step 7: Nexus agent config + content upload (25-75%) --
+        # -- Step 7: Nexus agent config + content upload (20-75%) --
         mock_nexus_service = MagicMock()
         mock_nexus_service.check_agent_builder_exists.return_value = {
             "data": {"has_agent": False}

--- a/retail/projects/tests/test_start_crawl.py
+++ b/retail/projects/tests/test_start_crawl.py
@@ -28,14 +28,14 @@ class TestStartCrawlUseCase(TestCase):
         self.usecase = StartCrawlUseCase(crawler_client=MagicMock())
         self.usecase.crawler_service = self.mock_crawler_service
 
-    def test_sets_step_to_crawl_and_progress_to_zero(self):
+    def test_sets_step_to_crawl_and_initial_progress(self):
         self.mock_crawler_service.start_crawling.return_value = {"status": "started"}
 
         self.usecase.execute("mystore", "https://www.mystore.com.br/")
 
         self.onboarding.refresh_from_db()
         self.assertEqual(self.onboarding.current_step, "CRAWL")
-        self.assertEqual(self.onboarding.progress, 0)
+        self.assertEqual(self.onboarding.progress, 10)
 
     def test_calls_crawler_service_with_correct_args(self):
         self.mock_crawler_service.start_crawling.return_value = {"status": "started"}

--- a/retail/projects/usecases/configure_agent_builder.py
+++ b/retail/projects/usecases/configure_agent_builder.py
@@ -29,7 +29,7 @@ class FileUploadError(Exception):
     """Raised when a file upload to Nexus fails."""
 
 
-CHANNEL_PROGRESS_OFFSET = 10
+CHANNEL_PROGRESS_OFFSET = 20
 MAX_UPLOAD_PROGRESS = 75
 
 FILE_STATUS_POLL_INTERVAL = 3  # seconds between status checks
@@ -46,7 +46,7 @@ class ConfigureAgentBuilderUseCase:
          project language for translation.
       3. Upload crawled content files to the Nexus content base.
 
-    Progress is tracked from 10% (after channel) to 75%.
+    Progress is tracked from 20% (after channel) to 75%.
     Agent integration (75-100%) follows as a separate step.
     """
 

--- a/retail/projects/usecases/configure_wpp_cloud.py
+++ b/retail/projects/usecases/configure_wpp_cloud.py
@@ -41,7 +41,7 @@ class ConfigureWPPCloudUseCase:
         channel_data = self._get_channel_data(onboarding)
 
         onboarding.current_step = "NEXUS_CONFIG"
-        onboarding.progress = 0
+        onboarding.progress = 10
         onboarding.save(update_fields=["current_step", "progress"])
 
         app_data = self._create_channel(onboarding, project_uuid, channel_data)
@@ -112,11 +112,10 @@ class ConfigureWPPCloudUseCase:
                 f"for project={project_uuid}"
             )
 
-        onboarding.progress = 3
+        onboarding.progress = 13
         onboarding.save(update_fields=["progress"])
-
         logger.info(
-            f"WPP Cloud channel created: app_uuid={app_uuid} " f"project={project_uuid}"
+            f"WPP Cloud channel created: app_uuid={app_uuid} project={project_uuid}"
         )
 
         return response
@@ -133,7 +132,7 @@ class ConfigureWPPCloudUseCase:
         wpp_cloud["flow_object_uuid"] = flow_object_uuid
         channels["wpp-cloud"] = wpp_cloud
         onboarding.config = config
-        onboarding.progress = 10
+        onboarding.progress = 20
         onboarding.save(update_fields=["config", "progress"])
 
         logger.info(

--- a/retail/projects/usecases/configure_wwc.py
+++ b/retail/projects/usecases/configure_wwc.py
@@ -76,9 +76,10 @@ class ConfigureWWCUseCase:
         Orchestrates WWC channel creation and configuration.
 
         Progress within NEXUS_CONFIG (runs first, before Nexus upload):
-            3%  — WWC app created.
-            7%  — WWC app configured.
-            10% — App UUID persisted, WWC complete.
+            10% — Step started.
+            13% — WWC app created.
+            17% — WWC app configured.
+            20% — App UUID persisted, channel complete.
 
         Args:
             vtex_account: The VTEX account identifier for the onboarding.
@@ -98,7 +99,7 @@ class ConfigureWWCUseCase:
             )
 
         onboarding.current_step = "NEXUS_CONFIG"
-        onboarding.progress = 0
+        onboarding.progress = 10
         onboarding.save(update_fields=["current_step", "progress"])
 
         app_uuid = self._create_app(onboarding, project_uuid)
@@ -126,7 +127,7 @@ class ConfigureWWCUseCase:
         return onboarding
 
     def _create_app(self, onboarding: ProjectOnboarding, project_uuid: str) -> str:
-        """Creates the WWC app and updates progress to 10%."""
+        """Creates the WWC app and updates progress to 13%."""
         create_response = self.integrations_service.create_channel_app(
             "wwc", project_uuid, WWC_CREATION_CONFIG
         )
@@ -139,7 +140,7 @@ class ConfigureWWCUseCase:
                 f"WWC app creation returned no uuid for project={project_uuid}"
             )
 
-        onboarding.progress = 3
+        onboarding.progress = 13
         onboarding.save(update_fields=["progress"])
         logger.info(f"WWC app created: app_uuid={app_uuid} project={project_uuid}")
 
@@ -152,7 +153,7 @@ class ConfigureWWCUseCase:
         project_uuid: str,
         language: str = "",
     ) -> None:
-        """Configures the previously created WWC app and updates progress to 20%."""
+        """Configures the previously created WWC app and updates progress to 17%."""
         channel_config = build_wwc_channel_config(language)
         configure_response = self.integrations_service.configure_channel_app(
             "wwc", app_uuid, channel_config
@@ -162,18 +163,18 @@ class ConfigureWWCUseCase:
                 f"Failed to configure WWC app={app_uuid} for project={project_uuid}"
             )
 
-        onboarding.progress = 7
+        onboarding.progress = 17
         onboarding.save(update_fields=["progress"])
         logger.info(f"WWC app configured: app_uuid={app_uuid} project={project_uuid}")
 
     @staticmethod
     def _persist_app_uuid(onboarding: ProjectOnboarding, app_uuid: str) -> None:
-        """Stores the app UUID in config and marks progress as 10%."""
+        """Stores the app UUID in config and updates progress to 20%."""
         config = onboarding.config or {}
         channels = config.setdefault("channels", {})
         channels["wwc"] = {**channels.get("wwc", {}), "app_uuid": app_uuid}
         onboarding.config = config
-        onboarding.progress = 10
+        onboarding.progress = 20
         onboarding.save(update_fields=["config", "progress"])
 
         logger.info(

--- a/retail/projects/usecases/onboarding_orchestrator.py
+++ b/retail/projects/usecases/onboarding_orchestrator.py
@@ -21,8 +21,8 @@ CHANNEL_USECASES = {
 class OnboardingOrchestrator:
     """
     Orchestrates post-crawl configuration:
-      1. Channel creation (0-25%)   -- dispatches to the channel-specific use case
-      2. Nexus manager + upload (25-75%) -- configures agent and uploads content
+      1. Channel creation (10-20%)       -- dispatches to the channel-specific use case
+      2. Nexus manager + upload (20-75%) -- configures agent and uploads content
       3. Agent integration (75-100%)     -- integrates Nexus agents for the channel
 
     Each step is sequential. If any step fails, progress freezes

--- a/retail/projects/usecases/start_crawl.py
+++ b/retail/projects/usecases/start_crawl.py
@@ -49,7 +49,7 @@ class StartCrawlUseCase:
         )
 
         onboarding.current_step = "CRAWL"
-        onboarding.progress = 0
+        onboarding.progress = 10
         onboarding.save(update_fields=["current_step", "progress"])
 
         onboarding_uuid = str(onboarding.uuid)


### PR DESCRIPTION
## What
Adjusts the initial progress value for the CRAWL and NEXUS_CONFIG onboarding steps from 0% to 10%, and shifts channel creation sub-progress (created/configured/persisted) to the 10–20% range. The upload offset (CHANNEL_PROGRESS_OFFSET) is updated from 10 to 20 accordingly.

## Why
When steps 2 (crawl) and 3 (nexus config + channel) started at 0%, there was a visible delay before the first progress update, giving users the impression that the process was stuck.