### PR TITLE
feat: Persist start-setup failure snapshot in onboarding config

### DIFF
--- a/retail/projects/tests/test_save_onboarding_failure.py
+++ b/retail/projects/tests/test_save_onboarding_failure.py
@@ -1,0 +1,100 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.save_onboarding_failure import (
+    SaveOnboardingFailureUseCase,
+)
+
+
+class TestSaveOnboardingFailureUseCase(TestCase):
+    def test_creates_onboarding_and_stores_failure_when_missing(self):
+        """When no onboarding exists, it should be created with the failure snapshot."""
+        SaveOnboardingFailureUseCase.execute(
+            vtex_account="newstore",
+            stage="start_setup_validation",
+            payload={"channel": "wpp-cloud"},
+            errors={"channel_data": ["This field is required."]},
+        )
+
+        onboarding = ProjectOnboarding.objects.get(vtex_account="newstore")
+        last_failure = onboarding.config["last_failure"]
+
+        self.assertEqual(last_failure["stage"], "start_setup_validation")
+        self.assertEqual(last_failure["payload"], {"channel": "wpp-cloud"})
+        self.assertEqual(
+            last_failure["errors"], {"channel_data": ["This field is required."]}
+        )
+        self.assertIsNotNone(last_failure["timestamp"])
+
+    def test_stores_failure_on_existing_onboarding(self):
+        """Existing onboarding should have its config updated without data loss."""
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            config={"channels": {"wwc": {}}},
+        )
+
+        SaveOnboardingFailureUseCase.execute(
+            vtex_account="mystore",
+            stage="start_setup_validation",
+            payload={"channel": "wwc"},
+            errors={"crawl_url": ["Required."]},
+        )
+
+        onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
+        self.assertIn("channels", onboarding.config)
+        self.assertEqual(
+            onboarding.config["last_failure"]["stage"], "start_setup_validation"
+        )
+
+    def test_overwrites_previous_failure(self):
+        """A new failure should replace the previous snapshot."""
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            config={"last_failure": {"stage": "old_stage"}},
+        )
+
+        SaveOnboardingFailureUseCase.execute(
+            vtex_account="mystore",
+            stage="start_setup_validation",
+            payload={"foo": "bar"},
+            errors={"field": ["error"]},
+        )
+
+        onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
+        self.assertEqual(
+            onboarding.config["last_failure"]["stage"], "start_setup_validation"
+        )
+
+    def test_converts_drf_error_detail_to_plain_string(self):
+        """DRF ErrorDetail objects must be serialized as plain strings."""
+        from rest_framework.exceptions import ErrorDetail
+
+        errors = {"channel_data": [ErrorDetail("Required.", code="required")]}
+
+        SaveOnboardingFailureUseCase.execute(
+            vtex_account="mystore",
+            stage="start_setup_validation",
+            payload={},
+            errors=errors,
+        )
+
+        onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
+        stored_errors = onboarding.config["last_failure"]["errors"]
+
+        self.assertEqual(stored_errors, {"channel_data": ["Required."]})
+
+    def test_does_not_propagate_exceptions(self):
+        """Persistence errors must be logged but never propagated."""
+        with patch(
+            "retail.projects.usecases.save_onboarding_failure."
+            "ProjectOnboarding.objects.get_or_create",
+            side_effect=RuntimeError("DB down"),
+        ):
+            SaveOnboardingFailureUseCase.execute(
+                vtex_account="mystore",
+                stage="start_setup_validation",
+                payload={},
+                errors={},
+            )

--- a/retail/projects/tests/test_start_onboarding.py
+++ b/retail/projects/tests/test_start_onboarding.py
@@ -58,6 +58,10 @@ class TestStartSetupUseCase(TestCase):
             progress=80,
             crawler_result=ProjectOnboarding.SUCCESS,
             completed=True,
+            config={
+                "last_failure": {"stage": "start_setup_validation"},
+                "reason_failed": "previous error",
+            },
         )
 
         usecase = StartSetupUseCase()
@@ -68,6 +72,8 @@ class TestStartSetupUseCase(TestCase):
         self.assertEqual(onboarding.current_step, "")
         self.assertIsNone(onboarding.crawler_result)
         self.assertFalse(onboarding.completed)
+        self.assertNotIn("last_failure", onboarding.config)
+        self.assertNotIn("reason_failed", onboarding.config)
 
     def test_try_link_project_finds_existing_project(self):
         """_try_link_project should link a matching project."""

