### PR TITLE
fix: Set payment recovery template category to MARKETING and standardize logs

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -621,9 +621,8 @@ class AssignAgentUseCase:
 
         try:
             logger.info(
-                f"[AssignAgent] Payment recovery template flow start for "
-                f"integrated_agent={integrated_agent.uuid}, "
-                f"language={template_language}"
+                f"[PaymentRecovery] Template creation started - "
+                f"agent={integrated_agent.uuid} language={template_language}"
             )
 
             placeholder_image_url = settings.ABANDONED_CART_DEFAULT_IMAGE_URL
@@ -644,7 +643,7 @@ class AssignAgentUseCase:
 
             payload: CreateCustomTemplateData = {
                 "template_translation": template_translation,
-                "category": "UTILITY",
+                "category": "MARKETING",
                 "app_uuid": str(app_uuid),
                 "project_uuid": str(project_uuid),
                 "display_name": "Payment Recovery",
@@ -673,21 +672,20 @@ class AssignAgentUseCase:
             use_case = CreateCustomTemplateUseCase()
             use_case.execute(payload)
             logger.info(
-                f"[AssignAgent] Payment recovery template creation completed for "
-                f"integrated_agent={integrated_agent.uuid}, "
-                f"language={template_language}"
+                f"[PaymentRecovery] Template created successfully - "
+                f"agent={integrated_agent.uuid} language={template_language}"
             )
             return True
         except CustomTemplateAlreadyExists:
             logger.info(
-                f"[AssignAgent] Payment recovery template already exists for "
-                f"integrated_agent={integrated_agent.uuid}"
+                f"[PaymentRecovery] Template already exists - "
+                f"agent={integrated_agent.uuid}"
             )
             return True
         except Exception as exc:
             logger.exception(
-                f"[AssignAgent] Error creating payment recovery template for "
-                f"integrated_agent={integrated_agent.uuid}: {exc}"
+                f"[PaymentRecovery] Template creation failed - "
+                f"agent={integrated_agent.uuid}: {exc}"
             )
             return False
 
@@ -702,9 +700,8 @@ class AssignAgentUseCase:
             webhook_url = self._build_payment_recovery_webhook_url(integrated_agent)
 
             logger.info(
-                f"[AssignAgent] Creating payment recovery VTEX hook for "
-                f"integrated_agent={integrated_agent.uuid}, "
-                f"webhook_url={webhook_url}"
+                f"[PaymentRecovery] Creating VTEX hook - "
+                f"agent={integrated_agent.uuid} webhook_url={webhook_url}"
             )
 
             hook_data = {
@@ -737,11 +734,11 @@ class AssignAgentUseCase:
             integrated_agent.save(update_fields=["config"])
 
             logger.info(
-                f"[AssignAgent] Payment recovery VTEX hook created for "
-                f"integrated_agent={integrated_agent.uuid}"
+                f"[PaymentRecovery] VTEX hook created successfully - "
+                f"agent={integrated_agent.uuid}"
             )
         except Exception as exc:
             logger.exception(
-                f"[AssignAgent] Error creating payment recovery VTEX hook for "
-                f"integrated_agent={integrated_agent.uuid}: {exc}"
+                f"[PaymentRecovery] VTEX hook creation failed - "
+                f"agent={integrated_agent.uuid}: {exc}"
             )

--- a/retail/agents/domains/agent_integration/usecases/payment_recovery.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery.py
@@ -62,8 +62,8 @@ class PaymentRecoveryWebhookUseCase:
         self.validate_payment_recovery_enabled(integrated_agent)
 
         logger.info(
-            f"[PaymentRecovery] Processing webhook for "
-            f"agent={integrated_agent.uuid}: {webhook_data}"
+            f"[PaymentRecovery] Processing webhook notification - "
+            f"agent={integrated_agent.uuid} data={webhook_data}"
         )
 
         self._process_payment_recovery_notification(integrated_agent, webhook_data)
@@ -90,14 +90,14 @@ class PaymentRecoveryWebhookUseCase:
         )
 
         logger.info(
-            f"[PaymentRecovery] OrderStatusDTO built: "
-            f"order_id={order_status_dto.orderId} agent={integrated_agent.uuid}"
+            f"[PaymentRecovery] OrderStatusDTO built - "
+            f"agent={integrated_agent.uuid} order_id={order_status_dto.orderId}"
         )
 
         order_status_usecase = AgentOrderStatusUpdateUsecase()
         order_status_usecase.execute(integrated_agent, order_status_dto)
 
         logger.info(
-            f"[PaymentRecovery] Processing completed for "
-            f"agent={integrated_agent.uuid} order={order_status_dto.orderId}"
+            f"[PaymentRecovery] Webhook processed successfully - "
+            f"agent={integrated_agent.uuid} order_id={order_status_dto.orderId}"
         )

--- a/retail/agents/domains/agent_integration/views.py
+++ b/retail/agents/domains/agent_integration/views.py
@@ -353,12 +353,12 @@ class PaymentRecoveryWebhookView(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request: Request, pk: UUID) -> Response:
-        logger.info(f"Health check received for payment recovery webhook - agent {pk}")
+        logger.info(f"[PaymentRecovery] Health check received - agent={pk}")
         return Response({"message": "Webhook available"}, status=status.HTTP_200_OK)
 
     def post(self, request: Request, pk: UUID) -> Response:
         if request.data.get("hookConfig") == "ping":
-            logger.info(f"VTEX ping received for payment recovery webhook - agent {pk}")
+            logger.info(f"[PaymentRecovery] VTEX ping received - agent={pk}")
             return Response({"message": "Webhook available"}, status=status.HTTP_200_OK)
 
         try:
@@ -372,13 +372,13 @@ class PaymentRecoveryWebhookView(APIView):
             )
 
             logger.info(
-                f"Payment recovery webhook scheduled for processing - agent {pk} "
-                f"countdown={countdown}s"
+                f"[PaymentRecovery] Webhook scheduled for processing - "
+                f"agent={pk} countdown={countdown}s"
             )
             return Response({"message": "Webhook received"}, status=status.HTTP_200_OK)
 
         except Exception as e:
             logger.exception(
-                f"Error queuing payment recovery webhook for agent {pk}: {e}"
+                f"[PaymentRecovery] Error queuing webhook - agent={pk}: {e}"
             )
             return Response({"message": "Webhook received"}, status=status.HTTP_200_OK)

