### PR TITLE
feat: Refactor onboarding process with pre-crawl channel setup

### DIFF
--- a/retail/projects/tasks.py
+++ b/retail/projects/tasks.py
@@ -7,6 +7,7 @@ from retail.projects.models import ProjectOnboarding
 from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_orchestrator import OnboardingOrchestrator
+from retail.projects.usecases.pre_crawl_channel import PreCrawlChannelUseCase
 from retail.projects.usecases.start_crawl import CrawlerStartError
 from retail.services.vtex_io.service import VtexIOService
 
@@ -15,6 +16,11 @@ logger = logging.getLogger(__name__)
 WAIT_CRAWL_RETRY_COUNTDOWN = 10  # seconds between retries
 WAIT_CRAWL_MAX_RETRIES = 60  # ~10 minutes of waiting
 TASK_LOCK_TIMEOUT = 1800  # 30 min safety timeout
+
+# Progress marker set right before invoking the channel use case so the
+# frontend reflects "project linked, starting channel setup" regardless of
+# whether the project was linked inline (StartSetupUseCase) or async (EDA).
+PROJECT_LINKED_PROGRESS = 30
 
 
 def _lock_key(task_name: str, vtex_account: str) -> str:
@@ -37,19 +43,25 @@ def release_task_lock(task_name: str, vtex_account: str) -> None:
     cache.delete(_lock_key(task_name, vtex_account))
 
 
-@shared_task(
-    bind=True,
-    name="task_wait_and_start_crawl",
-    max_retries=WAIT_CRAWL_MAX_RETRIES,
-)
-def task_wait_and_start_crawl(self, vtex_account: str, crawl_url: str) -> None:
+def _run_setup_channel_and_start_crawl(task, vtex_account: str, crawl_url: str) -> None:
     """
-    Waits for the project to be linked (via EDA), then triggers the crawl.
+    Shared implementation for the pre-crawl pipeline.
 
-    Retries periodically until the project is available or max_retries is reached.
+    Both ``task_setup_channel_and_start_crawl`` (new name) and the
+    legacy alias ``task_wait_and_start_crawl`` delegate here so the
+    same retry/cleanup logic runs regardless of how the task was
+    enqueued.
+
+    Args:
+        task: The bound Celery task instance (provides ``retry`` /
+            ``MaxRetriesExceededError``).
+        vtex_account: VTEX account identifier.
+        crawl_url: Store URL to crawl after channel setup.
     """
     try:
-        onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
+        onboarding = ProjectOnboarding.objects.select_related("project").get(
+            vtex_account=vtex_account,
+        )
     except ProjectOnboarding.DoesNotExist:
         mark_onboarding_failed(vtex_account, "Onboarding record not found")
         raise
@@ -60,23 +72,75 @@ def task_wait_and_start_crawl(self, vtex_account: str, crawl_url: str) -> None:
             f"Retrying in {WAIT_CRAWL_RETRY_COUNTDOWN}s..."
         )
         try:
-            raise self.retry(countdown=WAIT_CRAWL_RETRY_COUNTDOWN)
-        except self.MaxRetriesExceededError:
+            raise task.retry(countdown=WAIT_CRAWL_RETRY_COUNTDOWN)
+        except task.MaxRetriesExceededError:
             mark_onboarding_failed(
                 vtex_account,
                 "Project was never linked: max retries exceeded",
             )
             raise
 
-    logger.info(f"Project linked for vtex_account={vtex_account}. Starting crawl.")
+    logger.info(
+        f"Project linked for vtex_account={vtex_account}. "
+        f"Running pre-crawl channel setup."
+    )
+
+    if (
+        onboarding.current_step != "PROJECT_CONFIG"
+        or onboarding.progress < PROJECT_LINKED_PROGRESS
+    ):
+        onboarding.current_step = "PROJECT_CONFIG"
+        onboarding.progress = PROJECT_LINKED_PROGRESS
+        onboarding.save(update_fields=["current_step", "progress"])
 
     try:
-        InitiateCrawlUseCase().execute(
-            onboarding.project, vtex_account, crawl_url
-        )
+        PreCrawlChannelUseCase().execute(vtex_account)
+    except Exception as exc:
+        mark_onboarding_failed(vtex_account, f"Channel creation failed: {exc}")
+        raise
+
+    try:
+        InitiateCrawlUseCase().execute(onboarding.project, vtex_account, crawl_url)
     except CrawlerStartError as e:
         logger.error(f"Crawl start failed for vtex_account={vtex_account}: {e}")
         raise
+
+
+@shared_task(
+    bind=True,
+    name="task_setup_channel_and_start_crawl",
+    max_retries=WAIT_CRAWL_MAX_RETRIES,
+)
+def task_setup_channel_and_start_crawl(self, vtex_account: str, crawl_url: str) -> None:
+    """
+    Pre-crawl orchestration: wait for project link, create channel, start crawl.
+
+    The Facebook ``auth_code`` from Embedded Signup is short-lived, so the
+    channel must be created (and the code exchanged on the
+    integrations-engine side) before the long-running crawl can expire it.
+
+    Retries while the project is not linked. Once linked, runs the channel
+    use case (resolves wwc or wpp-cloud) and then starts the crawl. If
+    channel creation fails, the onboarding is marked failed and the crawl
+    is not started — the user must redo Embedded Signup.
+    """
+    return _run_setup_channel_and_start_crawl(self, vtex_account, crawl_url)
+
+
+@shared_task(
+    bind=True,
+    name="task_wait_and_start_crawl",
+    max_retries=WAIT_CRAWL_MAX_RETRIES,
+)
+def task_wait_and_start_crawl(self, vtex_account: str, crawl_url: str) -> None:
+    """
+    Deprecated alias for ``task_setup_channel_and_start_crawl``.
+
+    Kept registered under the original Celery task name so in-flight
+    retries queued before the rename keep executing the new pre-crawl
+    pipeline. New dispatches use the renamed task directly.
+    """
+    return _run_setup_channel_and_start_crawl(self, vtex_account, crawl_url)
 
 
 @shared_task(name="task_activate_agentic_cx_script")

--- a/retail/projects/tests/test_configure_wpp_cloud.py
+++ b/retail/projects/tests/test_configure_wpp_cloud.py
@@ -5,6 +5,9 @@ from django.test import TestCase
 
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.configure_wpp_cloud import (
+    PROJECT_CONFIG_AFTER_CREATE,
+    PROJECT_CONFIG_AFTER_PERSIST,
+    PROJECT_CONFIG_START,
     ConfigureWPPCloudUseCase,
     WPPCloudConfigError,
 )
@@ -42,8 +45,8 @@ class TestConfigureWPPCloudUseCase(TestCase):
         self.usecase.execute("mystore")
 
         self.onboarding.refresh_from_db()
-        self.assertEqual(self.onboarding.current_step, "NEXUS_CONFIG")
-        self.assertEqual(self.onboarding.progress, 20)
+        self.assertEqual(self.onboarding.current_step, "PROJECT_CONFIG")
+        self.assertEqual(self.onboarding.progress, PROJECT_CONFIG_AFTER_PERSIST)
         self.assertEqual(
             self.onboarding.config["channels"]["wpp-cloud"]["app_uuid"], app_uuid
         )
@@ -63,14 +66,35 @@ class TestConfigureWPPCloudUseCase(TestCase):
 
         self.assertIn("no project linked", str(ctx.exception))
 
-    def test_raises_error_when_already_configured(self):
-        self.onboarding.config = {"channels": {"wpp-cloud": {"app_uuid": str(uuid4())}}}
+    def test_skips_when_already_configured(self):
+        """
+        Already-configured onboardings are an idempotent no-op so that
+        Celery retries of the wrapping task do not fail mid-pipeline.
+        """
+        existing_app_uuid = str(uuid4())
+        self.onboarding.config = {
+            "channels": {
+                "wpp-cloud": {
+                    "channel_data": self.channel_data,
+                    "app_uuid": existing_app_uuid,
+                }
+            }
+        }
+        self.onboarding.current_step = "CRAWL"
+        self.onboarding.progress = 50
         self.onboarding.save()
 
-        with self.assertRaises(WPPCloudConfigError) as ctx:
-            self.usecase.execute("mystore")
+        self.usecase.execute("mystore")
 
