### PR TITLE
feat: Restrict broadcast conversion to payment recovery agent

### DIFF
--- a/retail/broadcasts/tests/test_mark_broadcast_converted.py
+++ b/retail/broadcasts/tests/test_mark_broadcast_converted.py
@@ -20,13 +20,17 @@ from retail.broadcasts.usecases.mark_broadcast_converted import (
 from retail.projects.models import Project
 
 
+PAYMENT_RECOVERY_AGENT_UUID = str(uuid4())
+
+
 @override_settings(
     CACHES={
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
             "LOCATION": "mark-broadcast-converted-test",
         }
-    }
+    },
+    PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_AGENT_UUID,
 )
 class MarkBroadcastConvertedUseCaseTest(TestCase):
     """Unit tests for the conversion attribution use case.
@@ -50,17 +54,21 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
             uuid=uuid4(),
             vtex_account="otheraccount",
         )
-        self.agent = Agent.objects.create(name="Agent A", project=self.project)
+        self.agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_AGENT_UUID,
+            name="Payment Recovery",
+            project=self.project,
+        )
         self.integrated_agent = IntegratedAgent.objects.create(
             agent=self.agent,
             project=self.project,
             channel_uuid=uuid4(),
         )
-        self.other_agent = Agent.objects.create(
-            name="Other Agent", project=self.project
+        self.order_status_agent = Agent.objects.create(
+            name="Order Status", project=self.project
         )
-        self.other_integrated_agent = IntegratedAgent.objects.create(
-            agent=self.other_agent,
+        self.order_status_integrated_agent = IntegratedAgent.objects.create(
+            agent=self.order_status_agent,
             project=self.project,
             channel_uuid=uuid4(),
         )
@@ -140,9 +148,9 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
         self.assertEqual(conversion.currency, "BRL")
         self.assertIsNotNone(conversion.converted_at)
 
-    def test_creates_conversion_for_abandoned_cart_dispatch(self):
-        """Cart abandonment flows fill ``order_form_id`` at dispatch;
-        ``order_id`` arrives later with the conversion event."""
+    def test_creates_conversion_matching_by_order_form_id(self):
+        """When the broadcast was dispatched with ``order_form_id`` only,
+        the VTEX lookup bridges it to the ``order_id`` from the invoice."""
         self._create_broadcast(order_form_id="of-cart-7")
         self.vtex_io_service.get_order_details_by_id.return_value = (
             self._vtex_order_details(
@@ -182,9 +190,14 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
         self.assertEqual(BroadcastConversion.objects.get().uuid, existing.uuid)
         self.assertTrue(any("conversion_already_recorded" in msg for msg in cm.output))
 
-    def test_picks_most_recent_broadcast_for_attribution(self):
-        """Last-touch attribution: the agent of the latest non-failed
-        broadcast wins, even if older broadcasts share the same order."""
+    def test_picks_most_recent_payment_recovery_broadcast(self):
+        """Last-touch attribution: the most recent non-failed broadcast
+        from the payment recovery agent wins."""
+        second_pr_integrated = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
         now = timezone.now()
         self._create_broadcast(
             integrated_agent=self.integrated_agent,
@@ -192,7 +205,7 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
             created_at=now - timedelta(hours=2),
         )
         self._create_broadcast(
-            integrated_agent=self.other_integrated_agent,
+            integrated_agent=second_pr_integrated,
             order_form_id="of-cart-8",
             created_at=now - timedelta(minutes=5),
         )
@@ -203,7 +216,7 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
         self.use_case.execute(order_id="order-300", project_uuid=str(self.project.uuid))
 
         conversion = BroadcastConversion.objects.get(order_id="order-300")
-        self.assertEqual(conversion.integrated_agent, self.other_integrated_agent)
+        self.assertEqual(conversion.integrated_agent, second_pr_integrated)
 
     def test_skips_when_only_failed_broadcasts_exist(self):
         """An invoiced order whose only related broadcasts failed must
