### PR TITLE
feat(payment-recovery): set 100% rollout and 5min delay as defaults

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -91,21 +91,25 @@ class AssignAgentUseCase:
         project: Project,
         channel_uuid: UUID,
         ignore_templates: List[str],
+        contact_percentage: Optional[int] = None,
     ) -> IntegratedAgent:
         ignore_templates_slugs = self._get_ignore_templates_slugs(ignore_templates)
 
-        # Build initial config based on agent type and project
         initial_config = self._build_initial_config(agent, project)
+
+        defaults: Dict[str, Any] = {
+            "channel_uuid": channel_uuid,
+            "ignore_templates": ignore_templates_slugs,
+            "config": initial_config,
+        }
+        if contact_percentage is not None:
+            defaults["contact_percentage"] = contact_percentage
 
         integrated_agent, created = IntegratedAgent.objects.get_or_create(
             agent=agent,
             project=project,
             is_active=True,
-            defaults={
-                "channel_uuid": channel_uuid,
-                "ignore_templates": ignore_templates_slugs,
-                "config": initial_config,
-            },
+            defaults=defaults,
         )
 
         if not created:
@@ -179,7 +183,7 @@ class AssignAgentUseCase:
         ):
             config["payment_recovery"] = {
                 "hook_created": False,
-                "delay_minutes": 10,
+                "delay_minutes": 5,
             }
 
         return config
@@ -207,6 +211,23 @@ class AssignAgentUseCase:
             "abandonment_time_minutes": 60,
             "minimum_cart_value": 50.0,
         }
+
+    def _resolve_contact_percentage(self, agent: Agent) -> Optional[int]:
+        """
+        Return the contact_percentage override for specific agent types.
+
+        Payment recovery must reach 100% of eligible contacts from day one;
+        other agents keep the model default (10%).
+        """
+        payment_recovery_agent_uuid = getattr(
+            settings, "PAYMENT_RECOVERY_AGENT_UUID", ""
+        )
+        if (
+            payment_recovery_agent_uuid
+            and str(agent.uuid) == payment_recovery_agent_uuid
+        ):
+            return 100
+        return None
 
     def _validate_credentials(self, agent: Agent, credentials: dict):
         for key in agent.credentials.keys():
@@ -475,11 +496,14 @@ class AssignAgentUseCase:
 
         ignore_templates = self._get_ignore_templates(agent, include_templates)
 
+        contact_percentage = self._resolve_contact_percentage(agent)
+
         integrated_agent = self._create_integrated_agent(
             agent=agent,
             project=project,
             channel_uuid=channel_uuid,
             ignore_templates=ignore_templates,
+            contact_percentage=contact_percentage,
         )
         logger.info(f"[AssignAgent] integrated_agent created={integrated_agent.uuid}")
 

--- a/retail/agents/domains/agent_integration/usecases/payment_recovery.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery.py
@@ -13,7 +13,7 @@ from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_DELAY_MINUTES = 10
+DEFAULT_DELAY_MINUTES = 5
 
 
 class PaymentRecoveryWebhookUseCase:

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -18,6 +18,52 @@ PAYMENT_RECOVERY_UUID = str(uuid.uuid4())
 ABANDONED_CART_UUID = str(uuid.uuid4())
 
 
+class ResolveContactPercentageTest(TestCase):
+    def setUp(self):
+        self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
+        self.use_case = AssignAgentUseCase(
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
+        )
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_UUID)
+    def test_returns_100_for_payment_recovery_agent(self):
+        agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_UUID,
+            name="Payment Recovery",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        result = self.use_case._resolve_contact_percentage(agent)
+        self.assertEqual(result, 100)
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_UUID)
+    def test_returns_none_for_non_payment_recovery_agent(self):
+        agent = Agent.objects.create(
+            name="Generic Agent",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        result = self.use_case._resolve_contact_percentage(agent)
+        self.assertIsNone(result)
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID="")
+    def test_returns_none_when_setting_is_empty(self):
+        agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_UUID,
+            name="Payment Recovery",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        result = self.use_case._resolve_contact_percentage(agent)
+        self.assertIsNone(result)
+
+
 class AssignPaymentRecoveryBuildConfigTest(TestCase):
     def setUp(self):
         self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
@@ -45,7 +91,7 @@ class AssignPaymentRecoveryBuildConfigTest(TestCase):
         config = self.use_case._build_initial_config(agent, self.project)
         self.assertIn("payment_recovery", config)
         self.assertFalse(config["payment_recovery"]["hook_created"])
-        self.assertEqual(config["payment_recovery"]["delay_minutes"], 10)
+        self.assertEqual(config["payment_recovery"]["delay_minutes"], 5)
 
     @override_settings(PAYMENT_RECOVERY_AGENT_UUID="")
     def test_build_initial_config_skips_payment_recovery_when_no_uuid(self):
@@ -241,7 +287,7 @@ class AssignPaymentRecoveryHookTest(TestCase):
         self.integrated_agent.config = {
             "payment_recovery": {
                 "hook_created": False,
-                "delay_minutes": 10,
+                "delay_minutes": 5,
             },
             "country_phone_code": "55",
         }
@@ -249,7 +295,7 @@ class AssignPaymentRecoveryHookTest(TestCase):
         self.use_case._create_payment_recovery_hook(self.integrated_agent)
 
         saved_config = self.integrated_agent.config
-        self.assertEqual(saved_config["payment_recovery"]["delay_minutes"], 10)
+        self.assertEqual(saved_config["payment_recovery"]["delay_minutes"], 5)
         self.assertTrue(saved_config["payment_recovery"]["hook_created"])
         self.assertIn("webhook_url", saved_config["payment_recovery"])
         self.assertEqual(saved_config["country_phone_code"], "55")


### PR DESCRIPTION
## What

Adjusts the default configuration for the payment recovery agent integration:
- `contact_percentage` is now set to **100%** (was 10%, the model default)
- `delay_minutes` is now set to **5** (was 10)

## Why

The payment recovery agent must reach all eligible contacts from day one — 
a 10% rollout means 90% of pending PIX payments would be missed. The 5-minute 
delay better fits the PIX payment window, where a shorter follow-up increases 
conversion.