-        self.assertIn("already configured", str(ctx.exception))
+        self.mock_integrations_service.create_wpp_cloud_channel.assert_not_called()
+        self.onboarding.refresh_from_db()
+        # State must not change when we skip
+        self.assertEqual(self.onboarding.current_step, "CRAWL")
+        self.assertEqual(self.onboarding.progress, 50)
+        self.assertEqual(
+            self.onboarding.config["channels"]["wpp-cloud"]["app_uuid"],
+            existing_app_uuid,
+        )
 
     def test_raises_error_when_no_channel_data(self):
         self.onboarding.config = {"channels": {"wpp-cloud": {}}}
@@ -129,10 +153,9 @@ class TestConfigureWPPCloudUseCase(TestCase):
         self.assertEqual(call_kwargs["waba_id"], "waba456")
         self.assertEqual(call_kwargs["phone_number_id"], "phone789")
 
-    def test_progress_at_13_after_channel_created(self):
-        """Progress should be 13% after channel creation, 20% after persist."""
+    def test_progress_milestones_within_project_config(self):
+        """Verifies progress walks the PROJECT_CONFIG start/create/persist milestones."""
         app_uuid = str(uuid4())
-
         self.mock_integrations_service.create_wpp_cloud_channel.return_value = {
             "app_uuid": app_uuid,
             "flow_object_uuid": str(uuid4()),
@@ -141,4 +164,8 @@ class TestConfigureWPPCloudUseCase(TestCase):
         self.usecase.execute("mystore")
 
         self.onboarding.refresh_from_db()
-        self.assertEqual(self.onboarding.progress, 20)
+        # Final progress lands at PROJECT_CONFIG_AFTER_PERSIST
+        self.assertEqual(self.onboarding.progress, PROJECT_CONFIG_AFTER_PERSIST)
+        # The milestones must be strictly increasing
+        self.assertLess(PROJECT_CONFIG_START, PROJECT_CONFIG_AFTER_CREATE)
+        self.assertLess(PROJECT_CONFIG_AFTER_CREATE, PROJECT_CONFIG_AFTER_PERSIST)

--- a/retail/projects/tests/test_configure_wwc.py
+++ b/retail/projects/tests/test_configure_wwc.py
@@ -5,6 +5,10 @@ from django.test import TestCase
 
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.configure_wwc import (
+    PROJECT_CONFIG_AFTER_CONFIGURE,
+    PROJECT_CONFIG_AFTER_CREATE,
+    PROJECT_CONFIG_AFTER_PERSIST,
+    PROJECT_CONFIG_START,
     ConfigureWWCUseCase,
     WWCConfigError,
 )
@@ -40,8 +44,8 @@ class TestConfigureWWCUseCase(TestCase):
         self.usecase.execute("mystore")
 
         self.onboarding.refresh_from_db()
-        self.assertEqual(self.onboarding.current_step, "NEXUS_CONFIG")
-        self.assertEqual(self.onboarding.progress, 20)
+        self.assertEqual(self.onboarding.current_step, "PROJECT_CONFIG")
+        self.assertEqual(self.onboarding.progress, PROJECT_CONFIG_AFTER_PERSIST)
         self.assertEqual(
             self.onboarding.config["channels"]["wwc"]["app_uuid"], app_uuid
         )
@@ -56,14 +60,27 @@ class TestConfigureWWCUseCase(TestCase):
 
         self.assertIn("no project linked", str(ctx.exception))
 
-    def test_raises_error_when_wwc_already_configured(self):
-        self.onboarding.config = {"channels": {"wwc": {"app_uuid": str(uuid4())}}}
+    def test_skips_when_wwc_already_configured(self):
+        """
+        Already-configured onboardings are an idempotent no-op so that
+        Celery retries of the wrapping task do not fail mid-pipeline.
+        """
+        existing_app_uuid = str(uuid4())
+        self.onboarding.config = {"channels": {"wwc": {"app_uuid": existing_app_uuid}}}
+        self.onboarding.current_step = "CRAWL"
+        self.onboarding.progress = 50
         self.onboarding.save()
 
-        with self.assertRaises(WWCConfigError) as ctx:
-            self.usecase.execute("mystore")
+        self.usecase.execute("mystore")
 
-        self.assertIn("already configured", str(ctx.exception))
+        self.mock_integrations_service.create_channel_app.assert_not_called()
+        self.mock_integrations_service.configure_channel_app.assert_not_called()
+        self.onboarding.refresh_from_db()
+        self.assertEqual(self.onboarding.current_step, "CRAWL")
+        self.assertEqual(self.onboarding.progress, 50)
+        self.assertEqual(
+            self.onboarding.config["channels"]["wwc"]["app_uuid"], existing_app_uuid
+        )
 
     def test_raises_error_when_create_fails(self):
         self.mock_integrations_service.create_channel_app.return_value = None
@@ -123,3 +140,21 @@ class TestConfigureWWCUseCase(TestCase):
         configure_call = self.mock_integrations_service.configure_channel_app.call_args
         self.assertEqual(configure_call[0][0], "wwc")
         self.assertEqual(configure_call[0][1], app_uuid)
+
+    def test_progress_milestones_within_project_config(self):
+        """Progress walks the PROJECT_CONFIG start/create/configure/persist milestones."""
+        app_uuid = str(uuid4())
+        self.mock_integrations_service.create_channel_app.return_value = {
+            "uuid": app_uuid,
+        }
+        self.mock_integrations_service.configure_channel_app.return_value = {
+            "uuid": app_uuid,
+        }
+
+        self.usecase.execute("mystore")
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(self.onboarding.progress, PROJECT_CONFIG_AFTER_PERSIST)
+        self.assertLess(PROJECT_CONFIG_START, PROJECT_CONFIG_AFTER_CREATE)
+        self.assertLess(PROJECT_CONFIG_AFTER_CREATE, PROJECT_CONFIG_AFTER_CONFIGURE)
+        self.assertLess(PROJECT_CONFIG_AFTER_CONFIGURE, PROJECT_CONFIG_AFTER_PERSIST)

--- a/retail/projects/tests/test_link_project_to_onboarding.py
+++ b/retail/projects/tests/test_link_project_to_onboarding.py
@@ -26,7 +26,16 @@ class TestLinkProjectToOnboardingUseCase(TestCase):
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.project, self.project)
 
-    def test_sets_project_config_step_and_100_progress(self):
+    def test_sets_project_config_step_and_partial_progress(self):
+        """
+        Linking the project advances PROJECT_CONFIG to a partial progress
+        value; the remaining progress is driven by the pre-crawl channel
+        setup task before the CRAWL transition.
+        """
+        from retail.projects.usecases.link_project_to_onboarding import (
+            PROJECT_LINKED_PROGRESS,
+        )
+
         onboarding = ProjectOnboarding.objects.create(
             vtex_account="mystore",
         )
@@ -35,7 +44,8 @@ class TestLinkProjectToOnboardingUseCase(TestCase):
 
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.current_step, "PROJECT_CONFIG")
-        self.assertEqual(onboarding.progress, 100)
+        self.assertEqual(onboarding.progress, PROJECT_LINKED_PROGRESS)
+        self.assertLess(onboarding.progress, 100)
 
     def test_does_nothing_when_no_pending_onboarding(self):
         # Should not raise any exception

--- a/retail/projects/tests/test_onboarding_full_flow.py
+++ b/retail/projects/tests/test_onboarding_full_flow.py
@@ -14,9 +14,13 @@ from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.configure_agent_builder import (
     ConfigureAgentBuilderUseCase,
 )
