### PR TITLE
feat: Handle crawl.url_redirected webhook event

### DIFF
--- a/retail/projects/tests/test_onboarding_full_flow.py
+++ b/retail/projects/tests/test_onboarding_full_flow.py
@@ -98,7 +98,7 @@ class TestFullOnboardingFlow(TestCase):
             url=self.crawl_url,
             progress=50,
         )
-        result = UpdateOnboardingProgressUseCase.execute(
+        result = UpdateOnboardingProgressUseCase().execute(
             str(onboarding.uuid), progress_dto
         )
         self.assertEqual(result.progress, 50)
@@ -131,7 +131,7 @@ class TestFullOnboardingFlow(TestCase):
                 progress=100,
                 data={"contents": crawled_contents},
             )
-            result = UpdateOnboardingProgressUseCase.execute(
+            result = UpdateOnboardingProgressUseCase().execute(
                 str(onboarding.uuid), completed_dto
             )
 

--- a/retail/projects/tests/test_update_onboarding_progress.py
+++ b/retail/projects/tests/test_update_onboarding_progress.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.test import TestCase
@@ -8,6 +8,7 @@ from retail.projects.usecases.onboarding_dto import CrawlerWebhookDTO
 from retail.projects.usecases.update_onboarding_progress import (
     COMPLETED_EVENT,
     FAILED_EVENT,
+    URL_REDIRECTED_EVENT,
     UpdateOnboardingProgressUseCase,
 )
 
@@ -25,6 +26,10 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
             current_step="CRAWL",
         )
         self.onboarding_uuid = str(self.onboarding.uuid)
+        self.connect_service = MagicMock()
+        self.use_case = UpdateOnboardingProgressUseCase(
+            connect_service=self.connect_service
+        )
 
     # ── Progress handling ──────────────────────────────────────────
 
@@ -37,7 +42,7 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
             progress=35,
         )
 
-        result = UpdateOnboardingProgressUseCase.execute(self.onboarding_uuid, dto)
+        result = self.use_case.execute(self.onboarding_uuid, dto)
 
         self.assertEqual(result.progress, 35)
 
@@ -54,7 +59,7 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
             progress=49,
         )
 
-        result = UpdateOnboardingProgressUseCase.execute(self.onboarding_uuid, dto)
+        result = self.use_case.execute(self.onboarding_uuid, dto)
 
         self.assertEqual(result.progress, 50)
 
@@ -70,7 +75,7 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
             progress=60,
         )
 
-        result = UpdateOnboardingProgressUseCase.execute(self.onboarding_uuid, dto)
+        result = self.use_case.execute(self.onboarding_uuid, dto)
 
         self.assertEqual(result.progress, 60)
 
@@ -96,7 +101,7 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
             data={"contents": contents},
         )
 
-        result = UpdateOnboardingProgressUseCase.execute(self.onboarding_uuid, dto)
+        result = self.use_case.execute(self.onboarding_uuid, dto)
 
         self.assertEqual(result.progress, 100)
         self.assertEqual(result.crawler_result, ProjectOnboarding.SUCCESS)
@@ -118,7 +123,7 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
             data={"contents": []},
         )
 
-        result = UpdateOnboardingProgressUseCase.execute(self.onboarding_uuid, dto)
+        result = self.use_case.execute(self.onboarding_uuid, dto)
 
         self.assertEqual(result.progress, 100)
         self.assertEqual(result.crawler_result, ProjectOnboarding.SUCCESS)
@@ -136,9 +141,105 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
             data={"error": "Connection timeout"},
         )
 
-        result = UpdateOnboardingProgressUseCase.execute(self.onboarding_uuid, dto)
+        result = self.use_case.execute(self.onboarding_uuid, dto)
 
         self.assertEqual(result.crawler_result, ProjectOnboarding.FAIL)
