### PR TITLE
chore: Standardize order status and webhook logs for Loki filtering

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/delivered_order_tracking.py
+++ b/retail/agents/domains/agent_integration/usecases/delivered_order_tracking.py
@@ -293,17 +293,21 @@ class DeliveredOrderTrackingWebhookUseCase:
         Returns:
             Dict containing processing result
         """
+        vtex_account = integrated_agent.project.vtex_account
+        agent_uuid = integrated_agent.uuid
+
         try:
-            # Validate tracking is enabled
             self.validate_tracking_enabled(integrated_agent)
 
-            # Log the received data
             logger.info(
-                f"Received VTEX delivered order tracking webhook for agent {integrated_agent.uuid}: {webhook_data}"
+                f"[DELIVERED_TRACKING] received: "
+                f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+                f"data={webhook_data}"
             )
 
-            # Process the notification
-            self._process_delivered_order_notification(integrated_agent, webhook_data)
+            self._process_delivered_order_notification(
+                integrated_agent, webhook_data, vtex_account
+            )
 
             return {
                 "status": "success",
@@ -314,33 +318,46 @@ class DeliveredOrderTrackingWebhookUseCase:
             raise
         except Exception as e:
             logger.exception(
-                f"Error processing delivered order tracking notification for agent {integrated_agent.uuid}: {e}"
+                f"[DELIVERED_TRACKING] processing_failed: "
+                f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+                f"data={webhook_data} error={e}"
             )
             raise
 
     def _process_delivered_order_notification(
-        self, integrated_agent: IntegratedAgent, webhook_data: Dict[str, Any]
+        self,
+        integrated_agent: IntegratedAgent,
+        webhook_data: Dict[str, Any],
+        vtex_account: str,
     ) -> None:
         """
-        Process the delivered order tracking notification from VTEX.
+        Build an OrderStatusDTO with ``currentState="delivered"``
+        and delegate to AgentOrderStatusUpdateUsecase.
+
+        The raw VTEX state is stored as ``lastState`` while
+        ``currentState`` is hardcoded because this hook only fires
+        for orders confirmed as delivered.
 
         Args:
-            integrated_agent: The integrated agent instance
-            webhook_data: Data received from VTEX webhook
+            integrated_agent: The integrated agent instance.
+            webhook_data: Data received from VTEX webhook.
+            vtex_account: The VTEX account identifier for the project.
         """
+        agent_uuid = integrated_agent.uuid
+        order_id = webhook_data.get("OrderId")
+
         try:
             logger.info(
-                f"Processing delivered order tracking notification for agent {integrated_agent.uuid}"
+                f"[DELIVERED_TRACKING] converting_state: "
+                f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+                f"mapped_state=delivered data={webhook_data}"
             )
-
-            # Get VTEX account from integrated agent's project
-            vtex_account = integrated_agent.project.vtex_account
 
             # Create OrderStatusDTO with "delivered" status
             order_status_dto = OrderStatusDTO(
                 recorder={},
                 domain="OrdersDocumentUpdated",
-                orderId=webhook_data.get("OrderId"),
+                orderId=order_id,
                 currentState="delivered",  # Force delivered status
                 lastState=webhook_data.get("State"),  # Original state
                 currentChangeDate=webhook_data.get("CurrentChange"),
@@ -348,20 +365,21 @@ class DeliveredOrderTrackingWebhookUseCase:
                 vtexAccount=vtex_account,
             )
 
-            logger.info(
-                f"Created OrderStatusDTO for delivered order: {order_status_dto.orderId} - {order_status_dto}"
-            )
-
             # Use AgentOrderStatusUpdateUsecase to update order status
             order_status_usecase = AgentOrderStatusUpdateUsecase()
             order_status_usecase.execute(integrated_agent, order_status_dto)
 
             logger.info(
-                f"Successfully processed delivered order notification for agent {integrated_agent.uuid}"
+                f"[DELIVERED_TRACKING] completed: "
+                f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+                f"current_state=delivered order_id={order_id} "
+                f"data={webhook_data}"
             )
 
         except Exception as e:
             logger.exception(
-                f"Error processing delivered order tracking notification: {e}"
+                f"[DELIVERED_TRACKING] notification_failed: "
+                f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+                f"order_id={order_id} error={e}"
             )
             raise

--- a/retail/agents/domains/agent_integration/usecases/payment_recovery.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery.py
@@ -20,6 +20,18 @@ class PaymentRecoveryWebhookUseCase:
     """Use case for processing payment recovery webhook notifications from VTEX."""
 
     def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
+        """
+        Retrieve an integrated agent by UUID.
+
+        Args:
+            integrated_agent_uuid: UUID of the integrated agent.
+
+        Returns:
+            IntegratedAgent: The matching integrated agent instance.
+
+        Raises:
+            NotFound: If no integrated agent exists with the given UUID.
+        """
         try:
             return IntegratedAgent.objects.get(uuid=integrated_agent_uuid)
         except IntegratedAgent.DoesNotExist:
@@ -45,6 +57,15 @@ class PaymentRecoveryWebhookUseCase:
     def validate_payment_recovery_enabled(
         self, integrated_agent: IntegratedAgent
     ) -> None:
+        """
+        Validate that payment recovery is enabled for the integrated agent.
+
+        Args:
+            integrated_agent: The integrated agent to validate.
+
+        Raises:
+            ValidationError: If payment recovery hook is not configured.
+        """
         payment_config = integrated_agent.config.get("payment_recovery", {})
         if not payment_config.get("hook_created", False):
             raise ValidationError("Payment recovery hook not configured")
@@ -58,15 +79,28 @@ class PaymentRecoveryWebhookUseCase:
         Validates that payment recovery is enabled, builds an OrderStatusDTO
         and delegates to AgentOrderStatusUpdateUsecase — same pattern as
         DeliveredOrderTrackingWebhookUseCase.
+
+        Args:
+            integrated_agent: The integrated agent that owns the webhook.
+            webhook_data: Raw data received from the VTEX webhook.
+
+        Returns:
+            Dict[str, str]: A dict with ``status`` and ``message`` keys.
         """
+        vtex_account = integrated_agent.project.vtex_account
+        agent_uuid = integrated_agent.uuid
+
         self.validate_payment_recovery_enabled(integrated_agent)
 
         logger.info(
-            f"[PaymentRecovery] Processing webhook notification - "
-            f"agent={integrated_agent.uuid} data={webhook_data}"
+            f"[PAYMENT_RECOVERY] received: "
+            f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+            f"data={webhook_data}"
         )
 
-        self._process_payment_recovery_notification(integrated_agent, webhook_data)
+        self._process_payment_recovery_notification(
+            integrated_agent, webhook_data, vtex_account
+        )
 
         return {
             "status": "success",
@@ -74,14 +108,37 @@ class PaymentRecoveryWebhookUseCase:
         }
 
     def _process_payment_recovery_notification(
-        self, integrated_agent: IntegratedAgent, webhook_data: Dict[str, Any]
+        self,
+        integrated_agent: IntegratedAgent,
+        webhook_data: Dict[str, Any],
+        vtex_account: str,
     ) -> None:
-        vtex_account = integrated_agent.project.vtex_account
+        """
+        Build an OrderStatusDTO with ``currentState="payment-pending"``
+        and delegate to AgentOrderStatusUpdateUsecase.
+
+        The raw VTEX state (often ``"unknow"``) is stored as ``lastState``
+        while ``currentState`` is hardcoded because the payment recovery
+        hook only fires for orders awaiting payment.
+
+        Args:
+            integrated_agent: The integrated agent that owns the webhook.
+            webhook_data: Raw data received from the VTEX webhook.
+            vtex_account: The VTEX account identifier for the project.
+        """
+        agent_uuid = integrated_agent.uuid
+        order_id = webhook_data.get("OrderId")
+
+        logger.info(
+            f"[PAYMENT_RECOVERY] converting_state: "
+            f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+            f"mapped_state=payment-pending data={webhook_data}"
+        )
 
         order_status_dto = OrderStatusDTO(
             recorder={},
             domain="OrdersDocumentUpdated",
-            orderId=webhook_data.get("OrderId"),
+            orderId=order_id,
             currentState="payment-pending",
             lastState=webhook_data.get("State"),
             currentChangeDate=webhook_data.get("CurrentChange"),
@@ -89,15 +146,11 @@ class PaymentRecoveryWebhookUseCase:
             vtexAccount=vtex_account,
         )
 
-        logger.info(
-            f"[PaymentRecovery] OrderStatusDTO built - "
-            f"agent={integrated_agent.uuid} order_id={order_status_dto.orderId}"
-        )
-
         order_status_usecase = AgentOrderStatusUpdateUsecase()
         order_status_usecase.execute(integrated_agent, order_status_dto)
 
         logger.info(
-            f"[PaymentRecovery] Webhook processed successfully - "
-            f"agent={integrated_agent.uuid} order_id={order_status_dto.orderId}"
+            f"[PAYMENT_RECOVERY] completed: "
+            f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+            f"current_state=payment-pending order_id={order_id}"
         )

