### PR TITLE
fix: Skip duplicate order status events

### DIFF
--- a/retail/agents/domains/agent_webhook/usecases/order_status.py
+++ b/retail/agents/domains/agent_webhook/usecases/order_status.py
@@ -141,9 +141,51 @@ class AgentOrderStatusUpdateUsecase:
             )
             return None
 
+    def _is_duplicate_event(
+        self,
+        integrated_agent: IntegratedAgent,
+        order_status_dto: OrderStatusDTO,
+    ) -> bool:
+        """
+        Check whether an identical order status event was already processed
+        within ORDER_STATUS_DUPLICATE_WINDOW_SECONDS.
+
+        An "identical event" is uniquely defined by:
+        project + integrated agent + order id + current state.
+
+        Returns:
+            True: an identical event is already registered in cache, so this
+                call should be treated as a duplicate and skipped.
+            False: the event is new within the window and has just been
+                registered; processing should continue.
+        """
+        cache_key = (
+            f"order_status_event:"
+            f"{integrated_agent.project_id}:"
+            f"{integrated_agent.uuid}:"
+            f"{order_status_dto.orderId}:"
+            f"{order_status_dto.currentState}"
+        )
+        event_registered_now = cache.add(
+            cache_key,
+            1,
+            timeout=settings.ORDER_STATUS_DUPLICATE_WINDOW_SECONDS,
+        )
+        return not event_registered_now
+
     def execute(
         self, integrated_agent: IntegratedAgent, order_status_dto: OrderStatusDTO
     ) -> None:
+        if self._is_duplicate_event(integrated_agent, order_status_dto):
+            logger.info(
+                f"Skipping duplicate order status event within dedup window. "
+                f"agent={integrated_agent.uuid} "
+                f"order_id={order_status_dto.orderId} "
+                f"current_state={order_status_dto.currentState} "
+                f"vtex_account={order_status_dto.vtexAccount}"
+            )
+            return
+
         logger.info(
             f"Starting execution for integrated agent: {integrated_agent.uuid} "
             f"and order ID: {order_status_dto.orderId}"

--- a/retail/agents/tests/usecases/test_order_status_update.py
+++ b/retail/agents/tests/usecases/test_order_status_update.py
@@ -22,6 +22,7 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
         self.mock_project.uuid = uuid4()
         self.mock_integrated_agent = MagicMock(spec=IntegratedAgent)
         self.mock_integrated_agent.uuid = uuid4()
+        self.mock_integrated_agent.project_id = 12345
         self.mock_integrated_agent.ignore_templates = False
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
@@ -249,13 +250,22 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
             vtex_account="vtex_account"
         )
 
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
     @patch(
         "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
     )
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.RequestData")
     def test_execute_calls_agent_webhook_use_case(
-        self, mock_request_data_cls, mock_agent_webhook_use_case_cls
+        self,
+        mock_request_data_cls,
+        mock_agent_webhook_use_case_cls,
+        mock_cache,
+        mock_settings,
     ):
+        mock_settings.ORDER_STATUS_DUPLICATE_WINDOW_SECONDS = 60
+        mock_cache.add.return_value = True
+
         mock_order_status_dto = MagicMock(spec=OrderStatusDTO)
         mock_order_status_dto.orderId = "order-id"
         mock_order_status_dto.domain = "test-domain"
@@ -293,6 +303,115 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
         mock_agent_webhook_use_case.execute.assert_called_once_with(
             self.mock_integrated_agent, mock_request_data
         )