-from retail.projects.usecases.configure_wwc import ConfigureWWCUseCase
+from retail.projects.usecases.configure_wwc import (
+    PROJECT_CONFIG_AFTER_PERSIST,
+    ConfigureWWCUseCase,
+)
 from retail.projects.usecases.integrate_agents import IntegrateAgentsUseCase
 from retail.projects.usecases.link_project_to_onboarding import (
+    PROJECT_LINKED_PROGRESS,
     LinkProjectToOnboardingUseCase,
 )
 from retail.projects.usecases.onboarding_dto import (
@@ -32,15 +36,16 @@ from retail.projects.usecases.update_onboarding_progress import (
 
 class TestFullOnboardingFlow(TestCase):
     """
-    Simulates the full onboarding flow end-to-end:
+    Simulates the full onboarding flow end-to-end (post pre-crawl refactor):
 
-    1. Front-end calls start-setup (project not linked yet)
-    2. EDA links the project -> PROJECT_CONFIG 100%
-    3. Crawler sends progress events
-    4. Crawler sends crawl.completed
-    5. Channel creation and configuration (10-20%)
-    6. Nexus agent config + content upload (20-75%)
-    7. Agent integration (75-100%)
+    1. Front-end calls start-setup (project not linked yet) -> PROJECT_CONFIG 0%
+    2. EDA links the project                                -> PROJECT_CONFIG 30%
+    3. Pre-crawl channel setup runs                         -> PROJECT_CONFIG 100%
+    4. Crawl starts                                         -> CRAWL 10%
+    5. Crawler sends progress events
+    6. Crawler sends crawl.completed                        -> CRAWL 100%
+    7. NEXUS_CONFIG: agent builder + content upload         -> 10% -> 75%
+    8. NEXUS_CONFIG: agent integration                      -> 100%
     """
 
     def setUp(self):
@@ -49,8 +54,8 @@ class TestFullOnboardingFlow(TestCase):
         self.crawl_url = "https://www.flowstore.com.br/"
         self.channel_app_uuid = str(uuid4())
 
-    @patch("retail.projects.usecases.start_setup.task_wait_and_start_crawl")
-    def test_full_flow(self, mock_wait_task):
+    @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
+    def test_full_flow(self, mock_setup_task):
         # -- Step 1: Front-end starts setup, no project yet --
         dto = StartSetupDTO(
             vtex_account=self.vtex_account,
@@ -61,11 +66,12 @@ class TestFullOnboardingFlow(TestCase):
 
         onboarding = ProjectOnboarding.objects.get(vtex_account=self.vtex_account)
         self.assertIsNone(onboarding.project)
+        self.assertEqual(onboarding.current_step, "PROJECT_CONFIG")
         self.assertEqual(onboarding.progress, 0)
         self.assertIn("wwc", onboarding.config["channels"])
-        mock_wait_task.delay.assert_called_once_with(self.vtex_account, self.crawl_url)
+        mock_setup_task.delay.assert_called_once_with(self.vtex_account, self.crawl_url)
 
-        # -- Step 2: EDA links the project --
+        # -- Step 2: EDA links the project (partial PROJECT_CONFIG progress) --
         project = Project.objects.create(
             name="Flow Store",
             uuid=self.project_uuid,
@@ -76,9 +82,32 @@ class TestFullOnboardingFlow(TestCase):
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.project, project)
         self.assertEqual(onboarding.current_step, "PROJECT_CONFIG")
-        self.assertEqual(onboarding.progress, 100)
+        self.assertEqual(onboarding.progress, PROJECT_LINKED_PROGRESS)
 
-        # -- Step 3: Simulate the wait task starting the crawl --
+        # -- Step 3: Pre-crawl channel setup completes PROJECT_CONFIG --
+        mock_integrations_service = MagicMock()
+        mock_integrations_service.create_channel_app.return_value = {
+            "uuid": self.channel_app_uuid,
+            "code": "wwc",
+        }
+        mock_integrations_service.configure_channel_app.return_value = {
+            "uuid": self.channel_app_uuid,
+            "script": "https://example.com/script.js",
+        }
+
+        wwc_usecase = ConfigureWWCUseCase(integrations_client=MagicMock())
+        wwc_usecase.integrations_service = mock_integrations_service
+        wwc_usecase.execute(self.vtex_account)
+
+        onboarding.refresh_from_db()
+        self.assertEqual(onboarding.current_step, "PROJECT_CONFIG")
+        self.assertEqual(onboarding.progress, PROJECT_CONFIG_AFTER_PERSIST)
+        self.assertEqual(
+            onboarding.config["channels"]["wwc"]["app_uuid"],
+            self.channel_app_uuid,
+        )
+
+        # -- Step 4: Pre-crawl task transitions into CRAWL --
         mock_crawler_service = MagicMock()
         mock_crawler_service.start_crawling.return_value = {"status": "started"}
 
@@ -90,7 +119,7 @@ class TestFullOnboardingFlow(TestCase):
         self.assertEqual(onboarding.current_step, "CRAWL")
         self.assertEqual(onboarding.progress, 10)
 
-        # -- Step 4: Crawler sends progress update --
+        # -- Step 5: Crawler sends progress update --
         progress_dto = CrawlerWebhookDTO(
             task_id="task-1",
             event="crawl.subpage.progress",
@@ -103,7 +132,7 @@ class TestFullOnboardingFlow(TestCase):
         )
         self.assertEqual(result.progress, 50)
 
-        # -- Step 5: Crawler sends crawl.completed --
+        # -- Step 6: Crawler sends crawl.completed --
         crawled_contents = [
             {
                 "link": "https://www.flowstore.com.br/",
@@ -141,30 +170,13 @@ class TestFullOnboardingFlow(TestCase):
             self.vtex_account, crawled_contents
         )
 
-        # -- Step 6: WWC channel creation and configuration (10-20%) --
-        mock_integrations_service = MagicMock()
-        mock_integrations_service.create_channel_app.return_value = {
-            "uuid": self.channel_app_uuid,
-            "code": "wwc",
-        }
-        mock_integrations_service.configure_channel_app.return_value = {
-            "uuid": self.channel_app_uuid,
-            "script": "https://example.com/script.js",
-        }
-
-        wwc_usecase = ConfigureWWCUseCase(integrations_client=MagicMock())
-        wwc_usecase.integrations_service = mock_integrations_service
-        wwc_usecase.execute(self.vtex_account)
-
+        # -- Step 7: Nexus agent config + content upload (10-75%) --
+        # The orchestrator marks NEXUS_CONFIG / 10 before agent builder runs.
         onboarding.refresh_from_db()
-        self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
-        self.assertEqual(onboarding.progress, 20)
-        self.assertEqual(
-            onboarding.config["channels"]["wwc"]["app_uuid"],
-            self.channel_app_uuid,
-        )
+        onboarding.current_step = "NEXUS_CONFIG"
+        onboarding.progress = 10
+        onboarding.save(update_fields=["current_step", "progress"])
 
-        # -- Step 7: Nexus agent config + content upload (20-75%) --
         mock_nexus_service = MagicMock()
         mock_nexus_service.check_agent_builder_exists.return_value = {
             "data": {"has_agent": False}

--- a/retail/projects/tests/test_onboarding_orchestrator.py
+++ b/retail/projects/tests/test_onboarding_orchestrator.py
@@ -1,0 +1,135 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.onboarding_orchestrator import (
+    NEXUS_CONFIG_START_PROGRESS,
+    OnboardingOrchestrator,
+)
+
+
+class TestOnboardingOrchestrator(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            current_step="CRAWL",
+            progress=100,
+            crawler_result=ProjectOnboarding.SUCCESS,
+            config={
+                "channels": {
+                    "wwc": {
+                        "app_uuid": str(uuid4()),
+                    }
+                }
+            },
+        )
+
+    @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
+    @patch(
+        "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
+    )
+    def test_runs_agent_builder_then_integrate(
+        self, mock_agent_builder_cls, mock_integrate_cls
+    ):
+        mock_agent_builder = MagicMock()
+        mock_agent_builder_cls.return_value = mock_agent_builder
+        mock_integrate = MagicMock()
+        mock_integrate_cls.return_value = mock_integrate
+
+        contents = [{"link": "a", "title": "b", "content": "c"}]
+        OnboardingOrchestrator().execute("mystore", contents)
+
+        mock_agent_builder.execute.assert_called_once_with("mystore", contents)
+        mock_integrate.execute.assert_called_once_with("mystore")
+
+    @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
+    @patch(
+        "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
+    )
+    def test_transitions_to_nexus_config_step(
+        self, mock_agent_builder_cls, _mock_integrate_cls
+    ):
+        """The orchestrator must mark NEXUS_CONFIG so the UI advances."""
+        progress_at_agent_time = {}
+
+        def capture(vtex_account, _contents):
+            onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
+            progress_at_agent_time["step"] = onboarding.current_step
+            progress_at_agent_time["progress"] = onboarding.progress
+
+        mock_agent_builder = MagicMock()
+        mock_agent_builder.execute.side_effect = capture
+        mock_agent_builder_cls.return_value = mock_agent_builder
+
+        OnboardingOrchestrator().execute("mystore", [])
+
+        self.assertEqual(progress_at_agent_time["step"], "NEXUS_CONFIG")
+        self.assertEqual(
+            progress_at_agent_time["progress"], NEXUS_CONFIG_START_PROGRESS
+        )
+
+    @patch("retail.projects.usecases.onboarding_orchestrator.mark_onboarding_failed")
+    @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
+    @patch(
+        "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
+    )
+    def test_marks_failed_when_agent_builder_fails(
+        self,
+        mock_agent_builder_cls,
+        mock_integrate_cls,
+        mock_mark_failed,
+    ):
+        mock_agent_builder = MagicMock()
+        mock_agent_builder.execute.side_effect = RuntimeError("nexus down")
+        mock_agent_builder_cls.return_value = mock_agent_builder
+
+        mock_integrate = MagicMock()
+        mock_integrate_cls.return_value = mock_integrate
+
+        with self.assertRaises(RuntimeError):
+            OnboardingOrchestrator().execute("mystore", [])
+
+        mock_mark_failed.assert_called_once()
+        mock_integrate.execute.assert_not_called()
+
+    @patch("retail.projects.usecases.onboarding_orchestrator.mark_onboarding_failed")
+    @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
+    @patch(
+        "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
+    )
+    def test_marks_failed_when_integrate_fails(
+        self,
+        mock_agent_builder_cls,
+        mock_integrate_cls,
+        mock_mark_failed,
+    ):
+        mock_agent_builder = MagicMock()
+        mock_agent_builder_cls.return_value = mock_agent_builder
+
+        mock_integrate = MagicMock()
+        mock_integrate.execute.side_effect = RuntimeError("nexus error")
+        mock_integrate_cls.return_value = mock_integrate
+
+        with self.assertRaises(RuntimeError):
+            OnboardingOrchestrator().execute("mystore", [])
+
+        mock_mark_failed.assert_called_once()
+
+    def test_does_not_invoke_channel_usecase(self):
+        """
+        Channel creation now runs pre-crawl. The post-crawl orchestrator
+        must not reference any channel use case.
+        """
+        import inspect
+
+        from retail.projects.usecases import onboarding_orchestrator
+
+        source = inspect.getsource(onboarding_orchestrator)
+        self.assertNotIn("ConfigureWPPCloudUseCase", source)
+        self.assertNotIn("ConfigureWWCUseCase", source)

--- a/retail/projects/tests/test_pre_crawl_channel.py
+++ b/retail/projects/tests/test_pre_crawl_channel.py
@@ -1,0 +1,117 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.channel_usecase_resolver import (
+    CHANNEL_USECASES,
+    resolve_channel_usecase,
+)
+from retail.projects.usecases.configure_wpp_cloud import ConfigureWPPCloudUseCase
+from retail.projects.usecases.configure_wwc import ConfigureWWCUseCase
+from retail.projects.usecases.pre_crawl_channel import PreCrawlChannelUseCase
+
+
+class TestChannelUseCaseResolver(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+
+    def test_resolves_wwc_usecase(self):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"wwc": {}}},
+        )
+
+        usecase_cls = resolve_channel_usecase("mystore")
+
+        self.assertIs(usecase_cls, ConfigureWWCUseCase)
+
+    def test_resolves_wpp_cloud_usecase(self):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"wpp-cloud": {"channel_data": {}}}},
+        )
+
+        usecase_cls = resolve_channel_usecase("mystore")
+
+        self.assertIs(usecase_cls, ConfigureWPPCloudUseCase)
+
+    def test_raises_when_no_channel_configured(self):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={},
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            resolve_channel_usecase("mystore")
+
+        self.assertIn("No channel configured", str(ctx.exception))
+
+    def test_raises_when_channel_unsupported(self):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"bogus": {}}},
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            resolve_channel_usecase("mystore")
+
+        self.assertIn("No channel use case registered", str(ctx.exception))
+
+    def test_registry_lists_supported_channels(self):
+        self.assertIn("wwc", CHANNEL_USECASES)
+        self.assertIn("wpp-cloud", CHANNEL_USECASES)
+
+
+class TestPreCrawlChannelUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+
+    @patch("retail.projects.usecases.pre_crawl_channel.resolve_channel_usecase")
+    def test_executes_resolved_channel_usecase(self, mock_resolve):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"wwc": {}}},
+        )
+
+        mock_channel_cls = MagicMock()
+        mock_channel_cls.__name__ = "MockChannelUseCase"
+        mock_channel_instance = MagicMock()
+        mock_channel_cls.return_value = mock_channel_instance
+        mock_resolve.return_value = mock_channel_cls
+
+        PreCrawlChannelUseCase().execute("mystore")
+
+        mock_resolve.assert_called_once_with("mystore")
+        mock_channel_cls.assert_called_once_with()
+        mock_channel_instance.execute.assert_called_once_with("mystore")
+
+    @patch("retail.projects.usecases.pre_crawl_channel.resolve_channel_usecase")
+    def test_propagates_channel_usecase_failure(self, mock_resolve):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"wpp-cloud": {"channel_data": {}}}},
+        )
+
+        mock_channel_cls = MagicMock()
+        mock_channel_cls.__name__ = "MockChannelUseCase"
+        mock_channel_instance = MagicMock()
+        mock_channel_instance.execute.side_effect = RuntimeError("auth_code expired")
+        mock_channel_cls.return_value = mock_channel_instance
+        mock_resolve.return_value = mock_channel_cls
+
+        with self.assertRaises(RuntimeError) as ctx:
+            PreCrawlChannelUseCase().execute("mystore")
+
+        self.assertIn("auth_code expired", str(ctx.exception))

