### PR TITLE
fix: Preserve payment_recovery config when creating VTEX hook

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -417,6 +417,7 @@ class AssignAgentUseCase:
         logger.info(f"[AssignAgent] integrated_agent created={integrated_agent.uuid}")
 
         self._create_credentials(integrated_agent, agent, credentials)
+
         self._create_templates(
             integrated_agent, templates, project_uuid, app_uuid, ignore_templates
         )
@@ -729,10 +730,14 @@ class AssignAgentUseCase:
             )
 
             current_config = integrated_agent.config.copy()
-            current_config["payment_recovery"] = {
-                "webhook_url": webhook_url,
-                "hook_created": True,
-            }
+            payment_recovery_config = current_config.get("payment_recovery", {})
+            payment_recovery_config.update(
+                {
+                    "webhook_url": webhook_url,
+                    "hook_created": True,
+                }
+            )
+            current_config["payment_recovery"] = payment_recovery_config
             integrated_agent.config = current_config
             integrated_agent.save(update_fields=["config"])
 

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -231,6 +231,31 @@ class AssignPaymentRecoveryHookTest(TestCase):
     @patch("retail.agents.domains.agent_integration.usecases.assign.ProxyVtexUsecase")
     @patch("retail.agents.domains.agent_integration.usecases.assign.VtexIOService")
     @override_settings(DOMAIN="https://retail.example.com")
+    def test_create_payment_recovery_hook_preserves_existing_config(
+        self, mock_vtex_service_cls, mock_proxy_cls
+    ):
+        mock_proxy = MagicMock()
+        mock_proxy_cls.return_value = mock_proxy
+
+        self.integrated_agent.config = {
+            "payment_recovery": {
+                "hook_created": False,
+                "delay_minutes": 10,
+            },
+            "country_phone_code": "55",
+        }
+
+        self.use_case._create_payment_recovery_hook(self.integrated_agent)
+
+        saved_config = self.integrated_agent.config
+        self.assertEqual(saved_config["payment_recovery"]["delay_minutes"], 10)
+        self.assertTrue(saved_config["payment_recovery"]["hook_created"])
+        self.assertIn("webhook_url", saved_config["payment_recovery"])
+        self.assertEqual(saved_config["country_phone_code"], "55")
+
+    @patch("retail.agents.domains.agent_integration.usecases.assign.ProxyVtexUsecase")
+    @patch("retail.agents.domains.agent_integration.usecases.assign.VtexIOService")
+    @override_settings(DOMAIN="https://retail.example.com")
     def test_create_payment_recovery_hook_proxy_failure_does_not_raise(
         self, mock_vtex_service_cls, mock_proxy_cls
     ):


### PR DESCRIPTION
## What
Fixes config merge in `_create_payment_recovery_hook` to preserve existing 
fields (like `delay_minutes`) instead of overwriting the entire 
`payment_recovery` dictionary.

## Why
When the VTEX hook was created, `_create_payment_recovery_hook` replaced 
the entire `payment_recovery` config with only `webhook_url` and `hook_created`, 
causing `delay_minutes` (set during `_build_initial_config`) to be lost. 
This made `PaymentRecoveryWebhookUseCase.get_delay_seconds` always fall back 
to the default value instead of using the configured one.