+
+    # ── URL redirected event ───────────────────────────────────────
+
+    def test_url_redirected_persists_resolved_url_and_notifies_connect(self):
+        dto = CrawlerWebhookDTO(
+            task_id="task-1",
+            event=URL_REDIRECTED_EVENT,
+            timestamp="2026-01-01T00:00:00Z",
+            url="https://mystore.com/",
+            data={
+                "original_url": "https://mystore.com/",
+                "resolved_url": "https://www.mystore.com/",
+            },
+        )
+
+        result = self.use_case.execute(self.onboarding_uuid, dto)
+
+        self.assertEqual(
+            result.config.get("vtex_host_store"), "https://www.mystore.com/"
+        )
+        self.connect_service.update_project_config.assert_called_once_with(
+            project_uuid=str(self.project.uuid),
+            config={"vtex_host_store": "https://www.mystore.com/"},
+        )
+
+    def test_url_redirected_preserves_existing_config(self):
+        self.onboarding.config = {"channels": {"wwc": {"channel_data": {"x": 1}}}}
+        self.onboarding.save()
+
+        dto = CrawlerWebhookDTO(
+            task_id="task-1",
+            event=URL_REDIRECTED_EVENT,
+            timestamp="2026-01-01T00:00:00Z",
+            url="https://mystore.com/",
+            data={
+                "original_url": "https://mystore.com/",
+                "resolved_url": "https://www.mystore.com/",
+            },
+        )
+
+        result = self.use_case.execute(self.onboarding_uuid, dto)
+
+        self.assertEqual(result.config["vtex_host_store"], "https://www.mystore.com/")
+        self.assertEqual(result.config["channels"]["wwc"]["channel_data"], {"x": 1})
+
+    def test_url_redirected_skips_when_resolved_url_missing(self):
+        dto = CrawlerWebhookDTO(
+            task_id="task-1",
+            event=URL_REDIRECTED_EVENT,
+            timestamp="2026-01-01T00:00:00Z",
+            url="https://mystore.com/",
+            data={"original_url": "https://mystore.com/"},
+        )
+
+        result = self.use_case.execute(self.onboarding_uuid, dto)
+
+        self.assertNotIn("vtex_host_store", result.config or {})
+        self.connect_service.update_project_config.assert_not_called()
+
+    def test_url_redirected_skips_connect_when_no_project_linked(self):
+        self.onboarding.project = None
+        self.onboarding.save()
+
+        dto = CrawlerWebhookDTO(
+            task_id="task-1",
+            event=URL_REDIRECTED_EVENT,
+            timestamp="2026-01-01T00:00:00Z",
+            url="https://mystore.com/",
+            data={
+                "original_url": "https://mystore.com/",
+                "resolved_url": "https://www.mystore.com/",
+            },
+        )
+
+        result = self.use_case.execute(self.onboarding_uuid, dto)
+
+        self.assertEqual(result.config["vtex_host_store"], "https://www.mystore.com/")
+        self.connect_service.update_project_config.assert_not_called()
+
+    def test_url_redirected_swallows_connect_failure(self):
+        self.connect_service.update_project_config.side_effect = RuntimeError("boom")
+
+        dto = CrawlerWebhookDTO(
+            task_id="task-1",
+            event=URL_REDIRECTED_EVENT,
+            timestamp="2026-01-01T00:00:00Z",
+            url="https://mystore.com/",
+            data={
+                "original_url": "https://mystore.com/",
+                "resolved_url": "https://www.mystore.com/",
+            },
+        )
+
+        result = self.use_case.execute(self.onboarding_uuid, dto)
+
+        self.assertEqual(result.config["vtex_host_store"], "https://www.mystore.com/")
 
     # ── Edge cases ─────────────────────────────────────────────────
 
@@ -152,4 +253,4 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
         )
 
         with self.assertRaises(ProjectOnboarding.DoesNotExist):
-            UpdateOnboardingProgressUseCase.execute(str(uuid4()), dto)
+            self.use_case.execute(str(uuid4()), dto)

--- a/retail/projects/usecases/update_onboarding_progress.py
+++ b/retail/projects/usecases/update_onboarding_progress.py
@@ -1,14 +1,17 @@
 import logging
+from typing import Optional
 
 from retail.projects.models import ProjectOnboarding
 from retail.projects.tasks import acquire_task_lock, task_configure_nexus
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_dto import CrawlerWebhookDTO
+from retail.services.connect.service import ConnectService
 
 logger = logging.getLogger(__name__)
 
 COMPLETED_EVENT = "crawl.completed"
 FAILED_EVENT = "crawl.failed"
+URL_REDIRECTED_EVENT = "crawl.url_redirected"
 
 
 class UpdateOnboardingProgressUseCase:
@@ -19,8 +22,12 @@ class UpdateOnboardingProgressUseCase:
     the orchestrator (execute) focused on routing only.
     """
 
-    @staticmethod
-    def execute(onboarding_uuid: str, dto: CrawlerWebhookDTO) -> ProjectOnboarding:
+    def __init__(self, connect_service: Optional[ConnectService] = None):
+        self.connect_service = connect_service or ConnectService()
+
+    def execute(
+        self, onboarding_uuid: str, dto: CrawlerWebhookDTO
+    ) -> ProjectOnboarding:
         """
         Routes the crawler webhook event to the appropriate handler.
 
