### PR TITLE
fix: Prevent customer templates from shadowing defaults

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -1,7 +1,7 @@
 import logging
 from urllib.parse import urlparse
 
-from typing import List, TypedDict, Mapping, Any, Optional
+from typing import Dict, List, TypedDict, Mapping, Any, Optional
 
 from uuid import UUID
 
@@ -56,6 +56,16 @@ class IntegrationsButtonUrlFormat(TypedDict):
 class IntegrationsButtonFormat(TypedDict):
     type: str
     url: IntegrationsButtonUrlFormat
+
+
+# Settings key -> display_name for agents that manage their own default
+# custom template. Single source of truth used by both the template creation
+# flows and the reserved-names check that prevents customer templates with
+# the same name from shadowing our `weni_<name>_<timestamp>` template.
+AGENT_DEFAULT_TEMPLATE_DISPLAY_NAMES: Dict[str, str] = {
+    "ABANDONED_CART_AGENT_UUID": "Abandoned Cart",
+    "PAYMENT_RECOVERY_AGENT_UUID": "Payment Recovery",
+}
 
 
 class AssignAgentUseCase:
@@ -324,6 +334,20 @@ class AssignAgentUseCase:
                 version.status = "APPROVED"
                 version.save()
 
+    def _get_reserved_display_names(self, agent: Agent) -> List[str]:
+        """
+        Return the display names reserved by this agent's default custom template.
+
+        These names must not be adopted from the customer's WABA by
+        `_create_invalid_templates` — adoption would shadow our
+        `weni_<name>_<timestamp>` template at broadcast time.
+        """
+        reserved: List[str] = []
+        for setting_name, display_name in AGENT_DEFAULT_TEMPLATE_DISPLAY_NAMES.items():
+            if str(agent.uuid) == getattr(settings, setting_name, ""):
+                reserved.append(display_name)
+        return reserved
+
     def _create_templates(
         self,
         integrated_agent: IntegratedAgent,
@@ -340,8 +364,33 @@ class AssignAgentUseCase:
           (or flag for button edit when buttons are present).
         - Invalid pre-approved: fetch user's approved translations and adapt them,
           creating an approved version directly.
+
+        Pre-approved templates whose display_name collides with a default custom
+        template managed by the agent are skipped to avoid shadowing the
+        `weni_<name>_<timestamp>` template we will create later.
         """
         pre_approveds = pre_approveds.exclude(uuid__in=ignore_templates)
+
+        reserved_display_names = self._get_reserved_display_names(
+            integrated_agent.agent
+        )
+        if reserved_display_names:
+            skipped = list(
+                pre_approveds.filter(
+                    display_name__in=reserved_display_names
+                ).values_list("name", flat=True)
+            )
+            if skipped:
+                logger.info(
+                    f"[AssignAgent] Skipping pre-approved templates reserved by "
+                    f"default custom template flow - "
+                    f"agent={integrated_agent.agent.uuid} "
+                    f"reserved={reserved_display_names} skipped={skipped}"
+                )
+                pre_approveds = pre_approveds.exclude(
+                    display_name__in=reserved_display_names
+                )
+
         valid_pre_approveds = pre_approveds.filter(is_valid=True)
         invalid_pre_approveds = pre_approveds.filter(is_valid=False)
 
@@ -534,7 +583,9 @@ class AssignAgentUseCase:
                 "category": "MARKETING",
                 "app_uuid": str(app_uuid),
                 "project_uuid": str(project_uuid),
-                "display_name": "Abandoned Cart",
+                "display_name": AGENT_DEFAULT_TEMPLATE_DISPLAY_NAMES[
+                    "ABANDONED_CART_AGENT_UUID"
+                ],
                 # NOTE: start_condition is derived from parameters by TemplateMetadataHandler
                 "start_condition": "If cart_link is not empty",
                 "parameters": [
@@ -647,7 +698,9 @@ class AssignAgentUseCase:
                 "category": "MARKETING",
                 "app_uuid": str(app_uuid),
                 "project_uuid": str(project_uuid),
-                "display_name": "Payment Recovery",
+                "display_name": AGENT_DEFAULT_TEMPLATE_DISPLAY_NAMES[
+                    "PAYMENT_RECOVERY_AGENT_UUID"
+                ],
                 "start_condition": "If payment_status is pending",
                 "parameters": [
                     {

--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -235,15 +235,22 @@ class AssignAgentUseCase:
                 },
             )
 
-    def _create_valid_templates(
+    def _create_library_templates(
         self,
         integrated_agent: IntegratedAgent,
-        valid_pre_approveds: List[PreApprovedTemplate],
+        library_pre_approveds: List[PreApprovedTemplate],
         project_uuid: UUID,
         app_uuid: UUID,
     ) -> None:
+        """
+        Instantiate pre-approveds that are available in Meta's Library catalog.
+
+        For each spec, create a local Template+Version and (unless the template
+        has a URL button requiring manual customization) trigger submission to
+        Meta via `CreateLibraryTemplateUseCase.notify_integrations`.
+        """
         create_library_use_case = CreateLibraryTemplateUseCase()
-        for pre_approved in valid_pre_approveds:
+        for pre_approved in library_pre_approveds:
             metadata = pre_approved.metadata or {}
             # TODO: Currently uses metadata.language from validation (fixed pt_BR).
             # To support dynamic language per project, use:
@@ -282,15 +289,24 @@ class AssignAgentUseCase:
             integrated_agent.ignore_templates.append(template.parent.slug)
             integrated_agent.save(update_fields=["ignore_templates"])
 
-    def _create_invalid_templates(
+    def _adopt_customer_templates(
         self,
         integrated_agent: IntegratedAgent,
-        invalid_pre_approveds: List[PreApprovedTemplate],
+        customer_sourced_pre_approveds: List[PreApprovedTemplate],
         project_uuid: UUID,
         app_uuid: UUID,
     ) -> None:
+        """
+        Adopt pre-approveds whose source is the customer's WABA.
+
+        No template is submitted to Meta here — we fetch the customer's
+        approved translations via `integrations_service.fetch_templates_from_user`
+        and register a local Template+Version pointing at the existing Meta
+        template. Specs without a matching customer translation are skipped
+        silently (nothing to adopt yet).
+        """
         logger.info(
-            "Fetching user templates in integrations service (non-pre-approved)..."
+            "Fetching customer-approved translations for customer-sourced pre-approveds..."
         )
 
         template_builder = TemplateBuilderMixin()
@@ -302,15 +318,15 @@ class AssignAgentUseCase:
         translations_by_name = self.integrations_service.fetch_templates_from_user(
             app_uuid,
             str(project_uuid),
-            [pre_approved.name for pre_approved in invalid_pre_approveds],
+            [pre_approved.name for pre_approved in customer_sourced_pre_approveds],
             language,
         )
 
         logger.info(
-            f"Found {len(translations_by_name)} templates in integrations service (non-pre-approved)"
+            f"Found {len(translations_by_name)} customer-approved translations to adopt"
         )
 
-        for pre_approved in invalid_pre_approveds:
+        for pre_approved in customer_sourced_pre_approveds:
             translation = translations_by_name.get(pre_approved.name)
             if translation is not None:
                 template, version = template_builder.build_template_and_version(
@@ -339,7 +355,7 @@ class AssignAgentUseCase:
         Return the display names reserved by this agent's default custom template.
 
         These names must not be adopted from the customer's WABA by
-        `_create_invalid_templates` — adoption would shadow our
+        `_adopt_customer_templates` — adoption would shadow our
         `weni_<name>_<timestamp>` template at broadcast time.
         """
         reserved: List[str] = []
@@ -359,14 +375,16 @@ class AssignAgentUseCase:
         """
         Create templates for the integrated agent based on PreApprovedTemplate.
 
-        Responsibilities:
-        - Valid pre-approved: create library templates and notify integrations
-          (or flag for button edit when buttons are present).
-        - Invalid pre-approved: fetch user's approved translations and adapt them,
-          creating an approved version directly.
+        Each spec is routed by its source:
+        - Library-sourced (`is_valid=True`): instantiate via Meta Library
+          catalog and submit to Meta (unless a URL button requires manual
+          customization first).
+        - Customer-sourced (`is_valid=False`): reuse a translation the
+          customer already has approved in their WABA, without submitting to
+          Meta. Specs without a matching customer translation are ignored.
 
-        Pre-approved templates whose display_name collides with a default custom
-        template managed by the agent are skipped to avoid shadowing the
+        Pre-approveds whose display_name is reserved by the agent's default
+        custom template flow are dropped upfront to avoid shadowing the
         `weni_<name>_<timestamp>` template we will create later.
         """
         pre_approveds = pre_approveds.exclude(uuid__in=ignore_templates)
@@ -391,18 +409,18 @@ class AssignAgentUseCase:
                     display_name__in=reserved_display_names
                 )
 
