### PR TITLE
feat: Support multi-agent OR check on agent-active endpoint

### DIFF
--- a/retail/api/vtex_projects/serializers.py
+++ b/retail/api/vtex_projects/serializers.py
@@ -1,8 +1,19 @@
 from rest_framework import serializers
 
 
-ALLOWED_AGENT_TYPES = ("abandoned_cart", "order_status")
+ALLOWED_AGENT_TYPES = ("abandoned_cart", "order_status", "payment_recovery")
 
 
 class AgentActiveQuerySerializer(serializers.Serializer):
-    agent = serializers.ChoiceField(choices=ALLOWED_AGENT_TYPES)
+    """Validates the ``agent`` query param, single or repeated.
+
+    Accepts the param once (``?agent=order_status``) or repeated
+    (``?agent=order_status&agent=payment_recovery``). The deserialized
+    value is always a list of valid agent types and the endpoint
+    answers with OR semantics across the list.
+    """
+
+    agent = serializers.ListField(
+        child=serializers.ChoiceField(choices=ALLOWED_AGENT_TYPES),
+        min_length=1,
+    )

--- a/retail/api/vtex_projects/tests/test_check_agent_active.py
+++ b/retail/api/vtex_projects/tests/test_check_agent_active.py
@@ -62,6 +62,72 @@ class CheckAgentActiveUseCaseTest(TestCase):
     )
     @patch("retail.api.vtex_projects.usecases.check_agent_active.Project.objects")
     @patch("retail.api.vtex_projects.usecases.check_agent_active.settings")
+    def test_returns_true_when_payment_recovery_agent_active(
+        self, mock_settings, mock_project_qs, mock_ia_qs
+    ):
+        mock_settings.PAYMENT_RECOVERY_AGENT_UUID = "ghi-789"
+        mock_project_qs.get.return_value = self.project
+        mock_ia_qs.filter.return_value.exists.return_value = True
+
+        result = self.use_case.execute(self.vtex_account, "payment_recovery")
+
+        self.assertTrue(result)
+        mock_ia_qs.filter.assert_called_once_with(
+            agent__uuid="ghi-789",
+            project=self.project,
+            is_active=True,
+        )
+
+    @patch(
+        "retail.api.vtex_projects.usecases.check_agent_active.IntegratedFeature.objects"
+    )
+    @patch(
+        "retail.api.vtex_projects.usecases.check_agent_active.IntegratedAgent.objects"
+    )
+    @patch("retail.api.vtex_projects.usecases.check_agent_active.Project.objects")
+    @patch("retail.api.vtex_projects.usecases.check_agent_active.settings")
+    def test_returns_false_for_payment_recovery_no_agent_no_legacy(
+        self, mock_settings, mock_project_qs, mock_ia_qs, mock_if_qs
+    ):
+        mock_settings.PAYMENT_RECOVERY_AGENT_UUID = "ghi-789"
+        mock_project_qs.get.return_value = self.project
+        mock_ia_qs.filter.return_value.exists.return_value = False
+        mock_if_qs.filter.return_value.exists.return_value = False
+
+        result = self.use_case.execute(self.vtex_account, "payment_recovery")
+
+        self.assertFalse(result)
+
+    @patch(
+        "retail.api.vtex_projects.usecases.check_agent_active.IntegratedAgent.objects"
+    )
+    @patch("retail.api.vtex_projects.usecases.check_agent_active.Project.objects")
+    @patch("retail.api.vtex_projects.usecases.check_agent_active.settings")
+    def test_payment_recovery_does_not_check_parent_agent_fallback(
+        self, mock_settings, mock_project_qs, mock_ia_qs
+    ):
+        """``parent_agent_uuid`` fallback is exclusive to ``order_status``.
+
+        Payment recovery has no inheritance model, so the use case must
+        not query ``parent_agent_uuid__isnull=False`` for it.
+        """
+        mock_settings.PAYMENT_RECOVERY_AGENT_UUID = "ghi-789"
+        mock_project_qs.get.return_value = self.project
+        mock_ia_qs.filter.return_value.exists.return_value = False
+
+        self.use_case.execute(self.vtex_account, "payment_recovery")
+
+        mock_ia_qs.filter.assert_called_once_with(
+            agent__uuid="ghi-789",
+            project=self.project,
+            is_active=True,
+        )
+
+    @patch(
+        "retail.api.vtex_projects.usecases.check_agent_active.IntegratedAgent.objects"
+    )
+    @patch("retail.api.vtex_projects.usecases.check_agent_active.Project.objects")
+    @patch("retail.api.vtex_projects.usecases.check_agent_active.settings")
     def test_returns_true_for_custom_order_status_agent_with_parent(
         self, mock_settings, mock_project_qs, mock_ia_qs
     ):