@@ -34,17 +41,20 @@ class UpdateOnboardingProgressUseCase:
         Raises:
             ProjectOnboarding.DoesNotExist: If no onboarding record is found.
         """
-        onboarding = ProjectOnboarding.objects.get(
+        onboarding = ProjectOnboarding.objects.select_related("project").get(
             uuid=onboarding_uuid,
         )
 
         if dto.event == COMPLETED_EVENT:
-            return UpdateOnboardingProgressUseCase._handle_completed(onboarding, dto)
+            return self._handle_completed(onboarding, dto)
 
         if dto.event == FAILED_EVENT:
-            return UpdateOnboardingProgressUseCase._handle_failed(onboarding, dto)
+            return self._handle_failed(onboarding, dto)
 
-        return UpdateOnboardingProgressUseCase._handle_progress(onboarding, dto)
+        if dto.event == URL_REDIRECTED_EVENT:
+            return self._handle_url_redirected(onboarding, dto)
+
+        return self._handle_progress(onboarding, dto)
 
     @staticmethod
     def _handle_completed(
@@ -84,6 +94,60 @@ class UpdateOnboardingProgressUseCase:
         error_msg = dto.data.get("error", "Unknown error")
         mark_onboarding_failed(onboarding.vtex_account, f"Crawler failed: {error_msg}")
         return onboarding
+
+    def _handle_url_redirected(
+        self, onboarding: ProjectOnboarding, dto: CrawlerWebhookDTO
+    ) -> ProjectOnboarding:
+        """
+        Persists the resolved store URL locally and propagates it to Connect.
+
+        Triggered when the original URL failed but a variant (e.g. with `www.`)
+        succeeded. The resolved URL becomes the canonical store URL going forward.
+        """
+        resolved_url = dto.data.get("resolved_url")
+        original_url = dto.data.get("original_url")
+
+        if not resolved_url:
+            logger.warning(
+                f"[url_redirected] Missing resolved_url in webhook payload for "
+                f"onboarding={onboarding.uuid}. Skipping update."
+            )
+            return onboarding
+
+        config = onboarding.config or {}
+        config["vtex_host_store"] = resolved_url
+        onboarding.config = config
+        onboarding.save(update_fields=["config"])
+
+        logger.info(
+            f"[url_redirected] Updated store URL for onboarding={onboarding.uuid}: "
+            f"original={original_url} -> resolved={resolved_url}"
+        )
+
+        self._send_vtex_host_store_to_connect(onboarding, resolved_url)
+        return onboarding
+
+    def _send_vtex_host_store_to_connect(
+        self, onboarding: ProjectOnboarding, resolved_url: str
+    ) -> None:
+        """Propagates the resolved store URL to Connect. Non-blocking by design."""
+        if onboarding.project is None:
+            logger.warning(
+                f"[url_redirected] Onboarding={onboarding.uuid} has no linked project. "
+                f"Skipping Connect update."
+            )
+            return
+
+        try:
+            self.connect_service.update_project_config(
+                project_uuid=str(onboarding.project.uuid),
+                config={"vtex_host_store": resolved_url},
+            )
+        except Exception:
+            logger.exception(
+                f"[url_redirected] Failed to propagate vtex_host_store to Connect "
+                f"for project={onboarding.project.uuid}"
+            )
 
     @staticmethod
     def _handle_progress(

--- a/retail/projects/views.py
+++ b/retail/projects/views.py
@@ -165,7 +165,7 @@ class CrawlerWebhookView(APIView):
         dto = CrawlerWebhookDTO(**serializer.validated_data)
 
         try:
-            onboarding = UpdateOnboardingProgressUseCase.execute(
+            onboarding = UpdateOnboardingProgressUseCase().execute(
                 str(onboarding_uuid), dto
             )
         except ProjectOnboarding.DoesNotExist:


### PR DESCRIPTION
## What
Adds a handler for the new `crawl.url_redirected` webhook event emitted by the Crawler MS when the original store URL fails but a variant (e.g. with `www.`) succeeds. The resolved URL is persisted in `ProjectOnboarding.config.vtex_host_store` and propagated to Connect via `ConnectService.update_project_config`. Also refactors `UpdateOnboardingProgressUseCase` from a static-method class into an instance-based one to support dependency injection of `ConnectService`.

## Why
When the crawler resolves to a different URL than the one originally provided, both Retail and Connect need to be kept in sync on the canonical store URL (`vtex_host_store`). Without this, downstream services using the Connect project config would keep referencing the broken URL, and any later crawler restart would fail again on the original URL.