+
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    def test_execute_skips_duplicate_event_within_window(
+        self, mock_agent_webhook_use_case_cls, mock_cache, mock_settings
+    ):
+        mock_settings.ORDER_STATUS_DUPLICATE_WINDOW_SECONDS = 60
+        mock_cache.add.return_value = False
+
+        mock_order_status_dto = MagicMock(spec=OrderStatusDTO)
+        mock_order_status_dto.orderId = "order-id"
+        mock_order_status_dto.currentState = "invoiced"
+        mock_order_status_dto.vtexAccount = "test-account"
+
+        mock_agent_webhook_use_case = MagicMock()
+        mock_agent_webhook_use_case_cls.return_value = mock_agent_webhook_use_case
+
+        self.usecase.execute(self.mock_integrated_agent, mock_order_status_dto)
+
+        mock_agent_webhook_use_case_cls.assert_not_called()
+        mock_agent_webhook_use_case.execute.assert_not_called()
+
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.RequestData")
+    def test_execute_uses_cache_key_with_all_required_components(
+        self,
+        mock_request_data_cls,
+        mock_agent_webhook_use_case_cls,
+        mock_cache,
+        mock_settings,
+    ):
+        mock_settings.ORDER_STATUS_DUPLICATE_WINDOW_SECONDS = 90
+        mock_cache.add.return_value = True
+
+        mock_order_status_dto = MagicMock(spec=OrderStatusDTO)
+        mock_order_status_dto.orderId = "1628250823413-01"
+        mock_order_status_dto.currentState = "order-created"
+        mock_order_status_dto.lastState = "not-started"
+        mock_order_status_dto.domain = "Marketplace"
+        mock_order_status_dto.vtexAccount = "citerol"
+
+        mock_agent_webhook_use_case_cls.return_value._addapt_credentials.return_value = (
+            {}
+        )
+
+        self.usecase.execute(self.mock_integrated_agent, mock_order_status_dto)
+
+        expected_cache_key = (
+            f"order_status_event:"
+            f"{self.mock_integrated_agent.project_id}:"
+            f"{self.mock_integrated_agent.uuid}:"
+            f"1628250823413-01:"
+            f"order-created"
+        )
+        mock_cache.add.assert_called_once_with(
+            expected_cache_key,
+            1,
+            timeout=90,
+        )
+
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.RequestData")
+    def test_execute_different_states_produce_different_cache_keys(
+        self,
+        mock_request_data_cls,
+        mock_agent_webhook_use_case_cls,
+        mock_cache,
+        mock_settings,
+    ):
+        mock_settings.ORDER_STATUS_DUPLICATE_WINDOW_SECONDS = 60
+        mock_cache.add.return_value = True
+        mock_agent_webhook_use_case_cls.return_value._addapt_credentials.return_value = (
+            {}
+        )
+
+        first_dto = MagicMock(spec=OrderStatusDTO)
+        first_dto.orderId = "order-1"
+        first_dto.currentState = "approve-payment"
+        first_dto.lastState = "payment-pending"
+        first_dto.domain = "Marketplace"
+        first_dto.vtexAccount = "test-account"
+
+        second_dto = MagicMock(spec=OrderStatusDTO)
+        second_dto.orderId = "order-1"
+        second_dto.currentState = "payment-approved"
+        second_dto.lastState = "approve-payment"
+        second_dto.domain = "Marketplace"
+        second_dto.vtexAccount = "test-account"
+
+        self.usecase.execute(self.mock_integrated_agent, first_dto)
+        self.usecase.execute(self.mock_integrated_agent, second_dto)
+
+        self.assertEqual(mock_cache.add.call_count, 2)
+        first_key = mock_cache.add.call_args_list[0][0][0]
+        second_key = mock_cache.add.call_args_list[1][0][0]
+        self.assertNotEqual(first_key, second_key)
+        self.assertTrue(first_key.endswith(":approve-payment"))
+        self.assertTrue(second_key.endswith(":payment-approved"))
 
     def test_adapt_order_status_to_webhook_payload(self):
         mock_order_status_dto = MagicMock(spec=OrderStatusDTO)

--- a/retail/settings.py
+++ b/retail/settings.py
@@ -333,6 +333,14 @@ ABANDONED_CART_DEFAULT_IMAGE_URL = env.str(
 )
 PAYMENT_RECOVERY_AGENT_UUID = env.str("PAYMENT_RECOVERY_AGENT_UUID", default="")
 
+# Time window (in seconds) to ignore repeated order status events.
+# An identical event (same project, agent, order, and current state) arriving
+# twice within this window is processed only once. This prevents duplicate
+# broadcasts caused by upstream retries.
+ORDER_STATUS_DUPLICATE_WINDOW_SECONDS = env.int(
+    "ORDER_STATUS_DUPLICATE_WINDOW_SECONDS", default=60
+)
+
 CONNECT_REST_ENDPOINT = env.str("CONNECT_REST_ENDPOINT", default="")
 
 # Slack notifications (hire intent)


### PR DESCRIPTION
## What
Adds idempotent processing to `AgentOrderStatusUpdateUsecase.execute()`: identical order status events (same project + agent + order + current state) arriving within `ORDER_STATUS_DUPLICATE_WINDOW_SECONDS` (default 60s) are processed only once. Uses an atomic `cache.add` (Redis SETNX) and covers all flows that go through this use case (order status webhook, payment recovery, delivered order tracking).

## Why
Production logs show the same order status event reaching us multiple times within milliseconds (order `1X2X25X823413-01`: 2 identical events 300ms apart → 2 broadcasts to the same contact). The duplication originates upstream (VTEX IO retries / brokers), so this change mitigates the impact at our convergence point while the root cause is investigated. Skips are logged so the volume can be measured and escalated.