### PR TITLE
fix: handle null buttons metadata when assigning library templates

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -289,7 +289,9 @@ class AssignAgentUseCase:
 
             template, version = create_library_use_case.execute(data)
 
-            buttons = metadata.get("buttons", [])
+            # `or []` covers both missing key and explicit `None` (some Meta
+            # library specs include `"buttons": null` for templates without buttons).
+            buttons = metadata.get("buttons") or []
             has_url_button = any(button.get("type") == "URL" for button in buttons)
 
             if has_url_button:

--- a/retail/agents/tests/usecases/test_assign_agent.py
+++ b/retail/agents/tests/usecases/test_assign_agent.py
@@ -428,6 +428,69 @@ class AssignAgentUseCaseTest(TestCase):
         mock_use_case_instance.execute.assert_called_once()
         mock_use_case_instance.notify_integrations.assert_called_once()
 
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateLibraryTemplateUseCase"
+    )
+    def test_create_templates_with_null_buttons_notifies_integrations(
+        self, mock_create_library_use_case
+    ):
+        """Regression: some Meta library specs ship `"buttons": null` instead of
+        omitting the key. The use case must treat that as "no buttons" and not
+        crash trying to iterate over `None`."""
+        mock_integrations_service = MagicMock()
+        mock_integrations_service.fetch_templates_from_user.return_value = {}
+        use_case = AssignAgentUseCase(
+            integrations_service=mock_integrations_service,
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+
+        integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid.uuid4(),
+            is_active=True,
+        )
+
+        pre_approved = MagicMock()
+        pre_approved.is_valid = True
+        pre_approved.metadata = {
+            "name": "Order Invoiced",
+            "category": "UTILITY",
+            "language": "pt_BR",
+            "buttons": None,
+        }
+        pre_approved.start_condition = "test_condition"
+        pre_approved.slug = "order-invoiced"
+        pre_approved.config = {}
+
+        pre_approveds = MagicMock()
+        filtered_queryset = MagicMock()
+        filtered_queryset.filter.side_effect = lambda is_valid: (
+            [pre_approved] if is_valid else []
+        )
+        pre_approveds.exclude.return_value = filtered_queryset
+
+        mock_template = MagicMock()
+        mock_template.needs_button_edit = False
+        mock_version = MagicMock()
+        mock_version.template_name = "Order Invoiced"
+        mock_version.uuid = uuid.uuid4()
+
+        mock_use_case_instance = mock_create_library_use_case.return_value
+        mock_use_case_instance.execute.return_value = (mock_template, mock_version)
+
+        use_case._create_templates(
+            integrated_agent=integrated_agent,
+            pre_approveds=pre_approveds,
+            project_uuid=self.project.uuid,
+            app_uuid=uuid.uuid4(),
+            ignore_templates=[],
+        )
+
+        mock_use_case_instance.execute.assert_called_once()
+        mock_use_case_instance.notify_integrations.assert_called_once()
+        self.assertFalse(mock_template.needs_button_edit)
+
     def test_get_ignore_templates(self):
         template1 = PreApprovedTemplate.objects.create(
             agent=self.agent,


### PR DESCRIPTION
## What
Treat `metadata["buttons"] = None` as "no buttons" inside `AssignAgentUseCase._create_library_templates`, by replacing `metadata.get("buttons", [])` with `metadata.get("buttons") or []`. Adds a regression test that reproduces the Sentry crash with `"buttons": null` in the pre-approved template metadata.

## Why
Some Meta library specs (e.g. `order_update_no_cta_*`, `order_management_no_cta_*` used by the `active_order_status` agent) ship templates without buttons, which `ValidatePreApprovedTemplatesUseCase` persists as `metadata["buttons"] = null`. The previous default `[]` only kicked in when the key was missing, so when the key was present with `None`, the subsequent `any(button.get("type") == "URL" for button in buttons)` raised `TypeError: 'NoneType' object is not iterable`. The transactional `execute()` then rolled back the entire assignment, blocking customers (e.g. Diadora) from installing the order-status agent. This is a regression introduced by PR #429 (`fix/needs-button-edit-only-url-type`), which switched the original truthy check (`if not metadata.get("buttons")`) to iteration without considering the `None` case already produced by the validator.