@@ -260,12 +273,10 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
 
     def test_other_projects_broadcast_is_not_attributed(self):
         """Multi-tenant safety: a project's invoice never credits
-        another project's broadcasts even if order ids overlap."""
-        other_agent = Agent.objects.create(
-            name="Cross Tenant Agent", project=self.other_project
-        )
+        another project's broadcasts even if order ids and agent UUIDs
+        overlap (same payment recovery agent integrated in both projects)."""
         cross_tenant_integrated_agent = IntegratedAgent.objects.create(
-            agent=other_agent,
+            agent=self.agent,
             project=self.other_project,
             channel_uuid=uuid4(),
         )
@@ -377,10 +388,68 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
             any("conversion_vtex_lookup_failed" in msg for msg in cm.output)
         )
 
-    def test_attribution_to_null_agent_when_broadcast_lost_agent(self):
+    def test_ignores_order_status_agent_broadcasts(self):
+        """Broadcasts from non-payment-recovery agents must not produce
+        conversions — order-status has no conversion tracking and
+        abandoned-cart uses UTM."""
+        self._create_broadcast(
+            integrated_agent=self.order_status_integrated_agent,
+            order_id="order-os",
+        )
+        self.vtex_io_service.get_order_details_by_id.return_value = (
+            self._vtex_order_details(order_form_id="of-os")
+        )
+
+        self.use_case.execute(order_id="order-os", project_uuid=str(self.project.uuid))
+
+        self.assertFalse(BroadcastConversion.objects.exists())
+
+    def test_picks_payment_recovery_even_with_newer_order_status_broadcast(self):
+        """When both an order-status and a payment-recovery broadcast
+        exist for the same order, only the payment-recovery one is
+        eligible for conversion."""
+        now = timezone.now()
+        self._create_broadcast(
+            integrated_agent=self.integrated_agent,
+            order_id="order-mixed",
+            created_at=now - timedelta(hours=1),
+        )
+        self._create_broadcast(
+            integrated_agent=self.order_status_integrated_agent,
+            order_id="order-mixed",
+            created_at=now - timedelta(minutes=5),
+        )
+        self.vtex_io_service.get_order_details_by_id.return_value = (
+            self._vtex_order_details(order_form_id="of-mixed")
+        )
+
+        self.use_case.execute(
+            order_id="order-mixed", project_uuid=str(self.project.uuid)
+        )
+
+        conversion = BroadcastConversion.objects.get(order_id="order-mixed")
+        self.assertEqual(conversion.integrated_agent, self.integrated_agent)
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID="")
+    def test_skips_conversion_when_payment_recovery_uuid_not_configured(self):
+        """When PAYMENT_RECOVERY_AGENT_UUID is empty, no conversion can
+        be attributed — the feature is effectively disabled."""
+        self._create_broadcast(order_id="order-no-setting")
+        self.vtex_io_service.get_order_details_by_id.return_value = (
+            self._vtex_order_details(order_form_id="of-no-setting")
+        )
+
+        self.use_case.execute(
+            order_id="order-no-setting", project_uuid=str(self.project.uuid)
+        )
+
+        self.assertFalse(BroadcastConversion.objects.exists())
+
+    def test_null_agent_broadcast_is_not_eligible(self):
         """``IntegratedAgent`` may be NULL on the broadcast row (agent
-        was deleted, ``SET_NULL`` cascade); the conversion still goes
-        through with a NULL agent so per-project metrics include it."""
+        was deleted, ``SET_NULL`` cascade). Since we cannot confirm the
+        broadcast originated from the payment recovery agent, it must
+        not produce a conversion."""
         broadcast = self._create_broadcast(order_id="order-no-agent")
         BroadcastMessage.objects.filter(pk=broadcast.pk).update(integrated_agent=None)
         self.vtex_io_service.get_order_details_by_id.return_value = (
@@ -391,8 +460,7 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
             order_id="order-no-agent", project_uuid=str(self.project.uuid)
         )
 
-        conversion = BroadcastConversion.objects.get(order_id="order-no-agent")
-        self.assertIsNone(conversion.integrated_agent)
+        self.assertFalse(BroadcastConversion.objects.exists())
 
 
 @override_settings(

--- a/retail/broadcasts/usecases/mark_broadcast_converted.py
+++ b/retail/broadcasts/usecases/mark_broadcast_converted.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional
 
+from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Q
 
@@ -52,11 +53,12 @@ class MarkBroadcastConvertedUseCase:
     1. Pull the canonical ``order_form_id`` / ``value`` / ``currency``
        from VTEX so the conversion row is filled with authoritative
        data even if the originating broadcast only knew one identifier.
-    2. Pick the last-touch broadcast (most recent non-failed dispatch
-       that matches by ``order_id`` or ``order_form_id``) so the
-       conversion can be attributed to a specific ``integrated_agent``.
-       No broadcast match means an organic purchase and is a no-op —
-       the conversion table tracks broadcast-driven sales only.
+    2. Pick the last-touch broadcast from the **payment recovery agent**
+       (most recent non-failed dispatch that matches by ``order_id`` or
+       ``order_form_id``). Only payment recovery dispatches are eligible;
+       order-status agents have no conversion tracking and abandoned-cart
+       conversions are handled via UTM on the VTEX side. No match means
+       an organic purchase and is a no-op.
     3. Create a single ``BroadcastConversion`` row per (project,
        order_id). Idempotency is enforced by the unique constraint at
        the database level: a duplicate insert raises ``IntegrityError``
@@ -202,16 +204,27 @@ class MarkBroadcastConvertedUseCase:
     ) -> Optional[BroadcastMessage]:
         """Pick the most recent eligible broadcast this conversion can be attributed to.
 
+        Only broadcasts dispatched by the payment recovery agent are
+        eligible. Order-status agents have no conversion tracking and
+        abandoned-cart conversions are handled via UTM on the VTEX side.
+
         ``select_related("integrated_agent")`` avoids an extra query
         when the caller dereferences the agent for attribution.
         """
+        payment_recovery_uuid = getattr(settings, "PAYMENT_RECOVERY_AGENT_UUID", "")
+        if not payment_recovery_uuid:
+            return None
+
         match_filter = Q(order_id=order_id)
         if order_form_id:
             match_filter |= Q(order_form_id=order_form_id)
 
         return (
             BroadcastMessage.objects.select_related("integrated_agent")
-            .filter(project=project)
+            .filter(
+                project=project,
+                integrated_agent__agent__uuid=payment_recovery_uuid,
+            )
             .filter(match_filter)
             .exclude(status__in=_BROADCAST_STATUSES_INELIGIBLE_FOR_CONVERSION)
             .order_by("-created_at")


### PR DESCRIPTION
## What
Restricts the `BroadcastConversion` flow so only broadcasts dispatched by the
payment recovery agent are eligible for last-touch attribution. Order-status
and abandoned-cart dispatches no longer produce conversion records via this
path.

## Why
Conversion tracking via `BroadcastConversion` is meant for payment recovery
only. Order-status flows have no conversion semantics, and abandoned-cart
conversions are handled via UTM on the VTEX side. Without this filter, any
broadcast matching by `order_id` / `order_form_id` could be wrongly credited.