--- a/retail/projects/tests/test_start_onboarding.py
+++ b/retail/projects/tests/test_start_onboarding.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.test import TestCase
@@ -16,39 +16,44 @@ class TestStartSetupUseCase(TestCase):
             channel="wwc",
         )
 
-    @patch("retail.projects.usecases.start_setup.task_wait_and_start_crawl")
-    def test_creates_onboarding_and_schedules_wait_task_when_no_project(
+    @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
+    def test_creates_onboarding_and_schedules_setup_task_when_no_project(
         self, mock_task
     ):
-        """When no project exists, should schedule task_wait_and_start_crawl."""
+        """When no project exists, should schedule the pre-crawl setup task."""
         usecase = StartSetupUseCase()
 
         usecase.execute(self.dto)
 
         onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
         self.assertIsNone(onboarding.project)
+        self.assertEqual(onboarding.current_step, "PROJECT_CONFIG")
+        self.assertEqual(onboarding.progress, 0)
         mock_task.delay.assert_called_once_with(
             "mystore", "https://www.mystore.com.br/"
         )
 
-    def test_initiates_crawl_immediately_when_project_exists(self):
-        """When a project is linked, should call InitiateCrawlUseCase."""
-        project = Project.objects.create(
-            name="Test", uuid=uuid4(), vtex_account="mystore"
-        )
+    @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
+    def test_schedules_setup_task_when_project_already_linked(self, mock_task):
+        """
+        When a project is already linked at start-setup time, the task is
+        still dispatched (no inline crawl initiation). The task owns the
+        full pre-crawl pipeline regardless of link timing.
+        """
+        Project.objects.create(name="Test", uuid=uuid4(), vtex_account="mystore")
 
-        mock_initiate_crawl = MagicMock()
-        usecase = StartSetupUseCase(initiate_crawl_usecase=mock_initiate_crawl)
-
+        usecase = StartSetupUseCase()
         usecase.execute(self.dto)
 
         onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
-        self.assertEqual(onboarding.project, project)
-        mock_initiate_crawl.execute.assert_called_once_with(
-            project, "mystore", "https://www.mystore.com.br/"
+        self.assertIsNotNone(onboarding.project)
+        self.assertEqual(onboarding.current_step, "PROJECT_CONFIG")
+        self.assertEqual(onboarding.progress, 0)
+        mock_task.delay.assert_called_once_with(
+            "mystore", "https://www.mystore.com.br/"
         )
 
-    @patch("retail.projects.usecases.start_setup.task_wait_and_start_crawl")
+    @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
     @patch("retail.projects.tasks.task_activate_agentic_cx_script")
     def test_resets_existing_onboarding_on_retry(self, _mock_agentic, mock_task):
         """When an onboarding already exists, should reset transient fields."""
@@ -68,12 +73,44 @@ class TestStartSetupUseCase(TestCase):
         usecase.execute(self.dto)
 
         onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
+        self.assertEqual(onboarding.current_step, "PROJECT_CONFIG")
         self.assertEqual(onboarding.progress, 0)
-        self.assertEqual(onboarding.current_step, "")
         self.assertIsNone(onboarding.crawler_result)
         self.assertFalse(onboarding.completed)
         self.assertNotIn("last_failure", onboarding.config)
         self.assertNotIn("reason_failed", onboarding.config)
+
+    @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
+    def test_reset_clears_previous_channel_app_uuid(self, _mock_task):
+        """
+        Re-running start-setup must clear previously persisted app_uuid /
+        flow_object_uuid so the pre-crawl channel use case can re-create
+        the channel with a fresh auth_code.
+        """
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            config={
+                "channels": {
+                    "wwc": {
+                        "app_uuid": "old-app",
+                        "flow_object_uuid": "old-flow",
+                    },
+                    "wpp-cloud": {
+                        "channel_data": {"auth_code": "old"},
+                        "app_uuid": "old-wpp",
+                        "flow_object_uuid": "old-flow-wpp",
+                    },
+                }
+            },
+        )
+
+        usecase = StartSetupUseCase()
+        usecase.execute(self.dto)
+
+        onboarding = ProjectOnboarding.objects.get(vtex_account="mystore")
+        for channel_config in onboarding.config["channels"].values():
+            self.assertNotIn("app_uuid", channel_config)
+            self.assertNotIn("flow_object_uuid", channel_config)
 
     def test_try_link_project_finds_existing_project(self):
         """_try_link_project should link a matching project."""
@@ -115,7 +152,7 @@ class TestStartSetupUseCase(TestCase):
         with self.assertRaises(Project.MultipleObjectsReturned):
             StartSetupUseCase._try_link_project(onboarding)
 
-    @patch("retail.projects.usecases.start_setup.task_wait_and_start_crawl")
+    @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
     def test_stores_channel_data_in_config(self, mock_task):
         """When channel_data is provided, it should be stored in onboarding config."""
         dto = StartSetupDTO(

--- a/retail/projects/tests/test_tasks.py
+++ b/retail/projects/tests/test_tasks.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.tasks import (
+    PROJECT_LINKED_PROGRESS,
     _lock_key,
     acquire_task_lock,
     release_task_lock,
@@ -46,44 +47,189 @@ class TestTaskLocking(TestCase):
         self.assertEqual(key, "task_lock:configure_nexus:mystore")
 
 
-class TestTaskWaitAndStartCrawl(TestCase):
+class TestTaskSetupChannelAndStartCrawl(TestCase):
     def setUp(self):
         self.project = Project.objects.create(
             name="Test", uuid=uuid4(), vtex_account="mystore"
         )
 
     @patch("retail.projects.tasks.InitiateCrawlUseCase")
-    def test_delegates_to_initiate_crawl_when_project_linked(
-        self, mock_initiate_cls
+    @patch("retail.projects.tasks.PreCrawlChannelUseCase")
+    def test_runs_channel_then_crawl_when_project_linked(
+        self, mock_channel_cls, mock_initiate_cls
     ):
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
+            config={"channels": {"wwc": {}}},
         )
 
-        mock_instance = MagicMock()
-        mock_initiate_cls.return_value = mock_instance
+        mock_channel = MagicMock()
+        mock_channel_cls.return_value = mock_channel
+        mock_initiate = MagicMock()
+        mock_initiate_cls.return_value = mock_initiate
 
-        from retail.projects.tasks import task_wait_and_start_crawl
+        from retail.projects.tasks import task_setup_channel_and_start_crawl
 
-        task_wait_and_start_crawl("mystore", "https://mystore.com.br/")
+        task_setup_channel_and_start_crawl("mystore", "https://mystore.com.br/")
 
-        mock_instance.execute.assert_called_once_with(
+        mock_channel.execute.assert_called_once_with("mystore")
+        mock_initiate.execute.assert_called_once_with(
             self.project, "mystore", "https://mystore.com.br/"
         )
+
+        # Channel must run before crawl initiation.
+        channel_call_order = mock_channel.execute.call_args
+        crawl_call_order = mock_initiate.execute.call_args
+        self.assertIsNotNone(channel_call_order)
+        self.assertIsNotNone(crawl_call_order)
+
+    @patch("retail.projects.tasks.InitiateCrawlUseCase")
+    @patch("retail.projects.tasks.PreCrawlChannelUseCase")
+    def test_sets_project_linked_progress_before_channel_setup(
+        self, mock_channel_cls, _mock_initiate
+    ):
+        """When start-setup linked the project inline, the task still bumps progress."""
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            current_step="PROJECT_CONFIG",
+            progress=0,
+            config={"channels": {"wwc": {}}},
+        )
+
+        mock_channel = MagicMock()
+        mock_channel_cls.return_value = mock_channel
+
+        from retail.projects.tasks import task_setup_channel_and_start_crawl
+
+        # Capture progress at the moment the channel use case runs
+        progress_at_channel_time = {}
+
+        def capture_progress(vtex_account):
+            onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
+            progress_at_channel_time["value"] = onboarding.progress
+            progress_at_channel_time["step"] = onboarding.current_step
+
+        mock_channel.execute.side_effect = capture_progress
+
+        task_setup_channel_and_start_crawl("mystore", "https://mystore.com.br/")
+
+        self.assertEqual(progress_at_channel_time["value"], PROJECT_LINKED_PROGRESS)
+        self.assertEqual(progress_at_channel_time["step"], "PROJECT_CONFIG")
+
+    @patch("retail.projects.tasks.InitiateCrawlUseCase")
+    @patch("retail.projects.tasks.PreCrawlChannelUseCase")
+    def test_does_not_regress_progress_when_eda_linked_project(
+        self, mock_channel_cls, _mock_initiate
+    ):
+        """When EDA already set progress >= 30, the task must not regress it."""
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            current_step="PROJECT_CONFIG",
+            progress=PROJECT_LINKED_PROGRESS,
+            config={"channels": {"wwc": {}}},
+        )
+
+        mock_channel = MagicMock()
+        mock_channel_cls.return_value = mock_channel
+
+        from retail.projects.tasks import task_setup_channel_and_start_crawl
+
+        task_setup_channel_and_start_crawl("mystore", "https://mystore.com.br/")
+
+        # The single bump should be a no-op here; the progress at the time
+        # the channel use case ran is still PROJECT_LINKED_PROGRESS.
+        # We assert by verifying the call sequence works without errors.
+        mock_channel.execute.assert_called_once()
 
     def test_retries_when_project_not_linked(self):
         ProjectOnboarding.objects.create(vtex_account="mystore")
 
         from celery.exceptions import Retry
-        from retail.projects.tasks import task_wait_and_start_crawl
+        from retail.projects.tasks import task_setup_channel_and_start_crawl
 
         with patch.object(
-            task_wait_and_start_crawl, "retry", side_effect=Retry()
+            task_setup_channel_and_start_crawl, "retry", side_effect=Retry()
         ) as mock_retry:
             with self.assertRaises(Retry):
-                task_wait_and_start_crawl("mystore", "https://mystore.com.br/")
+                task_setup_channel_and_start_crawl("mystore", "https://mystore.com.br/")
             mock_retry.assert_called_once()
+
+    @patch("retail.projects.tasks.mark_onboarding_failed")
+    def test_marks_failed_when_onboarding_record_missing(self, mock_mark_failed):
+        from retail.projects.tasks import task_setup_channel_and_start_crawl
+
+        with self.assertRaises(ProjectOnboarding.DoesNotExist):
+            task_setup_channel_and_start_crawl(
+                "missing-store", "https://missing.com.br/"
+            )
+
+        mock_mark_failed.assert_called_once_with(
+            "missing-store", "Onboarding record not found"
+        )
+
+    @patch("retail.projects.tasks.mark_onboarding_failed")
+    @patch("retail.projects.tasks.InitiateCrawlUseCase")
+    @patch("retail.projects.tasks.PreCrawlChannelUseCase")
+    def test_marks_failed_and_skips_crawl_when_channel_fails(
+        self, mock_channel_cls, mock_initiate_cls, mock_mark_failed
+    ):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"wpp-cloud": {"channel_data": {}}}},
+        )
+
+        mock_channel = MagicMock()
+        mock_channel.execute.side_effect = RuntimeError("auth_code expired")
+        mock_channel_cls.return_value = mock_channel
+
+        mock_initiate = MagicMock()
+        mock_initiate_cls.return_value = mock_initiate
+
+        from retail.projects.tasks import task_setup_channel_and_start_crawl
+
+        with self.assertRaises(RuntimeError):
+            task_setup_channel_and_start_crawl("mystore", "https://mystore.com.br/")
+
+        mock_mark_failed.assert_called_once()
+        called_with_reason = mock_mark_failed.call_args[0][1]
+        self.assertIn("Channel creation failed", called_with_reason)
+        mock_initiate.execute.assert_not_called()
+
+
+class TestTaskWaitAndStartCrawlAlias(TestCase):
+    """The legacy task name must keep executing the new pre-crawl pipeline."""
+
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+
+    @patch("retail.projects.tasks.InitiateCrawlUseCase")
+    @patch("retail.projects.tasks.PreCrawlChannelUseCase")
+    def test_alias_runs_channel_then_crawl(self, mock_channel_cls, mock_initiate_cls):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"wwc": {}}},
+        )
+
+        mock_channel = MagicMock()
+        mock_channel_cls.return_value = mock_channel
+        mock_initiate = MagicMock()
+        mock_initiate_cls.return_value = mock_initiate
+
+        from retail.projects.tasks import task_wait_and_start_crawl
+
+        task_wait_and_start_crawl("mystore", "https://mystore.com.br/")
+
+        mock_channel.execute.assert_called_once_with("mystore")
+        mock_initiate.execute.assert_called_once_with(
+            self.project, "mystore", "https://mystore.com.br/"
+        )
 
 
 class TestTaskConfigureNexus(TestCase):

