### PR TITLE
refactor: Centralize integrated agent cache invalidation

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/unassign.py
+++ b/retail/agents/domains/agent_integration/usecases/unassign.py
@@ -4,9 +4,6 @@ from typing import Callable
 
 from datetime import datetime
 
-from django.conf import settings
-from django.core.cache import cache
-
 from rest_framework.exceptions import NotFound
 
 from retail.agents.domains.agent_integration.models import IntegratedAgent
@@ -44,7 +41,7 @@ class UnassignAgentUseCase:
         integrated_agent.is_active = False
         integrated_agent.save()
         self._register_agent_unassign_event(agent, project_uuid)
-        self._clear_cache(agent, integrated_agent)
+        self._clear_cache(integrated_agent)
 
     def _register_agent_unassign_event(self, agent: Agent, project_uuid: str):
         """
@@ -70,42 +67,19 @@ class UnassignAgentUseCase:
         self.audit_func(CommerceWebhookPath, event_data)
         logger.info(f"Agent unassignment event registered for agent {agent.uuid}")
 
-    def _clear_cache(self, agent: Agent, integrated_agent: IntegratedAgent) -> None:
-        # Clear webhook cache (used by AgentWebhookUseCase)
+    def _clear_cache(self, integrated_agent: IntegratedAgent) -> None:
+        """Drop every cache entry derived from this IntegratedAgent.
+
+        Defensive against cache backend failures: a Redis hiccup must
+        not break the unassign flow, so we log and continue.
+        """
         try:
-            self.cache_handler.clear_cached_agent(integrated_agent.uuid)
+            self.cache_handler.invalidate_all_for(integrated_agent)
             logger.info(
-                "Cleared integrated agent webhook cache for %s", integrated_agent.uuid
+                f"Invalidated all caches for integrated agent {integrated_agent.uuid}"
             )
         except Exception as exc:
             logger.warning(
-                "Failed to clear integrated agent webhook cache for %s: %s",
-                integrated_agent.uuid,
-                exc,
+                f"Failed to invalidate caches for integrated agent "
+                f"{integrated_agent.uuid}: {exc}"
             )
-
-        # Clear 6h per-project/agent cache used by BaseAgentWebhookUseCase
-        try:
-            cache_key = (
-                f"integrated_agent_{str(agent.uuid)}_"
-                f"{str(integrated_agent.project.uuid)}"
-            )
-            cache.delete(cache_key)
-            logger.info("Cleared per-project integrated agent cache key: %s", cache_key)
-        except Exception as exc:
-            logger.warning(
-                "Failed to clear per-project integrated agent cache for %s/%s: %s",
-                agent.uuid,
-                integrated_agent.project.uuid,
-                exc,
-            )
-
-        # Clear order status cache if applicable
-        if not settings.ORDER_STATUS_AGENT_UUID:
-            logger.warning("ORDER_STATUS_AGENT_UUID is not set in settings.")
-            return
-
-        if str(agent.uuid) == settings.ORDER_STATUS_AGENT_UUID:
-            cache_key = f"integrated_agent_{settings.ORDER_STATUS_AGENT_UUID}_{str(integrated_agent.project.uuid)}"
-            cache.delete(cache_key)
-            logger.info(f"Cleared cache for key: {cache_key}")

--- a/retail/agents/domains/agent_integration/usecases/update.py
+++ b/retail/agents/domains/agent_integration/usecases/update.py
@@ -5,9 +5,6 @@ from rest_framework.exceptions import NotFound, ValidationError
 
 from uuid import UUID
 
-from django.core.cache import cache
-from django.conf import settings
-
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_integration.services.global_rule import GlobalRule
 from retail.agents.shared.cache import (
@@ -29,11 +26,6 @@ class UpdateIntegratedAgentData(TypedDict, total=False):
     contact_percentage: Optional[int]
     global_rule: Optional[str]
     abandoned_cart_config: Optional[AbandonedCartConfigData]
-
-
-# TODO: Refactor cache clearing logic - currently we have 3 separate cache keys
-# (webhook, order_status, abandoned_cart) that should be centralized in
-# IntegratedAgentCacheHandler.clear_all_agent_caches() method.
 
 
 class UpdateIntegratedAgentUseCase:
@@ -90,14 +82,7 @@ class UpdateIntegratedAgentUseCase:
 
         integrated_agent.save()
 
-        # Clear the webhook cache (30 seconds)
-        self.cache_handler.clear_cached_agent(integrated_agent.uuid)
-
-        # Clear the order status cache (6 hours) if this is an order status agent
-        self._clear_order_status_cache(integrated_agent)
-
-        # Clear the abandoned cart cache (6 hours) if this is an abandoned cart agent
-        self._clear_abandoned_cart_cache(integrated_agent)
+        self.cache_handler.invalidate_all_for(integrated_agent)
 
         return integrated_agent
 
@@ -144,46 +129,3 @@ class UpdateIntegratedAgentUseCase:
             f"Updated abandoned cart config for agent {integrated_agent.uuid}: "
             f"{abandoned_cart}"
         )
-
-    def _clear_order_status_cache(self, integrated_agent: IntegratedAgent) -> None:
-        """
-        Clear the order status cache if this is an order status agent.
-
-        This cache is used in AgentOrderStatusUpdateUsecase and has a 6-hour timeout.
-        """
-        if not settings.ORDER_STATUS_AGENT_UUID:
-            return
-
-        # Check if this is an order status agent (official or custom with parent_agent_uuid)
-        is_order_status_agent = (
-            str(integrated_agent.agent.uuid) == settings.ORDER_STATUS_AGENT_UUID
-            or integrated_agent.parent_agent_uuid is not None
-        )
-
-        if is_order_status_agent:
-            cache_key = f"order_status_agent_{str(integrated_agent.project.uuid)}"
-            cache.delete(cache_key)
-            logger.info(
-                f"Cleared order status cache for agent {integrated_agent.uuid} with key: {cache_key}"
-            )
-
-    def _clear_abandoned_cart_cache(self, integrated_agent: IntegratedAgent) -> None:
-        """
-        Clear the abandoned cart cache if this is an abandoned cart agent.
-
-        This cache is used in BaseAgentWebhookUseCase.get_integrated_agent_if_exists()
-        and has a 6-hour timeout.
-        """
-        if not settings.ABANDONED_CART_AGENT_UUID:
-            return
-
-        is_abandoned_cart_agent = (
-            str(integrated_agent.agent.uuid) == settings.ABANDONED_CART_AGENT_UUID
-        )
-
-        if is_abandoned_cart_agent:
-            cache_key = f"integrated_agent_{settings.ABANDONED_CART_AGENT_UUID}_{str(integrated_agent.project.uuid)}"
-            cache.delete(cache_key)
-            logger.info(
-                f"Cleared abandoned cart cache for agent {integrated_agent.uuid} with key: {cache_key}"
-            )

--- a/retail/agents/domains/agent_webhook/usecases/abandoned_cart.py
+++ b/retail/agents/domains/agent_webhook/usecases/abandoned_cart.py
@@ -2,12 +2,11 @@ import logging
 
 from typing import Optional
 
-from django.conf import settings
-
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_webhook.usecases.base_agent_webhook import (
     BaseAgentWebhookUseCase,
 )
+from retail.agents.shared.cache import AgentRole
 from retail.projects.models import Project
 from retail.vtex.models import Cart
 
@@ -42,11 +41,7 @@ class AgentAbandonedCartUseCase(BaseAgentWebhookUseCase):
         Returns:
             Optional[IntegratedAgent]: The integrated agent if found, None otherwise.
         """