-        valid_pre_approveds = pre_approveds.filter(is_valid=True)
-        invalid_pre_approveds = pre_approveds.filter(is_valid=False)
+        library_pre_approveds = pre_approveds.filter(is_valid=True)
+        customer_sourced_pre_approveds = pre_approveds.filter(is_valid=False)
 
-        self._create_valid_templates(
+        self._create_library_templates(
             integrated_agent,
-            valid_pre_approveds,
+            library_pre_approveds,
             project_uuid,
             app_uuid,
         )
-        self._create_invalid_templates(
+        self._adopt_customer_templates(
             integrated_agent,
-            invalid_pre_approveds,
+            customer_sourced_pre_approveds,
             project_uuid,
             app_uuid,
         )

--- a/retail/agents/tests/usecases/test_assign_agent.py
+++ b/retail/agents/tests/usecases/test_assign_agent.py
@@ -594,7 +594,7 @@ class AssignAgentUseCaseTest(TestCase):
     @patch(
         "retail.agents.domains.agent_integration.usecases.assign.TemplateBuilderMixin"
     )
-    def test_create_invalid_templates_success(self, mock_template_builder):
+    def test_adopt_customer_templates_success(self, mock_template_builder):
         integrated_agent = IntegratedAgent.objects.create(
             agent=self.agent,
             project=self.project,
@@ -602,20 +602,20 @@ class AssignAgentUseCaseTest(TestCase):
             is_active=True,
         )
 
-        invalid_template1 = MagicMock()
-        invalid_template1.name = "template_invalid_1"
-        invalid_template1.start_condition = "start_condition_1"
-        invalid_template1.display_name = "Template Inválido 1"
+        pre_approved_1 = MagicMock()
+        pre_approved_1.name = "pre_approved_1"
+        pre_approved_1.start_condition = "start_condition_1"
+        pre_approved_1.display_name = "Pre-approved 1"
 
-        invalid_template2 = MagicMock()
-        invalid_template2.name = "template_invalid_2"
-        invalid_template2.start_condition = "start_condition_2"
-        invalid_template2.display_name = "Template Inválido 2"
+        pre_approved_2 = MagicMock()
+        pre_approved_2.name = "pre_approved_2"
+        pre_approved_2.start_condition = "start_condition_2"
+        pre_approved_2.display_name = "Pre-approved 2"
 
-        invalid_pre_approveds = [invalid_template1, invalid_template2]
+        customer_sourced_pre_approveds = [pre_approved_1, pre_approved_2]
 
         mock_translations = {
-            "template_invalid_1": {
+            "pre_approved_1": {
                 "header": "Header 1",
                 "body": "Body 1",
                 "footer": "Footer 1",
@@ -638,14 +638,14 @@ class AssignAgentUseCaseTest(TestCase):
         project_uuid = self.project.uuid
         app_uuid = uuid.uuid4()
 
-        self.use_case._create_invalid_templates(
-            integrated_agent, invalid_pre_approveds, project_uuid, app_uuid
+        self.use_case._adopt_customer_templates(
+            integrated_agent, customer_sourced_pre_approveds, project_uuid, app_uuid
         )
 
         self.use_case.integrations_service.fetch_templates_from_user.assert_called_once_with(
             app_uuid,
             str(project_uuid),
-            ["template_invalid_1", "template_invalid_2"],
+            ["pre_approved_1", "pre_approved_2"],
             self.agent.language,
         )
 
@@ -654,7 +654,7 @@ class AssignAgentUseCaseTest(TestCase):
     @patch(
         "retail.agents.domains.agent_integration.usecases.assign.TemplateBuilderMixin"
     )
-    def test_create_invalid_templates_no_translations_found(
+    def test_adopt_customer_templates_no_translations_found(
         self, mock_template_builder
     ):
         integrated_agent = IntegratedAgent.objects.create(
@@ -664,9 +664,9 @@ class AssignAgentUseCaseTest(TestCase):
             is_active=True,
         )
 
-        invalid_template = MagicMock()
-        invalid_template.name = "template_not_found"
-        invalid_pre_approveds = [invalid_template]
+        pre_approved = MagicMock()
+        pre_approved.name = "template_not_found"
+        customer_sourced_pre_approveds = [pre_approved]
 
         self.use_case.integrations_service.fetch_templates_from_user = MagicMock(
             return_value={}
@@ -675,8 +675,8 @@ class AssignAgentUseCaseTest(TestCase):
         project_uuid = self.project.uuid
         app_uuid = uuid.uuid4()
 
-        self.use_case._create_invalid_templates(
-            integrated_agent, invalid_pre_approveds, project_uuid, app_uuid
+        self.use_case._adopt_customer_templates(
+            integrated_agent, customer_sourced_pre_approveds, project_uuid, app_uuid
         )
 
         self.use_case.integrations_service.fetch_templates_from_user.assert_called_once_with(
@@ -770,13 +770,13 @@ class AssignAgentUseCaseTest(TestCase):
             is_active=True,
         )
 
-        invalid_template = MagicMock()
-        invalid_template.name = "test_template"
+        pre_approved = MagicMock()
+        pre_approved.name = "test_template"
 
         mock_integrations_service.fetch_templates_from_user.return_value = {}
 
-        use_case_with_mock._create_invalid_templates(
-            integrated_agent, [invalid_template], self.project.uuid, uuid.uuid4()
+        use_case_with_mock._adopt_customer_templates(
+            integrated_agent, [pre_approved], self.project.uuid, uuid.uuid4()
         )
 
         mock_integrations_service.fetch_templates_from_user.assert_called_once()

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase, override_settings
 
-from retail.agents.domains.agent_management.models import Agent
+from retail.agents.domains.agent_management.models import Agent, PreApprovedTemplate
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_integration.usecases.assign import AssignAgentUseCase
 from retail.agents.domains.agent_integration.usecases.fetch_country_phone_code import (
@@ -15,6 +15,7 @@ from retail.projects.models import Project
 
 
 PAYMENT_RECOVERY_UUID = str(uuid.uuid4())
+ABANDONED_CART_UUID = str(uuid.uuid4())
 
 
 class AssignPaymentRecoveryBuildConfigTest(TestCase):
@@ -266,3 +267,189 @@ class AssignPaymentRecoveryHookTest(TestCase):
         self.use_case._create_payment_recovery_hook(self.integrated_agent)
 
         self.integrated_agent.save.assert_not_called()
+
+
+class GetReservedDisplayNamesTest(TestCase):
+    def setUp(self):
+        self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
+        self.use_case = AssignAgentUseCase(
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
+        )
+
+    @override_settings(
+        PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_UUID,
+        ABANDONED_CART_AGENT_UUID=ABANDONED_CART_UUID,
+    )
+    def test_returns_payment_recovery_for_payment_recovery_agent(self):
+        agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_UUID,
+            name="Payment Recovery",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        reserved = self.use_case._get_reserved_display_names(agent)
+        self.assertEqual(reserved, ["Payment Recovery"])
+
+    @override_settings(
+        PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_UUID,
+        ABANDONED_CART_AGENT_UUID=ABANDONED_CART_UUID,
+    )
+    def test_returns_abandoned_cart_for_abandoned_cart_agent(self):
+        agent = Agent.objects.create(
+            uuid=ABANDONED_CART_UUID,
+            name="Abandoned Cart",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        reserved = self.use_case._get_reserved_display_names(agent)
+        self.assertEqual(reserved, ["Abandoned Cart"])
+
+    @override_settings(
+        PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_UUID,
+        ABANDONED_CART_AGENT_UUID=ABANDONED_CART_UUID,
+    )
+    def test_returns_empty_list_for_unrelated_agent(self):
+        agent = Agent.objects.create(
+            name="Generic Agent",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        reserved = self.use_case._get_reserved_display_names(agent)
+        self.assertEqual(reserved, [])
+
+
+class CreateTemplatesSkipReservedDisplayNamesTest(TestCase):
+    def setUp(self):
+        self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
+        self.mock_fetch_phone_code.fetch_locale_info.return_value = VtexLocaleInfo(
+            country_phone_code="55",
+            meta_language="pt_BR",
+            vtex_locale="pt-BR",
+        )
+        self.mock_integrations_service = MagicMock()
+        self.mock_integrations_service.fetch_templates_from_user.return_value = {}
+
+        self.use_case = AssignAgentUseCase(
+            integrations_service=self.mock_integrations_service,
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
+        )
+        self.agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_UUID,
+            name="Payment Recovery",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid.uuid4(),
+            is_active=True,
+        )
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_UUID)
+    def test_pre_approved_matching_reserved_display_name_is_skipped(self):
+        """
+        When the agent owns the "Payment Recovery" display_name, any
+        PreApprovedTemplate with that display_name must be skipped to prevent
+        adoption of a customer's manually created template.
+        """
+        PreApprovedTemplate.objects.create(
+            agent=self.agent,
+            uuid=uuid.uuid4(),
+            slug="payment-recovery",
+            name="payment_recovery",
+            display_name="Payment Recovery",
+            is_valid=False,
+            start_condition="start",
+            metadata={"category": "MARKETING"},
+        )
+        app_uuid = uuid.uuid4()
+
+        self.use_case._create_templates(
+            self.integrated_agent,
+            self.agent.templates.all(),
+            self.project.uuid,
+            app_uuid,
+            [],
+        )
+
+        self.mock_integrations_service.fetch_templates_from_user.assert_called_once_with(
+            app_uuid,
+            str(self.project.uuid),
+            [],
+            self.agent.language,
+        )
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_UUID)
+    def test_pre_approved_with_other_display_name_is_still_processed(self):
+        """Non-reserved pre-approved templates must continue to be processed."""
+        PreApprovedTemplate.objects.create(
+            agent=self.agent,
+            uuid=uuid.uuid4(),
+            slug="order-update",
+            name="order_update",
+            display_name="Order Update",
+            is_valid=False,
+            start_condition="start",
+            metadata={"category": "UTILITY"},
+        )
+        app_uuid = uuid.uuid4()
+
+        self.use_case._create_templates(
+            self.integrated_agent,
+            self.agent.templates.all(),
+            self.project.uuid,
+            app_uuid,
+            [],
+        )
+
+        self.mock_integrations_service.fetch_templates_from_user.assert_called_once_with(
+            app_uuid,
+            str(self.project.uuid),
+            ["order_update"],
+            self.agent.language,
+        )
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID="")
+    def test_reserved_filter_inactive_when_agent_uuid_not_configured(self):
+        """
+        When the agent setting is unset the reserved filter must not drop
+        pre-approved templates — otherwise customer integrations without the
+        env var configured would silently lose adoption behaviour.
+        """
+        PreApprovedTemplate.objects.create(
+            agent=self.agent,
+            uuid=uuid.uuid4(),
+            slug="payment-recovery",
+            name="payment_recovery",
+            display_name="Payment Recovery",
+            is_valid=False,
+            start_condition="start",
+            metadata={"category": "MARKETING"},
+        )
+        app_uuid = uuid.uuid4()
+
+        self.use_case._create_templates(
+            self.integrated_agent,
+            self.agent.templates.all(),
+            self.project.uuid,
+            app_uuid,
+            [],
+        )
+
+        self.mock_integrations_service.fetch_templates_from_user.assert_called_once_with(
+            app_uuid,
+            str(self.project.uuid),
+            ["payment_recovery"],
+            self.agent.language,
+        )


### PR DESCRIPTION
## What
- Adds a single source of truth (`AGENT_DEFAULT_TEMPLATE_DISPLAY_NAMES`) mapping each Django settings key (`ABANDONED_CART_AGENT_UUID`, `PAYMENT_RECOVERY_AGENT_UUID`) to the display_name of the default custom template the agent creates.
- Introduces `_get_reserved_display_names(agent)` and plugs it into `_create_templates` so `PreApprovedTemplate` specs whose `display_name` is reserved by the agent are skipped before reaching `_create_invalid_templates`.
- Uses the new dict in `_create_default_abandoned_cart_template` and `_create_default_payment_recovery_template` so the display_name the agent submits and the reserved-names check can never drift apart.
- Tests covering the registry, the reserved-name lookup, the skip behavior in `_create_templates`, and the safeguard when the feature-flag env var is unset.

## Why
The Flows Broadcast API was sending `msg.template.name = "payment_recovery"` for a tenant that had an `approved` template named `payment_recovery` manually created in their Meta WABA. Our agent was supposed to broadcast via `weni_payment_recovery_<timestamp>`.

Root cause: `_create_invalid_templates` adopts any customer-approved translation whose name matches a `PreApprovedTemplate`. When the slug coincided with the display_name of our default custom template (e.g. "Payment Recovery"), the adopted `Template` was created first with `Version.template_name = "payment_recovery"`; the subsequent `_create_default_payment_recovery_template` then collided on `display_name` and was silenced by `CustomTemplateAlreadyExists`. At broadcast time, Meta resolved the raw slug to the customer's manual template.

This change guarantees that agents that own a default template keep ownership of its display_name, so our `weni_<name>_<timestamp>` template is never shadowed.