--- a/retail/projects/usecases/channel_usecase_resolver.py
+++ b/retail/projects/usecases/channel_usecase_resolver.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Type
+
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.configure_wpp_cloud import ConfigureWPPCloudUseCase
+from retail.projects.usecases.configure_wwc import ConfigureWWCUseCase
+
+logger = logging.getLogger(__name__)
+
+
+CHANNEL_USECASES = {
+    "wwc": ConfigureWWCUseCase,
+    "wpp-cloud": ConfigureWPPCloudUseCase,
+}
+
+
+def resolve_channel_usecase(vtex_account: str) -> Type:
+    """
+    Resolves the channel use case class registered for the channel
+    stored in the onboarding config.
+
+    The channel is set by ``StartSetupUseCase`` when the front-end
+    selects a channel and is later consumed by both the pre-crawl
+    channel setup task and the post-crawl orchestrator (for agent
+    integration lookups).
+
+    Raises:
+        ValueError: If no channel is configured or the channel is
+            not registered in ``CHANNEL_USECASES``.
+    """
+    onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
+    channels = (onboarding.config or {}).get("channels", {})
+    channel = next(iter(channels), None)
+
+    if channel is None:
+        raise ValueError(
+            f"No channel configured in onboarding " f"for vtex_account={vtex_account}"
+        )
+
+    usecase_cls = CHANNEL_USECASES.get(channel)
+    if usecase_cls is None:
+        raise ValueError(
+            f"No channel use case registered for '{channel}'. "
+            f"Supported: {list(CHANNEL_USECASES.keys())}"
+        )
+    return usecase_cls