-        integrated_agent = self.get_integrated_agent_if_exists(
-            project, settings.ABANDONED_CART_AGENT_UUID
-        )
-
-        return integrated_agent
+        return self.get_integrated_agent_if_exists(project, AgentRole.ABANDONED_CART)
 
     def execute(self, cart: Cart, integrated_agent: IntegratedAgent) -> None:
         """

--- a/retail/agents/domains/agent_webhook/usecases/base_agent_webhook.py
+++ b/retail/agents/domains/agent_webhook/usecases/base_agent_webhook.py
@@ -2,9 +2,16 @@ import logging
 
 from typing import Optional
 
+from django.conf import settings
 from django.core.cache import cache
 
 from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.shared.cache import (
+    AgentRole,
+    IntegratedAgentCacheHandler,
+    IntegratedAgentCacheHandlerRedis,
+    ROLE_SETTING_NAMES,
+)
 from retail.projects.models import Project
 
 
@@ -17,28 +24,32 @@ class BaseAgentWebhookUseCase:
     for retrieving integrated agents and projects.
     """
 
+    def __init__(
+        self,
+        cache_handler: Optional[IntegratedAgentCacheHandler] = None,
+    ) -> None:
+        self.cache_handler = cache_handler or IntegratedAgentCacheHandlerRedis()
+
     def get_integrated_agent_if_exists(
-        self, project: Project, agent_uuid: str
+        self, project: Project, role: AgentRole
     ) -> Optional[IntegratedAgent]:
         """
-        Retrieve the integrated agent if it exists, with caching for 6 hours.
+        Retrieve the integrated agent that fulfills ``role`` for ``project``.
 
-        Args:
-            project (Project): The project instance.
-            agent_uuid (str): The UUID of the agent to retrieve.
+        Hits the role cache first (6h TTL) and falls back to a DB
+        lookup keyed by the ``Agent.uuid`` configured in settings for
+        ``role``. The lookup is then cached for subsequent calls.
 
-        Returns:
-            Optional[IntegratedAgent]: The integrated agent if found, otherwise None.
+        Returns ``None`` when the role setting is not configured or
+        when no active integrated agent exists for the project.
         """
+        agent_uuid = self._resolve_role_agent_uuid(role)
         if not agent_uuid:
-            logger.warning("Agent UUID is not provided.")
             return None
 
-        cache_key = f"integrated_agent_{agent_uuid}_{str(project.uuid)}"
-        integrated_agent = cache.get(cache_key)
-
-        if integrated_agent:
-            return integrated_agent
+        cached = self.cache_handler.get_role_agent(project.uuid, role)
+        if cached is not None:
+            return cached
 
         try:
             integrated_agent = IntegratedAgent.objects.get(
@@ -46,14 +57,38 @@ class BaseAgentWebhookUseCase:
                 project=project,
                 is_active=True,
             )
-            cache.set(cache_key, integrated_agent, timeout=21600)  # 6 hours
         except IntegratedAgent.DoesNotExist:
             logger.info(
-                f"No active integrated agent found for agent UUID: {agent_uuid}"
+                f"No active integrated agent found for role {role.value} "
+                f"(agent_uuid={agent_uuid}, project={project.uuid})"
             )
             return None
 
+        self.cache_handler.set_role_agent(integrated_agent, role)
         return integrated_agent