--- a/retail/agents/domains/agent_webhook/usecases/order_status.py
+++ b/retail/agents/domains/agent_webhook/usecases/order_status.py
@@ -70,7 +70,10 @@ class AgentOrderStatusUpdateUsecase:
             Optional[IntegratedAgent]: The integrated agent if found, otherwise None.
         """
         if not settings.ORDER_STATUS_AGENT_UUID:
-            logger.warning("ORDER_STATUS_AGENT_UUID is not set in settings.")
+            logger.warning(
+                f"[ORDER_STATUS] agent_uuid_not_set: "
+                f"vtex_account={project.vtex_account} project_uuid={project.uuid}"
+            )
             return None
 
         cached = self.cache_handler.get_role_agent(project.uuid, AgentRole.ORDER_STATUS)
@@ -100,13 +103,16 @@ class AgentOrderStatusUpdateUsecase:
                 is_active=True,
             )
             logger.info(
-                f"Found official integrated agent for ORDER_STATUS_AGENT_UUID: {settings.ORDER_STATUS_AGENT_UUID}"
+                f"[ORDER_STATUS] agent_resolved: "
+                f"vtex_account={project.vtex_account} "
+                f"agent_uuid={integrated_agent.uuid} source=official"
             )
             return integrated_agent
         except IntegratedAgent.DoesNotExist:
             logger.info(
-                f"No official integrated agent found for ORDER_STATUS_AGENT_UUID: {settings.ORDER_STATUS_AGENT_UUID}. "
-                f"Looking for agents with parent_agent_uuid filled..."
+                f"[ORDER_STATUS] official_agent_not_found: "
+                f"vtex_account={project.vtex_account} "
+                f"project_uuid={project.uuid}"
             )
 
             try:
@@ -116,18 +122,25 @@ class AgentOrderStatusUpdateUsecase:
                     is_active=True,
                 )
                 logger.info(
-                    f"Found integrated agent with parent_agent_uuid: {integrated_agent.parent_agent_uuid}"
+                    f"[ORDER_STATUS] agent_resolved: "
+                    f"vtex_account={project.vtex_account} "
+                    f"agent_uuid={integrated_agent.uuid} "
+                    f"source=parent_agent "
+                    f"parent_uuid={integrated_agent.parent_agent_uuid}"
                 )
                 return integrated_agent
             except IntegratedAgent.DoesNotExist:
                 logger.info(
-                    f"No integrated agent found (official or with parent_agent_uuid) for project {project.uuid}"
+                    f"[ORDER_STATUS] no_agent_found: "
+                    f"vtex_account={project.vtex_account} "
+                    f"project_uuid={project.uuid}"
                 )
                 return None
             except IntegratedAgent.MultipleObjectsReturned:
                 logger.error(
-                    f"Multiple agents found with parent_agent_uuid for project {project.uuid}. "
-                    f"This should not happen - only one agent per project should have parent_agent_uuid."
+                    f"[ORDER_STATUS] multiple_parent_agents: "
+                    f"vtex_account={project.vtex_account} "
+                    f"project_uuid={project.uuid}"
                 )
                 raise ValidationError(
                     {
@@ -154,11 +167,13 @@ class AgentOrderStatusUpdateUsecase:
             cache.set(cache_key, project, timeout=43200)  # 12 hours
             return project
         except Project.DoesNotExist:
-            logger.info(f"Project not found for VTEX account {vtex_account}.")
+            logger.info(
+                f"[ORDER_STATUS] project_not_found: vtex_account={vtex_account}"
+            )
             return None
         except Project.MultipleObjectsReturned:
             logger.error(
-                f"Multiple projects found for VTEX account {vtex_account}.",
+                f"[ORDER_STATUS] multiple_projects: vtex_account={vtex_account}",
                 exc_info=True,
             )
             return None
@@ -198,25 +213,28 @@ class AgentOrderStatusUpdateUsecase:
     def execute(
         self, integrated_agent: IntegratedAgent, order_status_dto: OrderStatusDTO
     ) -> None:
+        vtex_account = order_status_dto.vtexAccount
+        current_state = order_status_dto.currentState
+        order_id = order_status_dto.orderId
+        agent_uuid = integrated_agent.uuid
+
         if self._is_duplicate_event(integrated_agent, order_status_dto):
             logger.info(
-                f"Skipping duplicate order status event within dedup window. "
-                f"agent={integrated_agent.uuid} "
-                f"order_id={order_status_dto.orderId} "
-                f"current_state={order_status_dto.currentState} "
-                f"vtex_account={order_status_dto.vtexAccount}"
+                f"[ORDER_STATUS] duplicate_skipped: "
+                f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+                f"current_state={current_state} order_id={order_id}"
             )
             return
 
         logger.info(
-            f"Starting execution for integrated agent: {integrated_agent.uuid} "
-            f"and order ID: {order_status_dto.orderId}"
+            f"[ORDER_STATUS] executing: "
+            f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+            f"current_state={current_state} order_id={order_id}"
         )
 
         webhook_payload: Dict[str, Any] = adapt_order_status_to_webhook_payload(
             order_status_dto
         )
-        logger.info(f"Adapted order status to webhook payload: {webhook_payload}")
 
         request_data = RequestData(
             params={},
@@ -231,6 +249,7 @@ class AgentOrderStatusUpdateUsecase:
 
         agent_webhook_use_case.execute(integrated_agent, request_data)
         logger.info(
-            f"Execution completed for integrated agent: {integrated_agent.uuid} "
-            f"and order ID: {order_status_dto.orderId}"
+            f"[ORDER_STATUS] executed: "
+            f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+            f"current_state={current_state} order_id={order_id}"
         )

--- a/retail/agents/tasks.py
+++ b/retail/agents/tasks.py
@@ -27,27 +27,29 @@ def task_delivered_order_tracking_webhook(
     """
     try:
         logger.info(
-            f"Processing delivered order tracking webhook task for agent {integrated_agent_uuid}"
+            f"[DELIVERED_TRACKING] task_started: "
+            f"agent_uuid={integrated_agent_uuid} data={webhook_data}"
         )
 
-        # Initialize use case
         webhook_use_case = DeliveredOrderTrackingWebhookUseCase()
-
-        # Get integrated agent
         integrated_agent = webhook_use_case.get_integrated_agent(integrated_agent_uuid)
+        vtex_account = integrated_agent.project.vtex_account
 