--- a/retail/agents/tasks.py
+++ b/retail/agents/tasks.py
@@ -63,21 +63,18 @@ def task_payment_recovery_webhook(
         webhook_data: Data received from VTEX webhook
     """
     try:
-        logger.info(
-            f"Processing payment recovery webhook task for agent {integrated_agent_uuid}"
-        )
+        logger.info(f"[PaymentRecovery] Task started - agent={integrated_agent_uuid}")
 
         use_case = PaymentRecoveryWebhookUseCase()
         integrated_agent = use_case.get_integrated_agent(integrated_agent_uuid)
         result = use_case.process_webhook_notification(integrated_agent, webhook_data)
 
         logger.info(
-            f"Successfully processed payment recovery webhook for "
-            f"agent {integrated_agent_uuid}: {result}"
+            f"[PaymentRecovery] Task completed successfully - "
+            f"agent={integrated_agent_uuid} result={result}"
         )
 
     except Exception as e:
         logger.exception(
-            f"Error processing payment recovery webhook task for "
-            f"agent {integrated_agent_uuid}: {e}"
+            f"[PaymentRecovery] Task failed - agent={integrated_agent_uuid}: {e}"
         )

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -107,7 +107,7 @@ class AssignPaymentRecoveryTemplateTest(TestCase):
         self.assertTrue(result)
         mock_template_usecase.execute.assert_called_once()
         payload = mock_template_usecase.execute.call_args[0][0]
-        self.assertEqual(payload["category"], "UTILITY")
+        self.assertEqual(payload["category"], "MARKETING")
         self.assertEqual(payload["display_name"], "Payment Recovery")
         self.assertTrue(payload["use_agent_rule"])
 


### PR DESCRIPTION

## What
Changes the payment recovery template category from UTILITY to MARKETING
and standardizes all log messages across the payment recovery flow with
a consistent `[PaymentRecovery]` prefix and structured key=value format.

## Why
Meta classifies the payment recovery template as MARKETING, causing
slowness to approve when submitted as UTILITY. Additionally, the log messages
across the flow (view, task, use cases) used inconsistent formats,
making it difficult to trace the full lifecycle of a payment recovery
request. The `[PaymentRecovery]` prefix enables quick log filtering
across all stages: setup, webhook ingestion, task scheduling, and
processing.