+
+    @staticmethod
+    def _resolve_role_agent_uuid(role: AgentRole) -> Optional[str]:
+        """Look up the ``Agent.uuid`` configured in settings for ``role``.
+
+        Each role maps to one Django setting via ``ROLE_SETTING_NAMES``
+        and that setting holds the canonical ``Agent.uuid``. Returns
+        ``None`` (and logs) when the setting is empty so the caller can
+        short-circuit without a DB hit.
+
+        Example:
+            role=AgentRole.ABANDONED_CART
+                → setting_name = "ABANDONED_CART_AGENT_UUID"
+                → returns settings.ABANDONED_CART_AGENT_UUID, e.g.
+                  "0a1b2c3d-...-abc"; or ``None`` when the setting is
+                  empty in this environment.
+        """
+        setting_name = ROLE_SETTING_NAMES[role]
+        agent_uuid = getattr(settings, setting_name, "")
+        if not agent_uuid:
+            logger.warning(f"{setting_name} is not configured in settings.")
+            return None
+        return agent_uuid
 
     def get_project_by_vtex_account(self, vtex_account: str) -> Optional[Project]:
         """

--- a/retail/agents/domains/agent_webhook/usecases/order_status.py
+++ b/retail/agents/domains/agent_webhook/usecases/order_status.py
@@ -10,6 +10,11 @@ from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_webhook.usecases.webhook import (
     AgentWebhookUseCase,
 )
+from retail.agents.shared.cache import (
+    AgentRole,
+    IntegratedAgentCacheHandler,
+    IntegratedAgentCacheHandlerRedis,
+)
 from retail.interfaces.clients.aws_lambda.client import RequestData
 from retail.projects.models import Project
 from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
@@ -43,6 +48,12 @@ def adapt_order_status_to_webhook_payload(
 
 
 class AgentOrderStatusUpdateUsecase:
+    def __init__(
+        self,
+        cache_handler: Optional[IntegratedAgentCacheHandler] = None,
+    ) -> None:
+        self.cache_handler = cache_handler or IntegratedAgentCacheHandlerRedis()
+
     def get_integrated_agent_if_exists(
         self, project: Project
     ) -> Optional[IntegratedAgent]:
@@ -62,14 +73,27 @@ class AgentOrderStatusUpdateUsecase:
             logger.warning("ORDER_STATUS_AGENT_UUID is not set in settings.")
             return None
 
-        cache_key = f"order_status_agent_{str(project.uuid)}"
-        integrated_agent = cache.get(cache_key)
+        cached = self.cache_handler.get_role_agent(project.uuid, AgentRole.ORDER_STATUS)
+        if cached is not None:
+            return cached
 
-        if integrated_agent:
-            return integrated_agent
+        integrated_agent = self._lookup_order_status_agent(project)
+        if integrated_agent is None:
+            return None
 
+        self.cache_handler.set_role_agent(integrated_agent, AgentRole.ORDER_STATUS)
+        return integrated_agent
+
+    def _lookup_order_status_agent(self, project: Project) -> Optional[IntegratedAgent]:
+        """Resolve the order-status agent for ``project`` from the database.
+
+        Tries the official agent first; only when ``DoesNotExist`` is
+        raised, falls back to any custom agent flagged with
+        ``parent_agent_uuid`` (inherited order-status logic). The
+        nested structure mirrors that "fallback only on missing
+        official" intent visually.
+        """
         try:
-            # First try to find the official agent
             integrated_agent = IntegratedAgent.objects.get(
                 agent__uuid=settings.ORDER_STATUS_AGENT_UUID,
                 project=project,
@@ -78,13 +102,13 @@ class AgentOrderStatusUpdateUsecase:
             logger.info(
                 f"Found official integrated agent for ORDER_STATUS_AGENT_UUID: {settings.ORDER_STATUS_AGENT_UUID}"
             )
+            return integrated_agent
         except IntegratedAgent.DoesNotExist:
             logger.info(
                 f"No official integrated agent found for ORDER_STATUS_AGENT_UUID: {settings.ORDER_STATUS_AGENT_UUID}. "
                 f"Looking for agents with parent_agent_uuid filled..."
             )
 
-            # If official agent not found, look for any agent with parent_agent_uuid filled
             try:
                 integrated_agent = IntegratedAgent.objects.get(
                     parent_agent_uuid__isnull=False,
@@ -94,6 +118,7 @@ class AgentOrderStatusUpdateUsecase:
                 logger.info(
                     f"Found integrated agent with parent_agent_uuid: {integrated_agent.parent_agent_uuid}"
                 )
+                return integrated_agent
             except IntegratedAgent.DoesNotExist:
                 logger.info(
                     f"No integrated agent found (official or with parent_agent_uuid) for project {project.uuid}"
@@ -110,9 +135,6 @@ class AgentOrderStatusUpdateUsecase:
                     },
                     code="multiple_parent_agents",
                 )
-
-        cache.set(cache_key, integrated_agent, timeout=21600)  # 6 hours
-        return integrated_agent
 
     def get_project_by_vtex_account(self, vtex_account: str) -> Project:
         """

--- a/retail/agents/shared/cache.py
+++ b/retail/agents/shared/cache.py
@@ -1,39 +1,72 @@
 from abc import ABC, abstractmethod
-
-from typing import Iterable, Optional
+from enum import Enum
+from typing import Dict, Iterable, Optional
 
 from uuid import UUID
 
+from django.conf import settings
 from django.core.cache import cache
 
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 
 
+class AgentRole(str, Enum):
+    """Special integration roles that have a project-scoped cache entry.
+
+    Each role maps to a Django setting holding the canonical
+    ``Agent.uuid`` for that role. The handler uses this enum (and the
+    mapping below) as the single source of truth so every cache layer
+    derives its keys consistently.
+    """
+
+    ABANDONED_CART = "abandoned_cart"
+    ORDER_STATUS = "order_status"
+    PAYMENT_RECOVERY = "payment_recovery"
+
+
+ROLE_SETTING_NAMES: Dict[AgentRole, str] = {
+    AgentRole.ABANDONED_CART: "ABANDONED_CART_AGENT_UUID",
+    AgentRole.ORDER_STATUS: "ORDER_STATUS_AGENT_UUID",
+    AgentRole.PAYMENT_RECOVERY: "PAYMENT_RECOVERY_AGENT_UUID",
+}
+
+
 class IntegratedAgentCacheHandler(ABC):
+    """Single source of truth for IntegratedAgent-derived caches.
+
+    Two cache layers are managed here:
+
+    * **Webhook cache** (short TTL): one entry per ``IntegratedAgent.uuid``
+      used by the synchronous webhook hot path. Reflects in-flight edits
+      (e.g. ``contact_percentage``, ``config``) within seconds.
+    * **Role cache** (long TTL): one entry per ``(role, project_uuid)``
+      pointing at the ``IntegratedAgent`` that fulfills that role for
+      the project. Lookups by role hit Redis instead of the database.
+
+    Use cases must never compose cache keys directly; they should call
+    into this handler so future layout changes are a single edit.
+    """
+
     @abstractmethod
     def get_cache_key(self, integrated_agent_uuid: UUID) -> str:
-        """Generate a cache key for the integrated agent."""
-        pass
+        """Generate a cache key for the integrated agent webhook cache."""
 
     @abstractmethod
     def get_cached_agent(
         self, integrated_agent_uuid: UUID
     ) -> Optional[IntegratedAgent]:
-        """Retrieve the integrated agent from cache."""
-        pass
+        """Retrieve the integrated agent from the webhook cache."""
 
     @abstractmethod
     def set_cached_agent(self, integrated_agent: IntegratedAgent) -> None:
-        """Set the integrated agent in cache."""
-        pass
+        """Set the integrated agent in the webhook cache."""
 
     @abstractmethod
     def clear_cached_agent(self, integrated_agent_uuid: UUID) -> None:
-        """Clear the integrated agent from cache."""
-        pass
+        """Clear the integrated agent from the webhook cache."""
 
     def clear_cached_agents(self, integrated_agent_uuids: Iterable[UUID]) -> None:
-        """Clear multiple integrated agents from cache.
+        """Clear multiple integrated agents from the webhook cache.
 
         Default implementation calls ``clear_cached_agent`` per uuid;
         backends that support batch deletion may override this for a
@@ -42,13 +75,95 @@ class IntegratedAgentCacheHandler(ABC):
         for integrated_agent_uuid in integrated_agent_uuids:
             self.clear_cached_agent(integrated_agent_uuid)
 
+    @abstractmethod
+    def get_role_cache_key(self, project_uuid: UUID, role: AgentRole) -> str:
+        """Generate a cache key for the role-based project cache."""
+
+    @abstractmethod
+    def get_role_agent(
+        self, project_uuid: UUID, role: AgentRole
+    ) -> Optional[IntegratedAgent]:
+        """Retrieve the IntegratedAgent fulfilling ``role`` for ``project``."""
+
+    @abstractmethod
+    def set_role_agent(
+        self, integrated_agent: IntegratedAgent, role: AgentRole
+    ) -> None:
+        """Cache ``integrated_agent`` as the holder of ``role`` for its project."""
+
+    @abstractmethod
+    def clear_role_agent(self, project_uuid: UUID, role: AgentRole) -> None:
+        """Clear the role cache entry for ``(role, project)``."""
+
+    @abstractmethod
+    def clear_agent_active_flag(self, vtex_account: str, role: AgentRole) -> None:
+        """Clear the boolean cache from ``CheckAgentActiveUseCase``.
+
+        That cache stores ``agent_active_<vtex_account>_<role>`` for 60s
+        and is consumed by the public-API endpoint that tells the
+        frontend whether a given role is active for a VTEX account.
+        Without explicit invalidation, assign/unassign/update would be
+        invisible to that endpoint for up to 60s.
+        """
+
+    def invalidate_all_for(self, integrated_agent: IntegratedAgent) -> None:
+        """Clear every cache key derived from ``integrated_agent``.
+
+        Always clears the webhook cache. Additionally clears the role
+        cache entry and the ``CheckAgentActive`` boolean flag for the
+        role this agent currently fulfills, if any. Callers don't need
+        to know the role; the handler resolves it from settings.
+        """
+        self.clear_cached_agent(integrated_agent.uuid)
+        role = self.resolve_role(integrated_agent)
+        if role is None:
+            return
+
+        self.clear_role_agent(integrated_agent.project.uuid, role)
+
+        vtex_account = integrated_agent.project.vtex_account
+        if vtex_account:
+            self.clear_agent_active_flag(vtex_account, role)
+
+    @staticmethod
+    def resolve_role(integrated_agent: IntegratedAgent) -> Optional[AgentRole]:
+        """Match ``integrated_agent`` against the role settings.
+
+        Returns the matching ``AgentRole`` or ``None`` if the agent does
+        not fulfill any of the special roles tracked by this handler.
+        """
+        agent_uuid = str(integrated_agent.agent.uuid)
+        for role, setting_name in ROLE_SETTING_NAMES.items():
+            configured = getattr(settings, setting_name, "")
+            if configured and configured == agent_uuid:
+                return role
+        return None
+
 
 class IntegratedAgentCacheHandlerRedis(IntegratedAgentCacheHandler):
+    """Redis-backed implementation using Django's cache framework.
+
+    TTLs are chosen to balance hot-path latency vs. propagation of
+    edits:
+
+    * ``WEBHOOK_TTL`` (30s): tight loop with the dispatch path; short
+      enough that ``contact_percentage`` and ``config`` edits feel
+      almost real-time without explicit invalidation.
+    * ``ROLE_TTL`` (6h): role-by-project lookups are stable per project
+      and are explicitly invalidated on assign/unassign/update via
+      ``invalidate_all_for``.
+    """
+
+    WEBHOOK_TTL = 30  # seconds
+    ROLE_TTL = 21600  # 6 hours
+
     def __init__(
         self, cache_key_prefix: Optional[str] = None, cache_time: Optional[int] = None
     ) -> None:
+        # The kwargs control the webhook cache only, which is the only
+        # one this class managed before the role-cache extension.
         self.cache_key_prefix = cache_key_prefix or "integrated_agent_webhook"
-        self.cache_time = cache_time or 30
+        self.cache_time = cache_time or self.WEBHOOK_TTL
 
     def get_cache_key(self, integrated_agent_uuid: UUID) -> str:
         return f"{self.cache_key_prefix}_{integrated_agent_uuid}"
@@ -56,18 +171,42 @@ class IntegratedAgentCacheHandlerRedis(IntegratedAgentCacheHandler):
     def get_cached_agent(
         self, integrated_agent_uuid: UUID
     ) -> Optional[IntegratedAgent]:
-        cache_key = self.get_cache_key(integrated_agent_uuid)
-        return cache.get(cache_key)
+        return cache.get(self.get_cache_key(integrated_agent_uuid))
 
     def set_cached_agent(self, integrated_agent: IntegratedAgent) -> None:
-        cache_key = self.get_cache_key(integrated_agent.uuid)
-        cache.set(cache_key, integrated_agent, timeout=self.cache_time)
+        cache.set(
+            self.get_cache_key(integrated_agent.uuid),
+            integrated_agent,
+            timeout=self.cache_time,
+        )
 
     def clear_cached_agent(self, integrated_agent_uuid: UUID) -> None:
-        cache_key = self.get_cache_key(integrated_agent_uuid)
-        cache.delete(cache_key)
+        cache.delete(self.get_cache_key(integrated_agent_uuid))
 
     def clear_cached_agents(self, integrated_agent_uuids: Iterable[UUID]) -> None:
         keys = [self.get_cache_key(u) for u in integrated_agent_uuids]
         if keys:
             cache.delete_many(keys)
+
+    def get_role_cache_key(self, project_uuid: UUID, role: AgentRole) -> str:
+        return f"{role.value}_agent_{project_uuid}"
+
+    def get_role_agent(
+        self, project_uuid: UUID, role: AgentRole
+    ) -> Optional[IntegratedAgent]:
+        return cache.get(self.get_role_cache_key(project_uuid, role))
+
+    def set_role_agent(
+        self, integrated_agent: IntegratedAgent, role: AgentRole
+    ) -> None:
+        cache.set(
+            self.get_role_cache_key(integrated_agent.project.uuid, role),
+            integrated_agent,
+            timeout=self.ROLE_TTL,
+        )
+
+    def clear_role_agent(self, project_uuid: UUID, role: AgentRole) -> None:
+        cache.delete(self.get_role_cache_key(project_uuid, role))
+
+    def clear_agent_active_flag(self, vtex_account: str, role: AgentRole) -> None:
+        cache.delete(f"agent_active_{vtex_account}_{role.value}")

