### PR TITLE
fix: Add User-Agent header to VTEX webhook hook config

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -714,7 +714,10 @@ class AssignAgentUseCase:
                     ),
                     "disableSingleFire": False,
                 },
-                "hook": {"url": webhook_url},
+                "hook": {
+                    "url": webhook_url,
+                    "headers": {"User-Agent": "vtex-retail/0.0.0"},
+                },
             }
 
             proxy_usecase = ProxyVtexUsecase(vtex_io_service=VtexIOService())

--- a/retail/agents/domains/agent_integration/usecases/delivered_order_tracking.py
+++ b/retail/agents/domains/agent_integration/usecases/delivered_order_tracking.py
@@ -177,7 +177,10 @@ class DeliveredOrderTrackingConfigUseCase:
                     "expression": '$count(packageAttachment.packages[courierStatus.deliveredDate != "" or courierStatus.finished = true]) > 0',  # noqa: E501
                     "disableSingleFire": False,
                 },
-                "hook": {"url": tracking_config["webhook_url"]},
+                "hook": {
+                    "url": tracking_config["webhook_url"],
+                    "headers": {"User-Agent": "vtex-retail/0.0.0"},
+                },
             }
 
             # Prepare headers for VTEX API

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -209,6 +209,10 @@ class AssignPaymentRecoveryHookTest(TestCase):
         self.assertEqual(call_kwargs["path"], "/api/orders/hook/config")
         self.assertIn("filter", call_kwargs["data"])
         self.assertIn("hook", call_kwargs["data"])
+        self.assertEqual(
+            call_kwargs["data"]["hook"]["headers"],
+            {"User-Agent": "vtex-retail/0.0.0"},
+        )
 
         self.integrated_agent.save.assert_called()
         saved_config = self.integrated_agent.config


### PR DESCRIPTION
## What
Adds a `User-Agent: vtex-retail/0.0.0` header to the VTEX hook configuration
for both payment recovery and delivered order tracking webhooks.

## Why
VTEX's hook validation request was being blocked by CloudFront WAF when
registering webhook URLs, returning "Unable to check address". Adding the
User-Agent header allows the WAF to identify and permit VTEX callback requests.