@@ -269,3 +335,76 @@ class CheckAgentActiveUseCaseTest(TestCase):
         result = self.use_case.execute(self.vtex_account, "abandoned_cart")
 
         self.assertFalse(result)
+
+
+@override_settings(**TEST_SETTINGS_OVERRIDES)
+class CheckAgentActiveUseCaseExecuteAnyTest(TestCase):
+    """Covers the OR-semantics variant used by callers that need to ask
+    about multiple agent roles in a single round-trip."""
+
+    def setUp(self):
+        from django.core.cache import cache
+
+        cache.clear()
+        self.use_case = CheckAgentActiveUseCase()
+        self.vtex_account = "teststore"
+
+    def tearDown(self):
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_returns_true_when_first_agent_is_active(self):
+        with patch.object(
+            self.use_case, "execute", side_effect=[True, False]
+        ) as mock_execute:
+            result = self.use_case.execute_any(
+                self.vtex_account, ["order_status", "payment_recovery"]
+            )
+
+        self.assertTrue(result)
+        mock_execute.assert_called_once_with(self.vtex_account, "order_status")
+
+    def test_returns_true_when_only_second_agent_is_active(self):
+        with patch.object(
+            self.use_case, "execute", side_effect=[False, True]
+        ) as mock_execute:
+            result = self.use_case.execute_any(
+                self.vtex_account, ["order_status", "payment_recovery"]
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(mock_execute.call_count, 2)
+
+    def test_returns_false_when_no_agent_is_active(self):
+        with patch.object(
+            self.use_case, "execute", side_effect=[False, False]
+        ) as mock_execute:
+            result = self.use_case.execute_any(
+                self.vtex_account, ["order_status", "payment_recovery"]
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(mock_execute.call_count, 2)
+
+    def test_returns_false_for_empty_list(self):
+        with patch.object(self.use_case, "execute") as mock_execute:
+            result = self.use_case.execute_any(self.vtex_account, [])
+
+        self.assertFalse(result)
+        mock_execute.assert_not_called()
+
+    def test_short_circuits_on_first_truthy_result(self):
+        """``execute_any`` must not query downstream agents once a match
+        is found — this keeps the cache footprint and DB load minimal
+        for the agentic-cx hot path."""
+        with patch.object(
+            self.use_case, "execute", side_effect=[True, Exception("must not run")]
+        ) as mock_execute:
+            result = self.use_case.execute_any(
+                self.vtex_account,
+                ["order_status", "payment_recovery"],
+            )
+
+        self.assertTrue(result)
+        mock_execute.assert_called_once_with(self.vtex_account, "order_status")

--- a/retail/api/vtex_projects/tests/test_views.py
+++ b/retail/api/vtex_projects/tests/test_views.py
@@ -33,7 +33,7 @@ class AgentActiveViewTest(TestCase):
     @_jwt_auth_bypass("teststore")
     @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
     def test_returns_is_active_true(self, mock_use_case_cls, _auth):
-        mock_use_case_cls.return_value.execute.return_value = True
+        mock_use_case_cls.return_value.execute_any.return_value = True
 
         request = self.factory.get(
             f"/api/vtex-projects/{self.vtex_account}/agent-active/",
@@ -47,7 +47,7 @@ class AgentActiveViewTest(TestCase):
     @_jwt_auth_bypass("teststore")
     @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
     def test_returns_is_active_false(self, mock_use_case_cls, _auth):
-        mock_use_case_cls.return_value.execute.return_value = False
+        mock_use_case_cls.return_value.execute_any.return_value = False
 
         request = self.factory.get(
             f"/api/vtex-projects/{self.vtex_account}/agent-active/",
@@ -82,7 +82,7 @@ class AgentActiveViewTest(TestCase):
     @_jwt_auth_bypass("teststore")
     @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
     def test_returns_false_on_use_case_exception(self, mock_use_case_cls, _auth):
-        mock_use_case_cls.return_value.execute.side_effect = Exception("db error")
+        mock_use_case_cls.return_value.execute_any.side_effect = Exception("db error")
 
         request = self.factory.get(
             f"/api/vtex-projects/{self.vtex_account}/agent-active/",
@@ -105,7 +105,7 @@ class AgentActiveViewTest(TestCase):
     @_jwt_auth_bypass("teststore")
     @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
     def test_passes_correct_params_to_use_case(self, mock_use_case_cls, _auth):
-        mock_use_case_cls.return_value.execute.return_value = True
+        mock_use_case_cls.return_value.execute_any.return_value = True
 
         request = self.factory.get(
             f"/api/vtex-projects/{self.vtex_account}/agent-active/",
@@ -113,10 +113,66 @@ class AgentActiveViewTest(TestCase):
         )
         self.view(request, vtex_account=self.vtex_account)
 
-        mock_use_case_cls.return_value.execute.assert_called_once_with(
+        mock_use_case_cls.return_value.execute_any.assert_called_once_with(
             vtex_account=self.vtex_account,
-            agent_type="order_status",
+            agent_types=["order_status"],
         )
+
+    @_jwt_auth_bypass("teststore")
+    @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
+    def test_accepts_payment_recovery_agent_type(self, mock_use_case_cls, _auth):
+        mock_use_case_cls.return_value.execute_any.return_value = True
+
+        request = self.factory.get(
+            f"/api/vtex-projects/{self.vtex_account}/agent-active/",
+            {"agent": "payment_recovery"},
+        )
+        response = self.view(request, vtex_account=self.vtex_account)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["is_active"])
+        mock_use_case_cls.return_value.execute_any.assert_called_once_with(
+            vtex_account=self.vtex_account,
+            agent_types=["payment_recovery"],
+        )
+
+    @_jwt_auth_bypass("teststore")
+    @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
+    def test_accepts_repeated_agent_param_with_or_semantics(
+        self, mock_use_case_cls, _auth
+    ):
+        """``?agent=order_status&agent=payment_recovery`` collapses into a
+        single OR check on the server, so the agentic-cx never pays the
+        cost of two HTTP round-trips."""
+        mock_use_case_cls.return_value.execute_any.return_value = True
+
+        request = self.factory.get(
+            f"/api/vtex-projects/{self.vtex_account}/agent-active/"
+            "?agent=order_status&agent=payment_recovery",
+        )
+        response = self.view(request, vtex_account=self.vtex_account)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["is_active"])
+        mock_use_case_cls.return_value.execute_any.assert_called_once_with(
+            vtex_account=self.vtex_account,
+            agent_types=["order_status", "payment_recovery"],
+        )
+
+    @_jwt_auth_bypass("teststore")
+    @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
+    def test_rejects_repeated_agent_when_any_value_is_invalid(
+        self, mock_use_case_cls, _auth
+    ):
+        request = self.factory.get(
+            f"/api/vtex-projects/{self.vtex_account}/agent-active/"
+            "?agent=order_status&agent=invalid_type",
+        )
+        response = self.view(request, vtex_account=self.vtex_account)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["is_active"])
+        mock_use_case_cls.return_value.execute_any.assert_not_called()
 
 
 class OnboardingCompleteViewTest(TestCase):

--- a/retail/api/vtex_projects/usecases/check_agent_active.py
+++ b/retail/api/vtex_projects/usecases/check_agent_active.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Iterable
 
 from django.conf import settings
 from django.core.cache import cache
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 AGENT_UUID_SETTINGS_MAP = {
     "abandoned_cart": "ABANDONED_CART_AGENT_UUID",
     "order_status": "ORDER_STATUS_AGENT_UUID",
+    "payment_recovery": "PAYMENT_RECOVERY_AGENT_UUID",
 }
 
 CACHE_TIMEOUT = 60
@@ -30,6 +32,19 @@ class CheckAgentActiveUseCase:
         is_active = self._check(vtex_account, agent_type)
         cache.set(cache_key, is_active, timeout=CACHE_TIMEOUT)
         return is_active
+
+    def execute_any(self, vtex_account: str, agent_types: Iterable[str]) -> bool:
+        """Return True if at least one of ``agent_types`` is active.
+
+        Each individual check goes through ``execute`` and therefore
+        reuses its per-role cache (key ``agent_active_<vtex>_<role>``,
+        60s TTL). Iteration short-circuits on the first match, so callers
+        should pass the most likely role first to keep the hot path cheap.
+        """
+        for agent_type in agent_types:
+            if self.execute(vtex_account, agent_type):
+                return True
+        return False
 
     def _check(self, vtex_account: str, agent_type: str) -> bool:
         project = self._get_project(vtex_account)

--- a/retail/api/vtex_projects/views.py
+++ b/retail/api/vtex_projects/views.py
@@ -30,22 +30,23 @@ class AgentActiveView(JWTModuleAuthMixin, APIView):
     """
 
     def get(self, request: Request, vtex_account: str) -> Response:
-        serializer = AgentActiveQuerySerializer(data=request.query_params)
+        data = {"agent": request.query_params.getlist("agent")}
+        serializer = AgentActiveQuerySerializer(data=data)
         if not serializer.is_valid():
             return Response(INACTIVE_RESPONSE, status=status.HTTP_200_OK)
 
-        agent_type = serializer.validated_data["agent"]
+        agent_types = serializer.validated_data["agent"]
 
         try:
             use_case = CheckAgentActiveUseCase()
-            is_active = use_case.execute(
+            is_active = use_case.execute_any(
                 vtex_account=vtex_account,
-                agent_type=agent_type,
+                agent_types=agent_types,
             )
         except Exception:
             logger.exception(
                 f"Unexpected error checking agent active for "
-                f"vtex_account={vtex_account} agent={agent_type}"
+                f"vtex_account={vtex_account} agents={agent_types}"
             )
             return Response(INACTIVE_RESPONSE, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## What
Extend `GET /api/vtex-projects/{vtex_account}/agent-active/` to accept
the `agent` query param **repeated** (e.g. `?agent=order_status&agent=payment_recovery`)
and answer with OR semantics across the list. Also exposes
`payment_recovery` as a valid agent type, completing the trio
`abandoned_cart` / `order_status` / `payment_recovery`. Single-agent
callers keep working unchanged.

## Why
The agentic-cx layer needs to forward order-status webhooks for pix
recovery clients to capture conversions in `mark_broadcast_converted`,
but those clients usually don't have the `order_status` agent active.
Adding a second HTTP call per webhook on the agentic-cx side was a
non-starter — the order-status volume is in the millions per day and
the per-request overhead (even with the 60s server-side cache) would
inflate the request count meaningfully.

Pushing the OR to the server keeps the agentic-cx hot path at one
request per webhook, preserves the per-role cache invalidation (each
agent role still has its own `agent_active_<vtex>_<role>` key, wired
through `IntegratedAgentCacheHandler.clear_agent_active_flag`), and
keeps the endpoint semantics explicit: every consumer still asks "is
any of these roles active?" rather than relying on hidden coupling
between unrelated agents.