--- a/retail/agents/tests/mocks/cache/integrated_agent_webhook.py
+++ b/retail/agents/tests/mocks/cache/integrated_agent_webhook.py
@@ -2,11 +2,18 @@ from typing import Optional
 
 from uuid import UUID
 
-from retail.agents.shared.cache import IntegratedAgentCacheHandler
+from retail.agents.shared.cache import AgentRole, IntegratedAgentCacheHandler
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 
 
 class IntegratedAgentCacheHandlerMock(IntegratedAgentCacheHandler):
+    """In-memory mock used by tests that exercise the cache contract.
+
+    Backed by a single ``dict`` keyed by the same string keys the
+    Redis implementation would write, so assertions work for both
+    the webhook cache and the role cache.
+    """
+
     def __init__(self) -> None:
         self.cache = {}
 
@@ -23,3 +30,25 @@ class IntegratedAgentCacheHandlerMock(IntegratedAgentCacheHandler):
 
     def clear_cached_agent(self, integrated_agent_uuid: UUID) -> None:
         self.cache.pop(self.get_cache_key(integrated_agent_uuid), None)
+
+    def get_role_cache_key(self, project_uuid: UUID, role: AgentRole) -> str:
+        return f"{role.value}_agent_{project_uuid}"
+
+    def get_role_agent(
+        self, project_uuid: UUID, role: AgentRole
+    ) -> Optional[IntegratedAgent]:
+        return self.cache.get(self.get_role_cache_key(project_uuid, role))
+
+    def set_role_agent(
+        self, integrated_agent: IntegratedAgent, role: AgentRole
+    ) -> None:
+        key = self.get_role_cache_key(integrated_agent.project.uuid, role)
+        self.cache[key] = integrated_agent
+
+    def clear_role_agent(self, project_uuid: UUID, role: AgentRole) -> None:
+        self.cache.pop(self.get_role_cache_key(project_uuid, role), None)
+
+    def clear_agent_active_flag(self, vtex_account: str, role: AgentRole) -> None:
+        # No-op for in-memory tests; the real handler delegates to Redis,
+        # which is exercised by IntegratedAgentCacheHandlerRedis tests.
+        return None

--- a/retail/agents/tests/shared/test_cache.py
+++ b/retail/agents/tests/shared/test_cache.py
@@ -2,15 +2,23 @@ import uuid
 
 from unittest.mock import Mock, patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.shared.cache import (
+    AgentRole,
     IntegratedAgentCacheHandlerRedis,
 )
 
 
-class IntegratedAgentCacheHandlerRedisTest(TestCase):
+PAYMENT_RECOVERY_AGENT_UUID = str(uuid.uuid4())
+ABANDONED_CART_AGENT_UUID = str(uuid.uuid4())
+ORDER_STATUS_AGENT_UUID = str(uuid.uuid4())
+
+
+class IntegratedAgentCacheHandlerRedisWebhookTest(TestCase):
+    """Tests for the webhook cache layer (one entry per IntegratedAgent.uuid)."""
+
     def setUp(self):
         self.cache_handler = IntegratedAgentCacheHandlerRedis()
         self.test_uuid = uuid.uuid4()
@@ -70,12 +78,6 @@ class IntegratedAgentCacheHandlerRedisTest(TestCase):
         expected_key = f"integrated_agent_webhook_{self.test_uuid}"
         mock_cache_delete.assert_called_once_with(expected_key)
 
-    @patch("django.core.cache.cache.delete")
-    def test_clear_cached_agent_not_exists(self, mock_cache_delete):
-        self.cache_handler.clear_cached_agent(self.test_uuid)
-        expected_key = f"integrated_agent_webhook_{self.test_uuid}"
-        mock_cache_delete.assert_called_once_with(expected_key)
-
     @patch("django.core.cache.cache.set")
     def test_set_cached_agent_with_timeout(self, mock_cache_set):
         custom_handler = IntegratedAgentCacheHandlerRedis(cache_time=60)
@@ -84,3 +86,199 @@ class IntegratedAgentCacheHandlerRedisTest(TestCase):
         mock_cache_set.assert_called_once_with(
             expected_key, self.integrated_agent, timeout=60
         )