--- a/retail/projects/usecases/configure_wpp_cloud.py
+++ b/retail/projects/usecases/configure_wpp_cloud.py
@@ -8,6 +8,15 @@ from retail.services.integrations.service import IntegrationsService
 logger = logging.getLogger(__name__)
 
 
+# Progress markers within the PROJECT_CONFIG step.
+# The pre-crawl pipeline sets PROJECT_CONFIG_START before invoking this
+# use case; we drive it the rest of the way to 100% as the Meta handshake
+# completes inside integrations-engine.
+PROJECT_CONFIG_START = 50
+PROJECT_CONFIG_AFTER_CREATE = 75
+PROJECT_CONFIG_AFTER_PERSIST = 100
+
+
 class WPPCloudConfigError(Exception):
     """Raised when the WPP Cloud channel creation fails."""
 
@@ -15,6 +24,10 @@ class WPPCloudConfigError(Exception):
 class ConfigureWPPCloudUseCase:
     """
     Creates a WhatsApp Cloud channel for a project via the integrations-engine.
+
+    Runs as part of the pre-crawl pipeline (PROJECT_CONFIG step) so the
+    short-lived Facebook ``auth_code`` is exchanged immediately, before
+    the long-running crawl can expire it.
 
     The channel_data (auth_code, waba_id, phone_number_id) is read from
     onboarding.config.channels['wpp-cloud'].channel_data, where it was
@@ -25,6 +38,11 @@ class ConfigureWPPCloudUseCase:
         2. POST to integrations-engine to create the wpp-cloud app
            (engine handles the full Meta API setup internally).
         3. Store app_uuid and flow_object_uuid in onboarding config.
+
+    The use case is idempotent at the "already-configured" level: if the
+    app_uuid is already persisted, the call is logged and returns
+    without raising. This lets the wrapping Celery task retry safely
+    when an upstream step fails after channel creation already succeeded.
     """
 
     def __init__(
@@ -36,18 +54,6 @@ class ConfigureWPPCloudUseCase:
         )
 
     def execute(self, vtex_account: str) -> None:
-        onboarding = self._load_onboarding(vtex_account)
-        project_uuid = str(onboarding.project.uuid)
-        channel_data = self._get_channel_data(onboarding)
-
-        onboarding.current_step = "NEXUS_CONFIG"
-        onboarding.progress = 10
-        onboarding.save(update_fields=["current_step", "progress"])
-
-        app_data = self._create_channel(onboarding, project_uuid, channel_data)
-        self._persist_app_data(onboarding, app_data)
-
-    def _load_onboarding(self, vtex_account: str) -> ProjectOnboarding:
         onboarding = ProjectOnboarding.objects.select_related("project").get(
             vtex_account=vtex_account
         )
@@ -59,12 +65,21 @@ class ConfigureWPPCloudUseCase:
 
         existing = (onboarding.config or {}).get("channels", {}).get("wpp-cloud", {})
         if existing.get("app_uuid"):
-            raise WPPCloudConfigError(
+            logger.info(
                 f"WPP Cloud channel already configured for onboarding={onboarding.uuid} "
-                f"(app_uuid={existing['app_uuid']}). Aborting to avoid duplicate."
+                f"(app_uuid={existing['app_uuid']}). Skipping."
             )
+            return
 
-        return onboarding
+        project_uuid = str(onboarding.project.uuid)
+        channel_data = self._get_channel_data(onboarding)
+
+        onboarding.current_step = "PROJECT_CONFIG"
+        onboarding.progress = PROJECT_CONFIG_START
+        onboarding.save(update_fields=["current_step", "progress"])
+
+        app_data = self._create_channel(onboarding, project_uuid, channel_data)
+        self._persist_app_data(onboarding, app_data)
 
     @staticmethod
     def _get_channel_data(onboarding: ProjectOnboarding) -> dict:
@@ -112,7 +127,7 @@ class ConfigureWPPCloudUseCase:
                 f"for project={project_uuid}"
             )
 
