### PR TITLE
feat: Add GET health check to payment recovery webhook

### DIFF
--- a/retail/agents/domains/agent_integration/views.py
+++ b/retail/agents/domains/agent_integration/views.py
@@ -352,6 +352,10 @@ class PaymentRecoveryWebhookView(APIView):
 
     permission_classes = [AllowAny]
 
+    def get(self, request: Request, pk: UUID) -> Response:
+        logger.info(f"Health check received for payment recovery webhook - agent {pk}")
+        return Response({"message": "Webhook available"}, status=status.HTTP_200_OK)
+
     def post(self, request: Request, pk: UUID) -> Response:
         if request.data.get("hookConfig") == "ping":
             logger.info(f"VTEX ping received for payment recovery webhook - agent {pk}")


### PR DESCRIPTION
## What
Adds GET method support to the PaymentRecoveryWebhookView, returning 200 
with a "Webhook available" message for health check requests.

## Why
VTEX validates webhook URLs before saving hook configurations. Without GET 
support, the endpoint returned 405 Method Not Allowed, which could cause 
URL validation failures during hook registration.