+
+
+class IntegratedAgentCacheHandlerRedisRoleCacheTest(TestCase):
+    """Tests for the role cache layer (one entry per (role, project))."""
+
+    def setUp(self):
+        self.cache_handler = IntegratedAgentCacheHandlerRedis()
+        self.project_uuid = uuid.uuid4()
+        self.integrated_agent = Mock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid.uuid4()
+        self.integrated_agent.project = Mock()
+        self.integrated_agent.project.uuid = self.project_uuid
+
+    def test_get_role_cache_key(self):
+        key = self.cache_handler.get_role_cache_key(
+            self.project_uuid, AgentRole.PAYMENT_RECOVERY
+        )
+        self.assertEqual(key, f"payment_recovery_agent_{self.project_uuid}")
+
+    def test_get_role_cache_key_for_each_role(self):
+        for role, expected_prefix in (
+            (AgentRole.PAYMENT_RECOVERY, "payment_recovery"),
+            (AgentRole.ABANDONED_CART, "abandoned_cart"),
+            (AgentRole.ORDER_STATUS, "order_status"),
+        ):
+            with self.subTest(role=role):
+                key = self.cache_handler.get_role_cache_key(self.project_uuid, role)
+                self.assertEqual(key, f"{expected_prefix}_agent_{self.project_uuid}")
+
+    @patch("django.core.cache.cache.get")
+    def test_get_role_agent_returns_cached_value(self, mock_cache_get):
+        mock_cache_get.return_value = self.integrated_agent
+        result = self.cache_handler.get_role_agent(
+            self.project_uuid, AgentRole.PAYMENT_RECOVERY
+        )
+        mock_cache_get.assert_called_once_with(
+            f"payment_recovery_agent_{self.project_uuid}"
+        )
+        self.assertEqual(result, self.integrated_agent)
+
+    @patch("django.core.cache.cache.set")
+    def test_set_role_agent_uses_role_ttl(self, mock_cache_set):
+        self.cache_handler.set_role_agent(self.integrated_agent, AgentRole.ORDER_STATUS)
+        mock_cache_set.assert_called_once_with(
+            f"order_status_agent_{self.project_uuid}",
+            self.integrated_agent,
+            timeout=21600,
+        )
+
+    @patch("django.core.cache.cache.delete")
+    def test_clear_role_agent(self, mock_cache_delete):
+        self.cache_handler.clear_role_agent(self.project_uuid, AgentRole.ABANDONED_CART)
+        mock_cache_delete.assert_called_once_with(
+            f"abandoned_cart_agent_{self.project_uuid}"
+        )
+
+    @patch("django.core.cache.cache.delete")
+    def test_clear_agent_active_flag(self, mock_cache_delete):
+        self.cache_handler.clear_agent_active_flag(
+            "myaccount", AgentRole.PAYMENT_RECOVERY
+        )
+        mock_cache_delete.assert_called_once_with(
+            "agent_active_myaccount_payment_recovery"
+        )
+
+
+class ResolveRoleTest(TestCase):
+    """Tests for ``IntegratedAgentCacheHandler.resolve_role``."""
+
+    def setUp(self):
+        self.cache_handler = IntegratedAgentCacheHandlerRedis()
+        self.integrated_agent = Mock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid.uuid4()
+        self.integrated_agent.agent = Mock()
+        self.integrated_agent.agent.uuid = uuid.uuid4()
+        self.integrated_agent.project = Mock()
+        self.integrated_agent.project.uuid = uuid.uuid4()
+        self.integrated_agent.project.vtex_account = "myaccount"
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_AGENT_UUID)
+    def test_resolves_payment_recovery_role(self):
+        self.integrated_agent.agent.uuid = PAYMENT_RECOVERY_AGENT_UUID
+        role = self.cache_handler.resolve_role(self.integrated_agent)
+        self.assertEqual(role, AgentRole.PAYMENT_RECOVERY)
+
+    @override_settings(ABANDONED_CART_AGENT_UUID=ABANDONED_CART_AGENT_UUID)
+    def test_resolves_abandoned_cart_role(self):
+        self.integrated_agent.agent.uuid = ABANDONED_CART_AGENT_UUID
+        role = self.cache_handler.resolve_role(self.integrated_agent)
+        self.assertEqual(role, AgentRole.ABANDONED_CART)
+
+    @override_settings(ORDER_STATUS_AGENT_UUID=ORDER_STATUS_AGENT_UUID)
+    def test_resolves_order_status_role(self):
+        self.integrated_agent.agent.uuid = ORDER_STATUS_AGENT_UUID
+        role = self.cache_handler.resolve_role(self.integrated_agent)
+        self.assertEqual(role, AgentRole.ORDER_STATUS)
+
+    @override_settings(
+        PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_AGENT_UUID,
+        ABANDONED_CART_AGENT_UUID=ABANDONED_CART_AGENT_UUID,
+        ORDER_STATUS_AGENT_UUID=ORDER_STATUS_AGENT_UUID,
+    )
+    def test_returns_none_for_unrelated_agent(self):
+        self.integrated_agent.agent.uuid = str(uuid.uuid4())
+        role = self.cache_handler.resolve_role(self.integrated_agent)
+        self.assertIsNone(role)
+
+    @override_settings(
+        PAYMENT_RECOVERY_AGENT_UUID="",
+        ABANDONED_CART_AGENT_UUID="",
+        ORDER_STATUS_AGENT_UUID="",
+    )
+    def test_returns_none_when_settings_are_empty(self):
+        self.integrated_agent.agent.uuid = PAYMENT_RECOVERY_AGENT_UUID
+        role = self.cache_handler.resolve_role(self.integrated_agent)
+        self.assertIsNone(role)
+
+
+class InvalidateAllForTest(TestCase):
+    """Tests for ``IntegratedAgentCacheHandler.invalidate_all_for``."""
+
+    def setUp(self):
+        self.cache_handler = IntegratedAgentCacheHandlerRedis()
+        self.integrated_agent = Mock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid.uuid4()
+        self.integrated_agent.agent = Mock()
+        self.integrated_agent.agent.uuid = PAYMENT_RECOVERY_AGENT_UUID
+        self.integrated_agent.project = Mock()
+        self.integrated_agent.project.uuid = uuid.uuid4()
+        self.integrated_agent.project.vtex_account = "myaccount"
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_AGENT_UUID)
+    @patch("django.core.cache.cache.delete")
+    def test_clears_all_keys_for_known_role(self, mock_cache_delete):
+        self.cache_handler.invalidate_all_for(self.integrated_agent)
+
+        cleared_keys = [call.args[0] for call in mock_cache_delete.call_args_list]
+        self.assertIn(
+            f"integrated_agent_webhook_{self.integrated_agent.uuid}", cleared_keys
+        )
+        self.assertIn(
+            f"payment_recovery_agent_{self.integrated_agent.project.uuid}",
+            cleared_keys,
+        )
+        self.assertIn("agent_active_myaccount_payment_recovery", cleared_keys)
+
+    @override_settings(
+        PAYMENT_RECOVERY_AGENT_UUID="",
+        ABANDONED_CART_AGENT_UUID="",
+        ORDER_STATUS_AGENT_UUID="",
+    )
+    @patch("django.core.cache.cache.delete")
+    def test_clears_only_webhook_key_when_role_unknown(self, mock_cache_delete):
+        self.cache_handler.invalidate_all_for(self.integrated_agent)
+
+        cleared_keys = [call.args[0] for call in mock_cache_delete.call_args_list]
+        self.assertEqual(
+            cleared_keys,
+            [f"integrated_agent_webhook_{self.integrated_agent.uuid}"],
+        )
+
+    @override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_AGENT_UUID)
+    @patch("django.core.cache.cache.delete")
+    def test_skips_agent_active_flag_when_vtex_account_missing(self, mock_cache_delete):
+        self.integrated_agent.project.vtex_account = ""
+
+        self.cache_handler.invalidate_all_for(self.integrated_agent)
+
+        cleared_keys = [call.args[0] for call in mock_cache_delete.call_args_list]
+        self.assertNotIn("agent_active__payment_recovery", cleared_keys)
+        self.assertIn(
+            f"payment_recovery_agent_{self.integrated_agent.project.uuid}",
+            cleared_keys,
+        )
+
+
+class ClearCachedAgentsTest(TestCase):
+    """Tests for the batch ``clear_cached_agents`` helper."""
+
+    def setUp(self):
+        self.cache_handler = IntegratedAgentCacheHandlerRedis()
+
+    @patch("django.core.cache.cache.delete_many")
+    def test_clear_cached_agents_uses_delete_many(self, mock_delete_many):
+        uuids = [uuid.uuid4(), uuid.uuid4()]
+
+        self.cache_handler.clear_cached_agents(uuids)
+
+        expected_keys = [f"integrated_agent_webhook_{u}" for u in uuids]
+        mock_delete_many.assert_called_once_with(expected_keys)
+
+    @patch("django.core.cache.cache.delete_many")
+    def test_clear_cached_agents_no_op_when_empty(self, mock_delete_many):
+        self.cache_handler.clear_cached_agents([])
+
+        mock_delete_many.assert_not_called()