-        onboarding.progress = 13
+        onboarding.progress = PROJECT_CONFIG_AFTER_CREATE
         onboarding.save(update_fields=["progress"])
         logger.info(
             f"WPP Cloud channel created: app_uuid={app_uuid} project={project_uuid}"
@@ -132,7 +147,7 @@ class ConfigureWPPCloudUseCase:
         wpp_cloud["flow_object_uuid"] = flow_object_uuid
         channels["wpp-cloud"] = wpp_cloud
         onboarding.config = config
-        onboarding.progress = 20
+        onboarding.progress = PROJECT_CONFIG_AFTER_PERSIST
         onboarding.save(update_fields=["config", "progress"])
 
         logger.info(

--- a/retail/projects/usecases/configure_wwc.py
+++ b/retail/projects/usecases/configure_wwc.py
@@ -38,6 +38,15 @@ WWC_CHANNEL_BASE_CONFIG = {
 }
 
 
+# Progress markers within the PROJECT_CONFIG step.
+# Matched to the milestones in configure_wpp_cloud so the UI advances
+# at a similar cadence regardless of which channel was selected.
+PROJECT_CONFIG_START = 50
+PROJECT_CONFIG_AFTER_CREATE = 66
+PROJECT_CONFIG_AFTER_CONFIGURE = 83
+PROJECT_CONFIG_AFTER_PERSIST = 100
+
+
 def build_wwc_channel_config(language: str) -> dict:
     """Builds the full WWC channel config with translated title, subtitle and placeholder."""
     translations = get_wwc_translations(language)
@@ -57,10 +66,18 @@ class ConfigureWWCUseCase:
     """
     Creates and configures a WWC (Weni Web Chat) channel for a project.
 
+    Runs as part of the pre-crawl pipeline (PROJECT_CONFIG step) so the
+    channel exists before the crawl starts, mirroring the WhatsApp
+    Cloud flow.
+
     Flow:
         1. POST to create the WWC app → receives the app UUID.
         2. PATCH to configure the WWC app → channel is live.
         3. Stores the app UUID in onboarding.config.channels.wwc.
+
+    The use case is idempotent at the "already-configured" level: if the
+    app_uuid is already persisted, the call is logged and returns
+    without raising.
     """
 
     def __init__(
@@ -75,39 +92,18 @@ class ConfigureWWCUseCase:
         """
         Orchestrates WWC channel creation and configuration.
 
-        Progress within NEXUS_CONFIG (runs first, before Nexus upload):
-            10% — Step started.
-            13% — WWC app created.
-            17% — WWC app configured.
-            20% — App UUID persisted, channel complete.
+        Progress within PROJECT_CONFIG (channel phase, before crawl):
+            50% — Step started.
+            66% — WWC app created.
+            83% — WWC app configured.
+            100% — App UUID persisted, channel ready for crawl handoff.
 
         Args:
             vtex_account: The VTEX account identifier for the onboarding.
 
         Raises:
-            WWCConfigError: If any step fails or if a WWC channel
-                is already configured for this onboarding.
+            WWCConfigError: If any step fails.
         """
-        onboarding = self._load_onboarding(vtex_account)
-        project_uuid = str(onboarding.project.uuid)
-        language = onboarding.project.language or ""
-
-        if not language:
-            logger.warning(
-                f"Project language is empty for project={project_uuid} "
-                f"vtex_account={vtex_account}. WWC will use English defaults."
-            )
-
-        onboarding.current_step = "NEXUS_CONFIG"
-        onboarding.progress = 10
-        onboarding.save(update_fields=["current_step", "progress"])
-
-        app_uuid = self._create_app(onboarding, project_uuid)
-        self._configure_app(onboarding, app_uuid, project_uuid, language)
-        self._persist_app_uuid(onboarding, app_uuid)
-
-    def _load_onboarding(self, vtex_account: str) -> ProjectOnboarding:
-        """Loads and validates the onboarding record."""
         onboarding = ProjectOnboarding.objects.select_related("project").get(
             vtex_account=vtex_account
         )
@@ -119,15 +115,31 @@ class ConfigureWWCUseCase:
 
         existing_wwc = (onboarding.config or {}).get("channels", {}).get("wwc", {})
         if existing_wwc.get("app_uuid"):
-            raise WWCConfigError(
+            logger.info(
                 f"WWC channel already configured for onboarding={onboarding.uuid} "
-                f"(app_uuid={existing_wwc['app_uuid']}). Aborting to avoid duplicate."
+                f"(app_uuid={existing_wwc['app_uuid']}). Skipping."
+            )
+            return
+
+        project_uuid = str(onboarding.project.uuid)
+        language = onboarding.project.language or ""
+
+        if not language:
+            logger.warning(
+                f"Project language is empty for project={project_uuid} "
+                f"vtex_account={vtex_account}. WWC will use English defaults."
             )
 
-        return onboarding
+        onboarding.current_step = "PROJECT_CONFIG"
+        onboarding.progress = PROJECT_CONFIG_START
+        onboarding.save(update_fields=["current_step", "progress"])
+
+        app_uuid = self._create_app(onboarding, project_uuid)
+        self._configure_app(onboarding, app_uuid, project_uuid, language)
+        self._persist_app_uuid(onboarding, app_uuid)
 
     def _create_app(self, onboarding: ProjectOnboarding, project_uuid: str) -> str:
-        """Creates the WWC app and updates progress to 13%."""
+        """Creates the WWC app and advances PROJECT_CONFIG progress."""
         create_response = self.integrations_service.create_channel_app(
             "wwc", project_uuid, WWC_CREATION_CONFIG
         )
@@ -140,7 +152,7 @@ class ConfigureWWCUseCase:
                 f"WWC app creation returned no uuid for project={project_uuid}"
             )
 
-        onboarding.progress = 13
+        onboarding.progress = PROJECT_CONFIG_AFTER_CREATE
         onboarding.save(update_fields=["progress"])
         logger.info(f"WWC app created: app_uuid={app_uuid} project={project_uuid}")
 
@@ -153,7 +165,7 @@ class ConfigureWWCUseCase:
         project_uuid: str,
         language: str = "",
     ) -> None:
-        """Configures the previously created WWC app and updates progress to 17%."""
+        """Configures the previously created WWC app and advances progress."""
         channel_config = build_wwc_channel_config(language)
         configure_response = self.integrations_service.configure_channel_app(
             "wwc", app_uuid, channel_config
@@ -163,18 +175,18 @@ class ConfigureWWCUseCase:
                 f"Failed to configure WWC app={app_uuid} for project={project_uuid}"
             )
 
-        onboarding.progress = 17
+        onboarding.progress = PROJECT_CONFIG_AFTER_CONFIGURE
         onboarding.save(update_fields=["progress"])
         logger.info(f"WWC app configured: app_uuid={app_uuid} project={project_uuid}")
 
     @staticmethod
     def _persist_app_uuid(onboarding: ProjectOnboarding, app_uuid: str) -> None:
-        """Stores the app UUID in config and updates progress to 20%."""
+        """Stores the app UUID in config and completes the PROJECT_CONFIG step."""
         config = onboarding.config or {}
         channels = config.setdefault("channels", {})
         channels["wwc"] = {**channels.get("wwc", {}), "app_uuid": app_uuid}
         onboarding.config = config
-        onboarding.progress = 20
+        onboarding.progress = PROJECT_CONFIG_AFTER_PERSIST
         onboarding.save(update_fields=["config", "progress"])
 
         logger.info(

--- a/retail/projects/usecases/initiate_crawl.py
+++ b/retail/projects/usecases/initiate_crawl.py
@@ -18,9 +18,8 @@ class InitiateCrawlUseCase:
       2. Starts the crawl via the Crawler MS (critical).
       3. Detects the storefront type (non-blocking).
 
-    Used by both StartSetupUseCase (immediate path) and
-    task_wait_and_start_crawl (deferred path) to avoid
-    duplicating the same orchestration.
+    Invoked by ``task_setup_channel_and_start_crawl`` after the pre-crawl
+    channel setup completes successfully.
     """
 
     def __init__(self, connect_service: Optional[ConnectService] = None):
@@ -28,9 +27,7 @@ class InitiateCrawlUseCase:
         self.start_crawl_usecase = StartCrawlUseCase()
         self.detect_storefront_usecase = DetectStorefrontTypeUseCase()
 
-    def execute(
-        self, project: Project, vtex_account: str, crawl_url: str
-    ) -> None:
+    def execute(self, project: Project, vtex_account: str, crawl_url: str) -> None:
         self._send_vtex_host_store(project, crawl_url)
         self.start_crawl_usecase.execute(vtex_account, crawl_url)
         self.detect_storefront_usecase.execute(project, crawl_url)

--- a/retail/projects/usecases/link_project_to_onboarding.py
+++ b/retail/projects/usecases/link_project_to_onboarding.py
@@ -5,13 +5,19 @@ from retail.projects.models import Project, ProjectOnboarding
 logger = logging.getLogger(__name__)
 
 
+PROJECT_LINKED_PROGRESS = 30
+
+
 class LinkProjectToOnboardingUseCase:
     """
     Links a newly created Project to an existing ProjectOnboarding
     identified by vtex_account.
 
     Called from the EDA consumer when a project creation event is received.
-    Sets progress to 100%, which unblocks the wait task that triggers the crawl.
+    Sets ``current_step = "PROJECT_CONFIG"`` and a partial progress
+    (``PROJECT_LINKED_PROGRESS``) so the pre-crawl channel setup task
+    can drive progress the rest of the way to 100% before transitioning
+    to CRAWL.
     """
 
     @staticmethod
@@ -39,10 +45,11 @@ class LinkProjectToOnboardingUseCase:
 
         onboarding.project = project
         onboarding.current_step = "PROJECT_CONFIG"
-        onboarding.progress = 100
+        onboarding.progress = PROJECT_LINKED_PROGRESS
         onboarding.save(update_fields=["project", "current_step", "progress"])
 
         logger.info(
             f"Linked project={project.uuid} to onboarding={onboarding.uuid} "
-            f"(vtex_account={project.vtex_account}, PROJECT_CONFIG=100%)"
+            f"(vtex_account={project.vtex_account}, "
+            f"PROJECT_CONFIG={PROJECT_LINKED_PROGRESS}%)"
         )

--- a/retail/projects/usecases/onboarding_orchestrator.py
+++ b/retail/projects/usecases/onboarding_orchestrator.py
@@ -1,29 +1,28 @@
 import logging
-from typing import Type
 
 from retail.projects.models import ProjectOnboarding
 from retail.projects.usecases.configure_agent_builder import (
     ConfigureAgentBuilderUseCase,
 )
-from retail.projects.usecases.configure_wwc import ConfigureWWCUseCase
-from retail.projects.usecases.configure_wpp_cloud import ConfigureWPPCloudUseCase
 from retail.projects.usecases.integrate_agents import IntegrateAgentsUseCase
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 
 logger = logging.getLogger(__name__)
 
-CHANNEL_USECASES = {
-    "wwc": ConfigureWWCUseCase,
-    "wpp-cloud": ConfigureWPPCloudUseCase,
-}
+
+NEXUS_CONFIG_START_PROGRESS = 10
 
 
 class OnboardingOrchestrator:
     """
     Orchestrates post-crawl configuration:
-      1. Channel creation (10-20%)       -- dispatches to the channel-specific use case
-      2. Nexus manager + upload (20-75%) -- configures agent and uploads content
-      3. Agent integration (75-100%)     -- integrates Nexus agents for the channel
+      1. Nexus manager + upload (20-75%) -- configures agent and uploads content
+      2. Agent integration (75-100%)     -- integrates Nexus agents for the channel
+
+    Channel creation runs before the crawl (see ``PreCrawlChannelUseCase``)
+    so the short-lived Facebook ``auth_code`` is not exposed to the
+    crawl's runtime. Both channels' ``app_uuid`` / ``flow_object_uuid``
+    are already persisted by the time this orchestrator runs.
 
     Each step is sequential. If any step fails, progress freezes
     at the last saved value and the error propagates.
@@ -33,8 +32,7 @@ class OnboardingOrchestrator:
         logger.info(f"Starting post-crawl config for vtex_account={vtex_account}")
 
         try:
-            channel_cls = self._resolve_channel_usecase(vtex_account)
-            channel_cls().execute(vtex_account)
+            self._mark_nexus_config_started(vtex_account)
 
             ConfigureAgentBuilderUseCase().execute(vtex_account, contents)
 
@@ -46,22 +44,9 @@ class OnboardingOrchestrator:
         logger.info(f"NEXUS_CONFIG completed for vtex_account={vtex_account}")
 
     @staticmethod
-    def _resolve_channel_usecase(vtex_account: str) -> Type:
-        """Resolves the channel use case class from the onboarding config."""
+    def _mark_nexus_config_started(vtex_account: str) -> None:
+        """Transitions the onboarding into the NEXUS_CONFIG step."""
         onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
-        channels = (onboarding.config or {}).get("channels", {})
-        channel = next(iter(channels), None)
-
-        if channel is None:
-            raise ValueError(
-                f"No channel configured in onboarding "
-                f"for vtex_account={vtex_account}"
-            )
-
-        usecase_cls = CHANNEL_USECASES.get(channel)
-        if usecase_cls is None:
-            raise ValueError(
-                f"No channel use case registered for '{channel}'. "
-                f"Supported: {list(CHANNEL_USECASES.keys())}"
-            )
-        return usecase_cls
+        onboarding.current_step = "NEXUS_CONFIG"
+        onboarding.progress = NEXUS_CONFIG_START_PROGRESS
+        onboarding.save(update_fields=["current_step", "progress"])

--- a/retail/projects/usecases/pre_crawl_channel.py
+++ b/retail/projects/usecases/pre_crawl_channel.py
@@ -1,0 +1,33 @@
+import logging
+
+from retail.projects.usecases.channel_usecase_resolver import (
+    resolve_channel_usecase,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PreCrawlChannelUseCase:
+    """
+    Runs the channel-specific configuration use case before the crawl.
+
+    The Facebook Embedded Signup ``auth_code`` is short-lived, so the
+    channel must be created (and the auth_code exchanged on the
+    integrations-engine side) as early as possible — before the
+    long-running crawl can expire it.
+
+    The concrete use case (``ConfigureWPPCloudUseCase`` or
+    ``ConfigureWWCUseCase``) is resolved from the channel stored in
+    ``onboarding.config["channels"]`` and is responsible for setting
+    ``current_step = "PROJECT_CONFIG"`` and driving its own progress.
+    """
+
+    def execute(self, vtex_account: str) -> None:
+        channel_cls = resolve_channel_usecase(vtex_account)
+
+        logger.info(
+            f"Running pre-crawl channel setup: "
+            f"vtex_account={vtex_account} usecase={channel_cls.__name__}"
+        )
+
+        channel_cls().execute(vtex_account)

--- a/retail/projects/usecases/start_setup.py
+++ b/retail/projects/usecases/start_setup.py
@@ -1,9 +1,7 @@
 import logging
-from typing import Optional
 
 from retail.projects.models import Project, ProjectOnboarding
-from retail.projects.tasks import task_wait_and_start_crawl
-from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
+from retail.projects.tasks import task_setup_channel_and_start_crawl
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_agents.agent_mappings import SUPPORTED_CHANNELS
 from retail.projects.usecases.onboarding_dto import StartSetupDTO
@@ -16,13 +14,16 @@ class StartSetupUseCase:
     Initiates the setup process for a store.
 
     Creates/gets the onboarding record, stores channel configuration
-    (including channel_data for wpp-cloud), then starts the crawl
-    immediately if the project is linked, or schedules a background
-    task to wait for the link.
-    """
+    (including channel_data for wpp-cloud), then schedules a single
+    background task that waits for the project link, creates the
+    channel, and starts the crawl.
 
-    def __init__(self, initiate_crawl_usecase: Optional[InitiateCrawlUseCase] = None):
-        self.initiate_crawl_usecase = initiate_crawl_usecase or InitiateCrawlUseCase()
+    The pre-crawl channel setup is dispatched unconditionally — even
+    when the project is already linked — so the task owns the channel
+    creation + crawl initiation pipeline end-to-end and the HTTP
+    response returns immediately while the (potentially slow) Meta
+    handshake runs asynchronously.
+    """
 
     def execute(self, dto: StartSetupDTO) -> None:
         onboarding, created = ProjectOnboarding.objects.get_or_create(
@@ -51,7 +52,9 @@ class StartSetupUseCase:
             channel_config["channel_data"] = dto.channel_data
 
         onboarding.config = config
-        onboarding.save(update_fields=["config"])
+        onboarding.current_step = "PROJECT_CONFIG"
+        onboarding.progress = 0
+        onboarding.save(update_fields=["config", "current_step", "progress"])
 
         try:
             self._try_link_project(onboarding)
@@ -59,22 +62,24 @@ class StartSetupUseCase:
             mark_onboarding_failed(dto.vtex_account, str(exc))
             raise
 
-        if onboarding.project is not None:
-            self.initiate_crawl_usecase.execute(
-                onboarding.project, dto.vtex_account, dto.crawl_url
-            )
-            return
-
-        task_wait_and_start_crawl.delay(dto.vtex_account, dto.crawl_url)
+        task_setup_channel_and_start_crawl.delay(dto.vtex_account, dto.crawl_url)
 
         logger.info(
-            f"Project not linked yet for vtex_account={dto.vtex_account}. "
-            f"Scheduled wait task for crawl_url={dto.crawl_url}"
+            f"Scheduled pre-crawl setup task for vtex_account={dto.vtex_account} "
+            f"(project_linked={onboarding.project is not None}, "
+            f"crawl_url={dto.crawl_url})"
         )
 
     @staticmethod
     def _reset_onboarding(onboarding: ProjectOnboarding) -> None:
-        """Resets transient fields so a new crawl cycle starts clean."""
+        """
+        Resets transient fields so a new pre-crawl cycle starts clean.
+
+        Also clears any previously created channel ``app_uuid`` /
+        ``flow_object_uuid`` so the new run can re-exchange a fresh
+        ``auth_code`` without tripping the channel use case's
+        idempotency guard.
+        """
         onboarding.progress = 0
         onboarding.crawler_result = None
         onboarding.completed = False
@@ -84,6 +89,12 @@ class StartSetupUseCase:
         config = onboarding.config or {}
         config.pop("last_failure", None)
         config.pop("reason_failed", None)
+
+        channels = config.get("channels", {})
+        for channel_config in channels.values():
+            channel_config.pop("app_uuid", None)
+            channel_config.pop("flow_object_uuid", None)
+
         onboarding.config = config
 
         onboarding.save(


### PR DESCRIPTION
- Introduced PreCrawlChannelUseCase to handle channel setup before initiating the crawl.
- Updated task_wait_and_start_crawl to task_setup_channel_and_start_crawl, delegating to the new pre-crawl logic.
- Enhanced onboarding progress tracking, setting PROJECT_LINKED_PROGRESS during project linking.
- Updated tests to reflect changes in onboarding flow and ensure proper progress milestones.
- Added channel use case resolver to dynamically select the appropriate channel configuration based on onboarding settings.