### PR TITLE
refactor: Clarify pre-approved template source naming

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -235,15 +235,22 @@ class AssignAgentUseCase:
                 },
             )
 
-    def _create_valid_templates(
+    def _create_library_templates(
         self,
         integrated_agent: IntegratedAgent,
-        valid_pre_approveds: List[PreApprovedTemplate],
+        library_pre_approveds: List[PreApprovedTemplate],
         project_uuid: UUID,
         app_uuid: UUID,
     ) -> None:
+        """
+        Instantiate pre-approveds that are available in Meta's Library catalog.
+
+        For each spec, create a local Template+Version and (unless the template
+        has a URL button requiring manual customization) trigger submission to
+        Meta via `CreateLibraryTemplateUseCase.notify_integrations`.
+        """
         create_library_use_case = CreateLibraryTemplateUseCase()
-        for pre_approved in valid_pre_approveds:
+        for pre_approved in library_pre_approveds:
             metadata = pre_approved.metadata or {}
             # TODO: Currently uses metadata.language from validation (fixed pt_BR).
             # To support dynamic language per project, use:
@@ -282,15 +289,24 @@ class AssignAgentUseCase:
             integrated_agent.ignore_templates.append(template.parent.slug)
             integrated_agent.save(update_fields=["ignore_templates"])
 
-    def _create_invalid_templates(
+    def _adopt_customer_templates(
         self,
         integrated_agent: IntegratedAgent,
-        invalid_pre_approveds: List[PreApprovedTemplate],
+        customer_sourced_pre_approveds: List[PreApprovedTemplate],
         project_uuid: UUID,
         app_uuid: UUID,
     ) -> None:
+        """
+        Adopt pre-approveds whose source is the customer's WABA.
+
+        No template is submitted to Meta here — we fetch the customer's
+        approved translations via `integrations_service.fetch_templates_from_user`
+        and register a local Template+Version pointing at the existing Meta
+        template. Specs without a matching customer translation are skipped
+        silently (nothing to adopt yet).
+        """
         logger.info(
-            "Fetching user templates in integrations service (non-pre-approved)..."
+            "Fetching customer-approved translations for customer-sourced pre-approveds..."
         )
 
         template_builder = TemplateBuilderMixin()
@@ -302,15 +318,15 @@ class AssignAgentUseCase:
         translations_by_name = self.integrations_service.fetch_templates_from_user(
             app_uuid,
             str(project_uuid),
-            [pre_approved.name for pre_approved in invalid_pre_approveds],
+            [pre_approved.name for pre_approved in customer_sourced_pre_approveds],
             language,
         )
 
         logger.info(
-            f"Found {len(translations_by_name)} templates in integrations service (non-pre-approved)"
+            f"Found {len(translations_by_name)} customer-approved translations to adopt"
         )
 
-        for pre_approved in invalid_pre_approveds:
+        for pre_approved in customer_sourced_pre_approveds:
             translation = translations_by_name.get(pre_approved.name)
             if translation is not None:
                 template, version = template_builder.build_template_and_version(
@@ -339,7 +355,7 @@ class AssignAgentUseCase:
         Return the display names reserved by this agent's default custom template.
 
         These names must not be adopted from the customer's WABA by
-        `_create_invalid_templates` — adoption would shadow our
+        `_adopt_customer_templates` — adoption would shadow our
         `weni_<name>_<timestamp>` template at broadcast time.
         """
         reserved: List[str] = []
@@ -359,14 +375,16 @@ class AssignAgentUseCase:
         """
         Create templates for the integrated agent based on PreApprovedTemplate.
 
-        Responsibilities:
-        - Valid pre-approved: create library templates and notify integrations
-          (or flag for button edit when buttons are present).
-        - Invalid pre-approved: fetch user's approved translations and adapt them,
-          creating an approved version directly.
+        Each spec is routed by its source:
+        - Library-sourced (`is_valid=True`): instantiate via Meta Library
+          catalog and submit to Meta (unless a URL button requires manual
+          customization first).
+        - Customer-sourced (`is_valid=False`): reuse a translation the
+          customer already has approved in their WABA, without submitting to
+          Meta. Specs without a matching customer translation are ignored.
 
-        Pre-approved templates whose display_name collides with a default custom
-        template managed by the agent are skipped to avoid shadowing the
+        Pre-approveds whose display_name is reserved by the agent's default
+        custom template flow are dropped upfront to avoid shadowing the
         `weni_<name>_<timestamp>` template we will create later.
         """
         pre_approveds = pre_approveds.exclude(uuid__in=ignore_templates)
@@ -391,18 +409,18 @@ class AssignAgentUseCase:
                     display_name__in=reserved_display_names
                 )
 
-        valid_pre_approveds = pre_approveds.filter(is_valid=True)
-        invalid_pre_approveds = pre_approveds.filter(is_valid=False)
+        library_pre_approveds = pre_approveds.filter(is_valid=True)
+        customer_sourced_pre_approveds = pre_approveds.filter(is_valid=False)
 
-        self._create_valid_templates(
+        self._create_library_templates(
             integrated_agent,
-            valid_pre_approveds,
+            library_pre_approveds,
             project_uuid,
             app_uuid,
         )
-        self._create_invalid_templates(
+        self._adopt_customer_templates(
             integrated_agent,
-            invalid_pre_approveds,
+            customer_sourced_pre_approveds,
             project_uuid,
             app_uuid,
         )

--- a/retail/agents/tests/usecases/test_assign_agent.py
+++ b/retail/agents/tests/usecases/test_assign_agent.py
@@ -594,7 +594,7 @@ class AssignAgentUseCaseTest(TestCase):
     @patch(
         "retail.agents.domains.agent_integration.usecases.assign.TemplateBuilderMixin"
     )
-    def test_create_invalid_templates_success(self, mock_template_builder):
+    def test_adopt_customer_templates_success(self, mock_template_builder):
         integrated_agent = IntegratedAgent.objects.create(
             agent=self.agent,
             project=self.project,
@@ -602,20 +602,20 @@ class AssignAgentUseCaseTest(TestCase):
             is_active=True,
         )
 
-        invalid_template1 = MagicMock()
-        invalid_template1.name = "template_invalid_1"
-        invalid_template1.start_condition = "start_condition_1"
-        invalid_template1.display_name = "Template Inválido 1"
+        pre_approved_1 = MagicMock()
+        pre_approved_1.name = "pre_approved_1"
+        pre_approved_1.start_condition = "start_condition_1"
+        pre_approved_1.display_name = "Pre-approved 1"
 
-        invalid_template2 = MagicMock()
-        invalid_template2.name = "template_invalid_2"
-        invalid_template2.start_condition = "start_condition_2"
-        invalid_template2.display_name = "Template Inválido 2"
+        pre_approved_2 = MagicMock()
+        pre_approved_2.name = "pre_approved_2"
+        pre_approved_2.start_condition = "start_condition_2"
+        pre_approved_2.display_name = "Pre-approved 2"
 
-        invalid_pre_approveds = [invalid_template1, invalid_template2]
+        customer_sourced_pre_approveds = [pre_approved_1, pre_approved_2]
 
         mock_translations = {
-            "template_invalid_1": {
+            "pre_approved_1": {
                 "header": "Header 1",
                 "body": "Body 1",
                 "footer": "Footer 1",
@@ -638,14 +638,14 @@ class AssignAgentUseCaseTest(TestCase):
         project_uuid = self.project.uuid
         app_uuid = uuid.uuid4()
 
-        self.use_case._create_invalid_templates(
-            integrated_agent, invalid_pre_approveds, project_uuid, app_uuid
+        self.use_case._adopt_customer_templates(
+            integrated_agent, customer_sourced_pre_approveds, project_uuid, app_uuid
         )
 
         self.use_case.integrations_service.fetch_templates_from_user.assert_called_once_with(
             app_uuid,
             str(project_uuid),
-            ["template_invalid_1", "template_invalid_2"],
+            ["pre_approved_1", "pre_approved_2"],
             self.agent.language,
         )
 
@@ -654,7 +654,7 @@ class AssignAgentUseCaseTest(TestCase):
     @patch(
         "retail.agents.domains.agent_integration.usecases.assign.TemplateBuilderMixin"
     )
-    def test_create_invalid_templates_no_translations_found(
+    def test_adopt_customer_templates_no_translations_found(
         self, mock_template_builder
     ):
         integrated_agent = IntegratedAgent.objects.create(
@@ -664,9 +664,9 @@ class AssignAgentUseCaseTest(TestCase):
             is_active=True,
         )
 
-        invalid_template = MagicMock()
-        invalid_template.name = "template_not_found"
-        invalid_pre_approveds = [invalid_template]
+        pre_approved = MagicMock()
+        pre_approved.name = "template_not_found"
+        customer_sourced_pre_approveds = [pre_approved]
 
         self.use_case.integrations_service.fetch_templates_from_user = MagicMock(
             return_value={}
@@ -675,8 +675,8 @@ class AssignAgentUseCaseTest(TestCase):
         project_uuid = self.project.uuid
         app_uuid = uuid.uuid4()
 
-        self.use_case._create_invalid_templates(
-            integrated_agent, invalid_pre_approveds, project_uuid, app_uuid
+        self.use_case._adopt_customer_templates(
+            integrated_agent, customer_sourced_pre_approveds, project_uuid, app_uuid
         )
 
         self.use_case.integrations_service.fetch_templates_from_user.assert_called_once_with(
@@ -770,13 +770,13 @@ class AssignAgentUseCaseTest(TestCase):
             is_active=True,
         )
 
-        invalid_template = MagicMock()
-        invalid_template.name = "test_template"
+        pre_approved = MagicMock()
+        pre_approved.name = "test_template"
 
         mock_integrations_service.fetch_templates_from_user.return_value = {}
 
-        use_case_with_mock._create_invalid_templates(
-            integrated_agent, [invalid_template], self.project.uuid, uuid.uuid4()
+        use_case_with_mock._adopt_customer_templates(
+            integrated_agent, [pre_approved], self.project.uuid, uuid.uuid4()
         )
 
         mock_integrations_service.fetch_templates_from_user.assert_called_once()


### PR DESCRIPTION
## What
Renames in `AssignAgentUseCase` (no DB migration, pure symbol/docstring refactor):

| Before | After |
|---|---|
| `_create_valid_templates` | `_create_library_templates` |
| `_create_invalid_templates` | `_adopt_customer_templates` |
| `valid_pre_approveds` | `library_pre_approveds` |
| `invalid_pre_approveds` | `customer_sourced_pre_approveds` |

Also updates:
- Docstrings of `_create_templates`, `_create_library_templates`, `_adopt_customer_templates`, and `_get_reserved_display_names` to use the new vocabulary and explain each strategy.
- Misleading log line `"Fetching user templates in integrations service (non-pre-approved)..."` replaced with `"Fetching customer-approved translations for customer-sourced pre-approveds..."` (the old message contradicted itself — these specs *are* pre-approveds, just with a different source).
- Test method names and mock variables renamed in `test_assign_agent.py` for consistency.

## Why
The previous names mixed three unrelated axes under a single `valid/invalid` label:
- **Source of the spec** — always `PreApprovedTemplate`; the word "invalid" suggested otherwise.
- **Creation strategy** — Meta Library catalog vs. adopting a customer-approved translation.
- **Final state of the template** — irrelevant at this stage; both branches end up with an `APPROVED` version.

`is_valid=True/False` on `PreApprovedTemplate` actually encodes the **source**: whether the spec is available in Meta's Library catalog or must reuse what the customer already has approved in their WABA. The new names describe that source directly, making the routing in `_create_templates` self-explanatory.

The `is_valid` field itself is kept as-is in this PR to avoid a migration; it's a natural candidate for a follow-up rename (e.g. `available_in_meta_library`) once the refactor lands.