--- a/retail/agents/tests/usecases/test_order_status_update.py
+++ b/retail/agents/tests/usecases/test_order_status_update.py
@@ -9,6 +9,7 @@ from retail.agents.domains.agent_webhook.usecases.order_status import (
     adapt_order_status_to_webhook_payload,
 )
 from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.shared.cache import AgentRole
 from retail.projects.models import Project
 from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 
@@ -17,7 +18,10 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
     """Test cases for AgentOrderStatusUpdateUsecase functionality."""
 
     def setUp(self):
-        self.usecase = AgentOrderStatusUpdateUsecase()
+        self.mock_cache_handler = MagicMock()
+        self.usecase = AgentOrderStatusUpdateUsecase(
+            cache_handler=self.mock_cache_handler
+        )
         self.mock_project = MagicMock(spec=Project)
         self.mock_project.uuid = uuid4()
         self.mock_integrated_agent = MagicMock(spec=IntegratedAgent)
@@ -26,28 +30,25 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
         self.mock_integrated_agent.ignore_templates = False
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
-    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
-    def test_get_integrated_agent_if_exists_returns_from_cache(
-        self, mock_cache, mock_settings
-    ):
+    def test_get_integrated_agent_if_exists_returns_from_cache(self, mock_settings):
         mock_settings.ORDER_STATUS_AGENT_UUID = "test-agent-uuid"
-        mock_cache.get.return_value = self.mock_integrated_agent
+        self.mock_cache_handler.get_role_agent.return_value = self.mock_integrated_agent
 
         result = self.usecase.get_integrated_agent_if_exists(self.mock_project)
 
         self.assertEqual(result, self.mock_integrated_agent)
-        mock_cache.get.assert_called_once_with(
-            f"order_status_agent_{str(self.mock_project.uuid)}"
+        self.mock_cache_handler.get_role_agent.assert_called_once_with(
+            self.mock_project.uuid, AgentRole.ORDER_STATUS
         )
+        self.mock_cache_handler.set_role_agent.assert_not_called()
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
-    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.IntegratedAgent")
     def test_get_integrated_agent_if_exists_fetches_and_sets_cache(
-        self, mock_integrated_agent_cls, mock_cache, mock_settings
+        self, mock_integrated_agent_cls, mock_settings
     ):
         mock_settings.ORDER_STATUS_AGENT_UUID = "test-agent-uuid"
-        mock_cache.get.return_value = None
+        self.mock_cache_handler.get_role_agent.return_value = None
         mock_obj = MagicMock()
         mock_integrated_agent_cls.objects.get.return_value = mock_obj
 
@@ -59,103 +60,87 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
             project=self.mock_project,
             is_active=True,
         )