-        # Process webhook notification
         result = webhook_use_case.process_webhook_notification(
             integrated_agent, webhook_data
         )
 
         logger.info(
-            f"Successfully processed delivered order tracking webhook for agent {integrated_agent_uuid}: {result}"
+            f"[DELIVERED_TRACKING] task_completed: "
+            f"vtex_account={vtex_account} agent_uuid={integrated_agent_uuid} "
+            f"result={result} data={webhook_data}"
         )
 
     except Exception as e:
         logger.exception(
-            f"Error processing delivered order tracking webhook task for agent {integrated_agent_uuid}: {e}"
+            f"[DELIVERED_TRACKING] task_failed: "
+            f"agent_uuid={integrated_agent_uuid} "
+            f"data={webhook_data} error={e}"
         )
 
 
@@ -63,18 +65,26 @@ def task_payment_recovery_webhook(
         webhook_data: Data received from VTEX webhook
     """
     try:
-        logger.info(f"[PaymentRecovery] Task started - agent={integrated_agent_uuid}")
+        logger.info(
+            f"[PAYMENT_RECOVERY] task_started: "
+            f"agent_uuid={integrated_agent_uuid} data={webhook_data}"
+        )
 
         use_case = PaymentRecoveryWebhookUseCase()
         integrated_agent = use_case.get_integrated_agent(integrated_agent_uuid)
+        vtex_account = integrated_agent.project.vtex_account
+
         result = use_case.process_webhook_notification(integrated_agent, webhook_data)
 
         logger.info(
-            f"[PaymentRecovery] Task completed successfully - "
-            f"agent={integrated_agent_uuid} result={result}"
+            f"[PAYMENT_RECOVERY] task_completed: "
+            f"vtex_account={vtex_account} agent_uuid={integrated_agent_uuid} "
+            f"result={result} data={webhook_data}"
         )
 
     except Exception as e:
         logger.exception(
-            f"[PaymentRecovery] Task failed - agent={integrated_agent_uuid}: {e}"
+            f"[PAYMENT_RECOVERY] task_failed: "
+            f"agent_uuid={integrated_agent_uuid} "
+            f"data={webhook_data} error={e}"
         )

--- a/retail/broadcasts/usecases/handle_status_update.py
+++ b/retail/broadcasts/usecases/handle_status_update.py
@@ -77,12 +77,13 @@ class HandleStatusUpdateUseCase:
     def link_send_event(self, event: BroadcastStatusEvent) -> None:
         """Public entry point for the template-send routing key.
 
-        The send event MUST carry a broadcast_id; missing it indicates a
-        contract drift on the courier side and is logged as ERROR so the
-        anomaly is surfaced (the row cannot be linked without it).
+        Events without a ``broadcast_id`` are non-broadcast templates
+        (NPS, pickup notifications, etc.) flowing through the same
+        courier topic. They are discarded silently since there is no
+        BroadcastMessage row to link.
         """
         if event.broadcast_id is None:
-            logger.error(
+            logger.debug(
                 f"[BROADCAST_TRACKING] send_event_missing_broadcast_id: "
                 f"message_id={event.message_id} payload={event.payload}"
             )

--- a/retail/vtex/tasks.py
+++ b/retail/vtex/tasks.py
@@ -106,33 +106,42 @@ def task_order_status_update(order_update_data: dict):
     """
     try:
         order_status_dto = OrderStatusDTO(**order_update_data)
+        vtex_account = order_status_dto.vtexAccount
+        order_id = order_status_dto.orderId
+        current_state = order_status_dto.currentState
+
+        logger.info(
+            f"[ORDER_STATUS] received: "
+            f"vtex_account={vtex_account} data={order_update_data}"
+        )
 
         use_case = AgentOrderStatusUpdateUsecase()
-        project = use_case.get_project_by_vtex_account(order_status_dto.vtexAccount)
+        project = use_case.get_project_by_vtex_account(vtex_account)
         if not project:
             logger.info(
-                f"Project not found for VTEX account {order_status_dto.vtexAccount}."
+                f"[ORDER_STATUS] project_not_found: vtex_account={vtex_account}"
             )
             return
 
-        if is_payment_approved(order_status_dto.currentState):
+        if is_payment_approved(current_state):
             logger.info(
-                f"Processing purchase event for order ID: {order_status_dto.orderId} "
-                f"VTEX account: {order_status_dto.vtexAccount}"
+                f"[ORDER_STATUS] dispatching_purchase_event: "
+                f"vtex_account={vtex_account} current_state={current_state} "
+                f"order_id={order_id}"
             )
             handle_purchase_event_task.apply_async(
-                args=[order_status_dto.orderId, str(project.uuid)],
+                args=[order_id, str(project.uuid)],
                 queue="vtex-io-orders-update-events",
             )
 
-        if _is_purchase_confirmed(order_status_dto.currentState):
+        if _is_purchase_confirmed(current_state):
             logger.info(
                 f"[CONVERSION_TRACKING] dispatching_conversion_check: "
-                f"order_id={order_status_dto.orderId} "
-                f"vtex_account={order_status_dto.vtexAccount}"
+                f"vtex_account={vtex_account} current_state={current_state} "
+                f"order_id={order_id}"
             )
             task_mark_broadcast_converted.apply_async(
-                args=[order_status_dto.orderId, str(project.uuid)],
+                args=[order_id, str(project.uuid)],
                 queue="vtex-io-orders-update-events",
             )
 
@@ -140,28 +149,31 @@ def task_order_status_update(order_update_data: dict):
 
         if integrated_agent:
             logger.info(
-                f"Processing order status with integrated agent. "
-                f"VTEX Account: {order_status_dto.vtexAccount}, "
-                f"Integrated Agent: {integrated_agent.uuid}, DTO: {order_update_data}"
+                f"[ORDER_STATUS] processing_with_agent: "
+                f"vtex_account={vtex_account} current_state={current_state} "
+                f"order_id={order_id} agent_uuid={integrated_agent.uuid}"
             )
             use_case.execute(integrated_agent, order_status_dto)
         else:
             logger.info(
-                f"Processing order status with legacy use case. "
-                f"VTEX Account: {order_status_dto.vtexAccount}, DTO: {order_update_data}"
+                f"[ORDER_STATUS] processing_with_legacy: "
+                f"vtex_account={vtex_account} current_state={current_state} "
+                f"order_id={order_id}"
             )
             legacy_use_case = OrderStatusUseCase(order_status_dto)
             legacy_use_case.process_notification(project)
 
         logger.info(
-            f"Successfully processed order update for order ID: {order_update_data.get('orderId')} "
-            f"VTEX account: {order_status_dto.vtexAccount}"
+            f"[ORDER_STATUS] completed: "
+            f"vtex_account={vtex_account} current_state={current_state} "
+            f"order_id={order_id}"
         )
     except ValidationError:
         pass
     except Exception as e:
         logger.error(
-            f"Unexpected error processing order update: {str(e)}", exc_info=True
+            f"[ORDER_STATUS] unexpected_error: " f"data={order_update_data} error={e}",
+            exc_info=True,
         )
 
 


### PR DESCRIPTION
## What
Standardizes log messages across order status, payment recovery, and
delivered order tracking flows using a structured `key=value` format
with consistent tag prefixes (`[ORDER_STATUS]`, `[PAYMENT_RECOVERY]`,
`[DELIVERED_TRACKING]`, `[CONVERSION_TRACKING]`). Adds missing
docstrings to payment recovery use case methods.

## Why
Current logs mix free-text with variable values, making it impossible
to filter by `vtex_account`, `current_state`, or `order_id` in Loki.
This is blocking investigation of missing conversion events for
specific VTEX accounts. With structured logs, operators can query
combinations like `[ORDER_STATUS] received` + `vtex_account=example`
to confirm whether a hook is configured and which states are arriving.