--- a/retail/projects/tests/test_views.py
+++ b/retail/projects/tests/test_views.py
@@ -101,6 +101,28 @@ class TestStartSetupView(TestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    @_auth_bypass(None)
+    def test_stores_failure_snapshot_on_validation_error(self, _mock_auth):
+        """When the payload is invalid, the snapshot must be persisted in config."""
+        payload = {
+            "crawl_url": "https://www.mystore.com.br/",
+            "channel": "wpp-cloud",
+        }
+
+        response = self.client.post(
+            "/api/onboard/mystore/start-setup/",
+            payload,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
+        last_failure = onboarding.config["last_failure"]
+        self.assertEqual(last_failure["stage"], "start_setup_validation")
+        self.assertEqual(last_failure["payload"], payload)
+        self.assertIn("channel_data", last_failure["errors"])
+
 
 class TestCrawlerWebhookView(TestCase):
     def setUp(self):

--- a/retail/projects/usecases/save_onboarding_failure.py
+++ b/retail/projects/usecases/save_onboarding_failure.py
@@ -1,0 +1,79 @@
+import logging
+from typing import Any, Mapping, Optional
+
+from django.utils import timezone
+
+from retail.projects.models import ProjectOnboarding
+
+logger = logging.getLogger(__name__)
+
+
+class SaveOnboardingFailureUseCase:
+    """
+    Stores a snapshot of a failed onboarding attempt in ProjectOnboarding.config.
+
+    Used to debug and recover cases where the onboarding could not proceed
+    (e.g., invalid payload from the front-end, external service failures).
+
+    The payload is stored under config["last_failure"] and is overwritten
+    on each new failure. It is cleared when a new attempt is made via
+    StartSetupUseCase (see _reset_onboarding).
+
+    Fail-safe: exceptions are logged and never propagated, so the caller's
+    flow is not affected by persistence issues.
+    """
+
+    @staticmethod
+    def execute(
+        vtex_account: str,
+        stage: str,
+        payload: Optional[Mapping[str, Any]] = None,
+        errors: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """
+        Args:
+            vtex_account: VTEX account identifier.
+            stage: Short code identifying where the failure happened
+                (e.g., "start_setup_validation", "crawler_start").
+            payload: The raw payload received by the backend.
+            errors: The validation or processing errors (serializable).
+        """
+        try:
+            onboarding, _ = ProjectOnboarding.objects.get_or_create(
+                vtex_account=vtex_account,
+            )
+            config = onboarding.config or {}
+            config["last_failure"] = {
+                "timestamp": timezone.now().isoformat(),
+                "stage": stage,
+                "errors": _to_plain(errors),
+                "payload": _to_plain(payload),
+            }
+            onboarding.config = config
+            onboarding.save(update_fields=["config"])
+
+            logger.info(
+                f"[SaveOnboardingFailure] stored failure "
+                f"vtex_account={vtex_account} stage={stage}"
+            )
+        except Exception as exc:
+            logger.error(
+                f"[SaveOnboardingFailure] could not store failure for "
+                f"vtex_account={vtex_account}: {exc}"
+            )
+
+
+def _to_plain(value: Any) -> Any:
+    """
+    Converts DRF ``ErrorDetail`` and ``ReturnDict`` structures into plain
+    JSON-serializable types so they can be safely stored in a JSONField.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {str(k): _to_plain(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_plain(v) for v in value]
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)

--- a/retail/projects/usecases/start_setup.py
+++ b/retail/projects/usecases/start_setup.py
@@ -80,6 +80,12 @@ class StartSetupUseCase:
         onboarding.completed = False
         onboarding.failed = False
         onboarding.current_step = ""
+
+        config = onboarding.config or {}
+        config.pop("last_failure", None)
+        config.pop("reason_failed", None)
+        onboarding.config = config
+
         onboarding.save(
             update_fields=[
                 "progress",
@@ -87,6 +93,7 @@ class StartSetupUseCase:
                 "completed",
                 "failed",
                 "current_step",
+                "config",
             ]
         )
 

--- a/retail/projects/views.py
+++ b/retail/projects/views.py
@@ -34,6 +34,9 @@ from retail.projects.usecases.onboarding_dto import (
     InstallChannelAgentsDTO,
 )
 from retail.projects.usecases.project_vtex import ProjectVtexConfigUseCase
+from retail.projects.usecases.save_onboarding_failure import (
+    SaveOnboardingFailureUseCase,
+)
 from retail.projects.usecases.start_crawl import CrawlerStartError
 from retail.projects.usecases.start_setup import StartSetupUseCase
 from retail.projects.usecases.update_onboarding_progress import (
@@ -121,7 +124,18 @@ class StartSetupView(KeycloakAPIView):
 
     def post(self, request, vtex_account: str) -> Response:
         serializer = StartSetupSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
+        if not serializer.is_valid():
+            logger.warning(
+                f"[StartSetup] Invalid payload for vtex_account={vtex_account}: "
+                f"errors={serializer.errors}"
+            )
+            SaveOnboardingFailureUseCase.execute(
+                vtex_account=vtex_account,
+                stage="start_setup_validation",
+                payload=request.data,
+                errors=serializer.errors,
+            )
+            raise ValidationError(serializer.errors)
 
         channel_data = serializer.validated_data.get("channel_data", {})
 


### PR DESCRIPTION
## What

Persists the received payload and validation errors in
`ProjectOnboarding.config["last_failure"]` when `start-setup` returns 400,
and clears it on retry.

## Why

Stuck onboardings returning 400 had no trace of the received payload,
blocking debug and recovery. Storing the failure snapshot makes the root
cause inspectable and enables resuming from the last known state.