-        mock_cache.set.assert_called_once_with(
-            f"order_status_agent_{str(self.mock_project.uuid)}",
-            mock_obj,
-            timeout=21600,
+        self.mock_cache_handler.set_role_agent.assert_called_once_with(
+            mock_obj, AgentRole.ORDER_STATUS
         )
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
-    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.IntegratedAgent")
     def test_get_integrated_agent_if_exists_returns_none_if_not_found(
-        self, mock_integrated_agent_cls, mock_cache, mock_settings
+        self, mock_integrated_agent_cls, mock_settings
     ):
         mock_settings.ORDER_STATUS_AGENT_UUID = "test-agent-uuid"
-        mock_cache.get.return_value = None
+        self.mock_cache_handler.get_role_agent.return_value = None
 
-        # Create a proper exception class that inherits from BaseException
         does_not_exist_exception = type("DoesNotExist", (Exception,), {})
         mock_integrated_agent_cls.DoesNotExist = does_not_exist_exception
-
-        # Both calls (official agent and parent_agent_uuid search) raise DoesNotExist
         mock_integrated_agent_cls.objects.get.side_effect = [
-            does_not_exist_exception(),  # Official agent not found
-            does_not_exist_exception(),  # Agent with parent_agent_uuid not found
+            does_not_exist_exception(),
+            does_not_exist_exception(),
         ]
 
         result = self.usecase.get_integrated_agent_if_exists(self.mock_project)
 
         self.assertIsNone(result)
-        # Should be called twice: once for official agent, once for parent_agent_uuid search
         self.assertEqual(mock_integrated_agent_cls.objects.get.call_count, 2)
+        self.mock_cache_handler.set_role_agent.assert_not_called()
 
-        # Verify the first call was for official agent
         first_call_args = mock_integrated_agent_cls.objects.get.call_args_list[0]
         self.assertEqual(first_call_args[1]["agent__uuid"], "test-agent-uuid")
         self.assertEqual(first_call_args[1]["project"], self.mock_project)
         self.assertEqual(first_call_args[1]["is_active"], True)
 
-        # Verify the second call was for parent_agent_uuid search
         second_call_args = mock_integrated_agent_cls.objects.get.call_args_list[1]
         self.assertEqual(second_call_args[1]["parent_agent_uuid__isnull"], False)
         self.assertEqual(second_call_args[1]["project"], self.mock_project)
         self.assertEqual(second_call_args[1]["is_active"], True)
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
-    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.IntegratedAgent")
     def test_get_integrated_agent_if_exists_finds_agent_with_parent_agent_uuid(
-        self, mock_integrated_agent_cls, mock_cache, mock_settings
+        self, mock_integrated_agent_cls, mock_settings
     ):
         mock_settings.ORDER_STATUS_AGENT_UUID = "test-agent-uuid"
-        mock_cache.get.return_value = None
+        self.mock_cache_handler.get_role_agent.return_value = None
 
-        # Mock official agent not found
         does_not_exist_exception = type("DoesNotExist", (Exception,), {})
         mock_integrated_agent_cls.DoesNotExist = does_not_exist_exception
 
-        # First call (official agent) raises DoesNotExist
-        # Second call (agent with parent_agent_uuid) returns a mock agent
         mock_agent_with_parent = MagicMock()
         mock_agent_with_parent.parent_agent_uuid = "parent-uuid-123"
         mock_integrated_agent_cls.objects.get.side_effect = [
-            does_not_exist_exception(),  # Official agent not found
-            mock_agent_with_parent,  # Agent with parent_agent_uuid found
+            does_not_exist_exception(),
+            mock_agent_with_parent,
         ]
 
         result = self.usecase.get_integrated_agent_if_exists(self.mock_project)
 
         self.assertEqual(result, mock_agent_with_parent)
-        # Should be called twice: once for official agent, once for agent with parent_agent_uuid
         self.assertEqual(mock_integrated_agent_cls.objects.get.call_count, 2)
+        self.mock_cache_handler.set_role_agent.assert_called_once_with(
+            mock_agent_with_parent, AgentRole.ORDER_STATUS
+        )
 
-        # Verify the second call was for parent_agent_uuid__isnull=False
         second_call_args = mock_integrated_agent_cls.objects.get.call_args_list[1]
         self.assertEqual(second_call_args[1]["parent_agent_uuid__isnull"], False)
         self.assertEqual(second_call_args[1]["project"], self.mock_project)
         self.assertEqual(second_call_args[1]["is_active"], True)
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
-    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.IntegratedAgent")
     def test_get_integrated_agent_if_exists_raises_error_on_multiple_parent_agents(
-        self, mock_integrated_agent_cls, mock_cache, mock_settings
+        self, mock_integrated_agent_cls, mock_settings
     ):
         mock_settings.ORDER_STATUS_AGENT_UUID = "test-agent-uuid"
-        mock_cache.get.return_value = None
+        self.mock_cache_handler.get_role_agent.return_value = None
 
-        # Mock official agent not found
         does_not_exist_exception = type("DoesNotExist", (Exception,), {})
         multiple_objects_exception = type("MultipleObjectsReturned", (Exception,), {})
         mock_integrated_agent_cls.DoesNotExist = does_not_exist_exception
         mock_integrated_agent_cls.MultipleObjectsReturned = multiple_objects_exception
-
-        # First call (official agent) raises DoesNotExist
-        # Second call (agents with parent_agent_uuid) raises MultipleObjectsReturned
         mock_integrated_agent_cls.objects.get.side_effect = [
-            does_not_exist_exception(),  # Official agent not found
-            multiple_objects_exception(),  # Multiple agents with parent_agent_uuid found
+            does_not_exist_exception(),
+            multiple_objects_exception(),
         ]
 
         with self.assertRaises(ValidationError) as context:
@@ -165,7 +150,6 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
             context.exception.detail["error"],
             "Multiple agents with parent_agent_uuid found for this project",
         )
-        # The code is stored in the ErrorDetail object within detail
         self.assertEqual(
             context.exception.detail["error"].code, "multiple_parent_agents"
         )
@@ -177,6 +161,7 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
         result = self.usecase.get_integrated_agent_if_exists(self.mock_project)
 
         self.assertIsNone(result)
+        self.mock_cache_handler.get_role_agent.assert_not_called()
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.Project")

--- a/retail/webhooks/vtex/usecases/cart.py
+++ b/retail/webhooks/vtex/usecases/cart.py
@@ -10,8 +10,6 @@ from retail.vtex.models import Cart
 from retail.vtex.tasks import task_abandoned_cart_update
 from django_redis import get_redis_connection
 
-from django.conf import settings
-
 from retail.webhooks.vtex.services import (
     CartTimeRestrictionService,
     CartPhoneRestrictionService,
@@ -20,6 +18,7 @@ from retail.webhooks.vtex.services import (
 from retail.agents.domains.agent_webhook.usecases.base_agent_webhook import (
     BaseAgentWebhookUseCase,
 )
+from retail.agents.shared.cache import AgentRole
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 
 
@@ -55,13 +54,8 @@ class CartUseCase(BaseAgentWebhookUseCase):
         if not self.project:
             return None
 
-        if not settings.ABANDONED_CART_AGENT_UUID:
-            logger.info("ABANDONED_CART_AGENT_UUID is not set in settings.")
-            return None
-
-        # Base method already logs when agent is not found
         return self.get_integrated_agent_if_exists(
-            self.project, settings.ABANDONED_CART_AGENT_UUID
+            self.project, AgentRole.ABANDONED_CART
         )
 
     def _get_project_by_account(self) -> Optional[Project]:


### PR DESCRIPTION
## What
Centralizes every cache key derived from `IntegratedAgent` into the
`IntegratedAgentCacheHandler`. Adds a role-based cache layer
(`<role>_agent_<project_uuid>`) and a single `invalidate_all_for`
entry point that all use cases call when an agent changes. Resolves
the existing TODO in `update.py`:
> Refactor cache clearing logic - currently we have 3 separate cache
> keys (webhook, order_status, abandoned_cart) that should be
> centralized in IntegratedAgentCacheHandler.clear_all_agent_caches()
> method.


## Why
Cache invalidation logic for `IntegratedAgent` was duplicated across
`update.py`, `unassign.py`, `update_template_strategies.py` and
`projects/models.py`. Adding a new role (e.g. payment recovery)
required duplicating the per-role check in each file. The handler now
owns the topology, so adding a role is a one-line change in the
`AgentRole` enum.
The refactor also fixes a latent bug: the
`agent_active_<vtex_account>_<role>` cache from
`CheckAgentActiveUseCase` had no explicit invalidation, leaving the
public agent-active endpoint stale for up to 60s after assign/
unassign/update. It is now invalidated alongside the other keys.