### PR TITLE
feat: Adds One-Click Payment agent with wpp_flow_uuid credential

### DIFF
--- a/retail/clients/nexus/client.py
+++ b/retail/clients/nexus/client.py
@@ -1,7 +1,7 @@
 """Client for connection with Nexus"""
 
 from django.conf import settings
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 from retail.clients.base import RequestClient, InternalAuthentication
 from retail.interfaces.clients.nexus.client import NexusClientInterface
@@ -72,6 +72,38 @@ class NexusClient(RequestClient, NexusClientInterface):
         response = self.make_request(
             url,
             method="PATCH",
+            json=payload,
+            headers=self.authentication_instance.headers,
+        )
+        return response.json()
+
+    def create_agent_credentials(
+        self,
+        project_uuid: str,
+        agent_uuid: str,
+        credentials: List[Dict],
+    ) -> Dict:
+        """
+        Creates one or more credentials on a Nexus agent for a project.
+
+        Args:
+            project_uuid: The project's unique identifier.
+            agent_uuid: The agent that will receive the credentials.
+            credentials: List of credential dicts (``name``, ``label``,
+                ``placeholder``, ``is_confidential``, ``value``).
+
+        Returns:
+            Dict with Nexus response (e.g. ``created_credentials``).
+        """
+        url = f"{self.base_url}/api/project/{str(project_uuid)}/app-credentials"
+        payload = {
+            "agent_uuid": str(agent_uuid),
+            "credentials": credentials,
+        }
+
+        response = self.make_request(
+            url,
+            method="POST",
             json=payload,
             headers=self.authentication_instance.headers,
         )

--- a/retail/interfaces/clients/nexus/client.py
+++ b/retail/interfaces/clients/nexus/client.py
@@ -1,4 +1,4 @@
-from typing import Dict, Protocol, Tuple
+from typing import Dict, List, Protocol, Tuple
 
 
 class NexusClientInterface(Protocol):
@@ -41,6 +41,28 @@ class NexusClientInterface(Protocol):
 
         Returns:
             Dict: Removal response data.
+        """
+        ...
+
+    def create_agent_credentials(
+        self,
+        project_uuid: str,
+        agent_uuid: str,
+        credentials: List[Dict],
+    ) -> Dict:
+        """
+        Creates one or more credentials on a Nexus agent for a project.
+
+        Args:
+            project_uuid: The project's unique identifier.
+            agent_uuid: The agent that will receive the credentials.
+            credentials: List of credential dicts. Each dict accepts
+                ``name``, ``label``, ``placeholder``, ``is_confidential``
+                and ``value`` keys.
+
+        Returns:
+            Dict with the Nexus response (typically including the list
+            of created credential names).
         """
         ...
 

--- a/retail/projects/tests/test_agent_mappings.py
+++ b/retail/projects/tests/test_agent_mappings.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+
+from retail.projects.usecases.onboarding_agents.agent_mappings import (
+    get_channel_agents,
+)
+from retail.projects.usecases.onboarding_agents.agents import (
+    AbandonedCartAgent,
+    OneClickPaymentAgent,
+)
+from retail.projects.usecases.onboarding_agents.base import PassiveAgent
+
+
+class TestGetChannelAgents(TestCase):
+    def test_raises_for_unsupported_channel(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_channel_agents("telegram")
+        self.assertIn("Unsupported channel", str(ctx.exception))
+
+    @override_settings(
+        PASSIVE_AGENTS_WWC={"order_status": "uuid-order"},
+    )
+    def test_wwc_returns_passive_agents_only(self):
+        agents = get_channel_agents("wwc")
+        self.assertEqual(len(agents), 1)
+        self.assertIsInstance(agents[0], PassiveAgent)
+        self.assertEqual(agents[0].uuid, "uuid-order")
+        self.assertEqual(agents[0].name, "Order Status")
+
+    @override_settings(
+        PASSIVE_AGENTS_WPP_CLOUD={
+            "order_status": "uuid-order",
+            "one_click_payment": "uuid-ocp",
+        },
+    )
+    def test_wpp_cloud_upgrades_one_click_payment(self):
+        agents = get_channel_agents("wpp-cloud")
+
+        passive = next(a for a in agents if a.uuid == "uuid-order")
+        upgraded = next(a for a in agents if a.uuid == "uuid-ocp")
+
+        self.assertIsInstance(passive, PassiveAgent)
+        self.assertIsInstance(upgraded, OneClickPaymentAgent)
+        self.assertEqual(upgraded.name, "One Click Payment")
+
+    @override_settings(PASSIVE_AGENTS_WPP_CLOUD={})
+    def test_wpp_cloud_includes_legacy_active_agents(self):
+        agents = get_channel_agents("wpp-cloud")
+        self.assertTrue(any(isinstance(a, AbandonedCartAgent) for a in agents))
+
+    @override_settings(
+        PASSIVE_AGENTS_WPP_CLOUD={
+            "order_status": "uuid-order",
+            "one_click_payment": "",
+        },
+    )
+    def test_skips_entries_with_empty_uuid(self):
+        agents = get_channel_agents("wpp-cloud")
+        codes = [
+            a.uuid
+            for a in agents
+            if isinstance(a, (PassiveAgent, OneClickPaymentAgent))
+        ]
+        self.assertIn("uuid-order", codes)
+        self.assertNotIn("", codes)
+
+    @override_settings(
+        PASSIVE_AGENTS_WPP_CLOUD={"order_status": "uuid-order"},
+    )
+    def test_warns_when_registered_behavior_missing_from_env(self):
+        with patch(
+            "retail.projects.usecases.onboarding_agents.agent_mappings.logger"
+        ) as mock_logger:
+            get_channel_agents("wpp-cloud")
+
+        warning_calls = [c for c in mock_logger.warning.call_args_list]
+        self.assertTrue(
+            any("one_click_payment" in str(c) for c in warning_calls),
+            "Expected a warning about missing 'one_click_payment' code.",
+        )

--- a/retail/projects/tests/test_configure_one_click_payment.py
+++ b/retail/projects/tests/test_configure_one_click_payment.py
@@ -18,7 +18,7 @@ from retail.services.key_generator.service import RSAKeyPair
 
 @override_settings(
     PAYMENT_REST_ENDPOINT="https://payment.test",
-    PAYMENT_FLOW_NAME="flow_confirmacao_pagamento",
+    PAYMENT_FLOW_NAME="payment_confirmation_flow",
 )
 class TestConfigureOneClickPaymentUseCase(TestCase):
     def setUp(self):
@@ -102,7 +102,7 @@ class TestConfigureOneClickPaymentUseCase(TestCase):
         )
         self.mock_meta_service.create_flow.assert_called_once_with(
             waba_id="waba-1",
-            name="flow_confirmacao_pagamento",
+            name="payment_confirmation_flow",
             categories=PAYMENT_FLOW_CATEGORIES,
             endpoint_uri=(
                 f"https://payment.test/v1/channels/{self.flow_object_uuid}"

--- a/retail/projects/tests/test_integrate_agents.py
+++ b/retail/projects/tests/test_integrate_agents.py
@@ -153,3 +153,43 @@ class TestIntegrateAgentsUseCase(TestCase):
         self.usecase.execute("mystore")
 
         self.assertEqual(self.mock_nexus_service.integrate_agent.call_count, 2)
+
+    def test_propagates_flow_id_from_payment_config_to_agent_context(self):
+        """When the wpp-cloud config has a published payment flow_id,
+        IntegrateAgentsUseCase must hand it to each agent via
+        AgentContext.flow_id (needed by OneClickPaymentAgent)."""
+        wpp_onboarding = ProjectOnboarding.objects.create(
+            vtex_account="wppstore",
+            project=Project.objects.create(
+                name="WPP Store", uuid=uuid4(), vtex_account="wppstore"
+            ),
+            config={
+                "channels": {
+                    "wpp-cloud": {
+                        "app_uuid": "app-1",
+                        "flow_object_uuid": "channel-1",
+                        "payment": {"flow_id": "flow-meta-123"},
+                    }
+                }
+            },
+        )
+
+        captured_contexts = []
+
+        class CapturingAgent(StubPassiveAgent):
+            def integrate(self, context, nexus_service):
+                captured_contexts.append(context)
+                return {"ok": True}
+
+        with patch(
+            "retail.projects.usecases.integrate_agents.get_channel_agents",
+            return_value=[CapturingAgent("uuid-x", "X")],
+        ):
+            self.usecase.execute("wppstore")
+
+        self.assertEqual(captured_contexts[0].flow_id, "flow-meta-123")
+        self.assertEqual(captured_contexts[0].app_uuid, "app-1")
+        self.assertEqual(captured_contexts[0].channel_uuid, "channel-1")
+
+        wpp_onboarding.refresh_from_db()
+        self.assertEqual(wpp_onboarding.progress, AGENT_PROGRESS_END)

--- a/retail/projects/tests/test_onboarding_orchestrator.py
+++ b/retail/projects/tests/test_onboarding_orchestrator.py
@@ -24,7 +24,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
 
         self._patch_target("CHANNEL_USECASES", new=self.fake_channel_usecases)
         self._patch_target("ConfigureAgentBuilderUseCase")
-        self._patch_target("IntegrateAgentsUseCase")
+        self.mock_integrate_cls = self._patch_target("IntegrateAgentsUseCase")
         self.mock_payment_cls = self._patch_target("ConfigureOneClickPaymentUseCase")
 
     def _patch_target(self, attr: str, new=None):
@@ -62,6 +62,22 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
         OnboardingOrchestrator().execute("mystore", contents=[])
 
         self.mock_payment_cls.assert_not_called()
+
+    def test_one_click_payment_runs_before_integrate_agents_for_wpp_cloud(self):
+        """OCP must execute before agent integration so the One-Click
+        Payment agent can read the published flow_id as a credential."""
+        self._make_onboarding("wpp-cloud")
+        call_order = []
+        self.mock_payment_cls.return_value.execute.side_effect = (
+            lambda *_: call_order.append("ocp")
+        )
+        self.mock_integrate_cls.return_value.execute.side_effect = (
+            lambda *_: call_order.append("integrate")
+        )
+
+        OnboardingOrchestrator().execute("mystore", contents=[])
+
+        self.assertEqual(call_order, ["ocp", "integrate"])
 
     def test_propagates_failure_and_marks_onboarding_failed(self):
         self._make_onboarding("wpp-cloud")

--- a/retail/projects/tests/test_one_click_payment_agent.py
+++ b/retail/projects/tests/test_one_click_payment_agent.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 from django.test import TestCase
 
 from retail.projects.usecases.onboarding_agents.agents import (
-    WPP_FLOW_CREDENTIAL_LABEL,
-    WPP_FLOW_CREDENTIAL_NAME,
+    WHATSAPP_CVV_FLOW_CREDENTIAL_LABEL,
+    WHATSAPP_CVV_FLOW_CREDENTIAL_NAME,
     OneClickPaymentAgent,
 )
 from retail.projects.usecases.onboarding_agents.base import AgentContext
@@ -26,7 +26,7 @@ class TestOneClickPaymentAgent(TestCase):
         self.mock_nexus_service = MagicMock()
         self.mock_nexus_service.integrate_agent.return_value = {"ok": True}
         self.mock_nexus_service.create_agent_credentials.return_value = {
-            "created_credentials": [WPP_FLOW_CREDENTIAL_NAME]
+            "created_credentials": [WHATSAPP_CVV_FLOW_CREDENTIAL_NAME]
         }
 
     def _make_agent(self) -> OneClickPaymentAgent:
@@ -45,8 +45,8 @@ class TestOneClickPaymentAgent(TestCase):
             agent_uuid=self.agent_uuid,
             credentials=[
                 {
-                    "name": WPP_FLOW_CREDENTIAL_NAME,
-                    "label": WPP_FLOW_CREDENTIAL_LABEL,
+                    "name": WHATSAPP_CVV_FLOW_CREDENTIAL_NAME,
+                    "label": WHATSAPP_CVV_FLOW_CREDENTIAL_LABEL,
                     "is_confidential": True,
                     "value": self.flow_id,
                 }
@@ -54,7 +54,8 @@ class TestOneClickPaymentAgent(TestCase):
         )
         self.assertEqual(result["agent_assignment"], {"ok": True})
         self.assertEqual(
-            result["credentials"], {"created_credentials": [WPP_FLOW_CREDENTIAL_NAME]}
+            result["credentials"],
+            {"created_credentials": [WHATSAPP_CVV_FLOW_CREDENTIAL_NAME]},
         )
 
     def test_raises_when_no_uuid_configured(self):

--- a/retail/projects/tests/test_one_click_payment_agent.py
+++ b/retail/projects/tests/test_one_click_payment_agent.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.usecases.onboarding_agents.agents import (
+    WPP_FLOW_CREDENTIAL_LABEL,
+    WPP_FLOW_CREDENTIAL_NAME,
+    OneClickPaymentAgent,
+)
+from retail.projects.usecases.onboarding_agents.base import AgentContext
+
+
+class TestOneClickPaymentAgent(TestCase):
+    def setUp(self):
+        self.project_uuid = str(uuid4())
+        self.agent_uuid = str(uuid4())
+        self.flow_id = "flow-meta-123"
+        self.context = AgentContext(
+            project_uuid=self.project_uuid,
+            vtex_account="mystore",
+            app_uuid=str(uuid4()),
+            channel_uuid=str(uuid4()),
+            flow_id=self.flow_id,
+        )
+        self.mock_nexus_service = MagicMock()
+        self.mock_nexus_service.integrate_agent.return_value = {"ok": True}
+        self.mock_nexus_service.create_agent_credentials.return_value = {
+            "created_credentials": [WPP_FLOW_CREDENTIAL_NAME]
+        }
+
+    def _make_agent(self) -> OneClickPaymentAgent:
+        return OneClickPaymentAgent(uuid=self.agent_uuid, name="One Click Payment")
+
+    def test_full_flow_calls_assign_then_credentials(self):
+        agent = self._make_agent()
+
+        result = agent.integrate(self.context, self.mock_nexus_service)
+
+        self.mock_nexus_service.integrate_agent.assert_called_once_with(
+            self.project_uuid, self.agent_uuid
+        )
+        self.mock_nexus_service.create_agent_credentials.assert_called_once_with(
+            project_uuid=self.project_uuid,
+            agent_uuid=self.agent_uuid,
+            credentials=[
+                {
+                    "name": WPP_FLOW_CREDENTIAL_NAME,
+                    "label": WPP_FLOW_CREDENTIAL_LABEL,
+                    "is_confidential": True,
+                    "value": self.flow_id,
+                }
+            ],
+        )
+        self.assertEqual(result["agent_assignment"], {"ok": True})
+        self.assertEqual(
+            result["credentials"], {"created_credentials": [WPP_FLOW_CREDENTIAL_NAME]}
+        )
+
+    def test_raises_when_no_uuid_configured(self):
+        agent = OneClickPaymentAgent()
+
+        with self.assertRaises(ValueError) as ctx:
+            agent.integrate(self.context, self.mock_nexus_service)
+
+        self.assertIn("has no UUID", str(ctx.exception))
+        self.mock_nexus_service.integrate_agent.assert_not_called()
+
+    def test_raises_when_flow_id_missing_in_context(self):
+        agent = self._make_agent()
+        context = AgentContext(
+            project_uuid=self.project_uuid,
+            vtex_account="mystore",
+            app_uuid=str(uuid4()),
+            channel_uuid=str(uuid4()),
+            flow_id=None,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            agent.integrate(context, self.mock_nexus_service)
+
+        self.assertIn("flow_id", str(ctx.exception))
+        self.mock_nexus_service.integrate_agent.assert_not_called()
+
+    def test_returns_none_when_app_assign_fails(self):
+        self.mock_nexus_service.integrate_agent.return_value = None
+        agent = self._make_agent()
+
+        result = agent.integrate(self.context, self.mock_nexus_service)
+
+        self.assertIsNone(result)
+        self.mock_nexus_service.create_agent_credentials.assert_not_called()
+
+    def test_returns_none_when_credentials_fail(self):
+        self.mock_nexus_service.create_agent_credentials.return_value = None
+        agent = self._make_agent()
+
+        result = agent.integrate(self.context, self.mock_nexus_service)
+
+        self.assertIsNone(result)

--- a/retail/projects/usecases/integrate_agents.py
+++ b/retail/projects/usecases/integrate_agents.py
@@ -76,6 +76,7 @@ class IntegrateAgentsUseCase:
             vtex_account=vtex_account,
             app_uuid=channel_config.get("app_uuid"),
             channel_uuid=channel_config.get("flow_object_uuid"),
+            flow_id=(channel_config.get("payment") or {}).get("flow_id"),
         )
 
         self._integrate_agents(onboarding, context, agents, integrated_uuids)

--- a/retail/projects/usecases/onboarding_agents/agent_mappings.py
+++ b/retail/projects/usecases/onboarding_agents/agent_mappings.py
@@ -1,67 +1,127 @@
 """
 Channel-to-agent mappings for onboarding.
 
-Maps each supported channel code to the list of agent instances
-that must be integrated when that channel is selected.
+For each supported channel the onboarding integrates a list of
+``OnboardingAgent`` instances. Two sources are combined:
 
-Passive agents are loaded from environment variables
-(PASSIVE_AGENTS_WWC / PASSIVE_AGENTS_WPP_CLOUD) as JSON dicts
-mapping agent name to UUID. Only active agents — which require
-complex integration logic — are defined as hardcoded classes.
+* The env ``PASSIVE_AGENTS_<CHANNEL>`` JSON is the canonical source
+  of agent UUIDs (devops-controlled). Keys are agent **codes** in
+  snake_case; values are UUIDs.
+* ``ACTIVE_AGENT_MAPPINGS`` holds legacy active agents that are NOT
+  listed in the env JSON because they use their own dedicated env
+  var (e.g. ``AbandonedCartAgent`` reads ``ABANDONED_CART_AGENT_UUID``).
 
-Pattern follows rule_mappings.py from weni-integrations-engine:
-the registry is consumed by IntegrateAgentsUseCase which iterates
-over the agents and calls ``agent.integrate(context, nexus_service)``.
+Most env entries are integrated with the default ``PassiveAgent``,
+which just does a single Nexus ``app-assign`` POST. When a code is
+listed in ``PASSIVE_AGENT_OVERRIDES``, that default class is
+overridden by the registered one, which does the same app-assign
+plus extra setup (credential injection, template setup, etc.). The
+env stays the single source of truth for UUIDs; the code only
+overrides the integration behavior. The display name passed to
+each instance is derived from the code (snake_case → Title Case)
+and is used only for logs.
 """
 
-from typing import Dict, List
+import logging
+from typing import Dict, List, Type
 
 from django.conf import settings
 
-from retail.projects.usecases.onboarding_agents.agents import AbandonedCartAgent
+from retail.projects.usecases.onboarding_agents.agents import (
+    AbandonedCartAgent,
+    OneClickPaymentAgent,
+)
 from retail.projects.usecases.onboarding_agents.base import (
     OnboardingAgent,
     PassiveAgent,
 )
 
+logger = logging.getLogger(__name__)
+
+
 SUPPORTED_CHANNELS = ["wwc", "wpp-cloud"]
 
-ACTIVE_AGENT_MAPPINGS = {
+# Channel → name of the Django setting that holds the passive
+# agent JSON (``{code: uuid}``) for that channel.
+PASSIVE_AGENTS_ENV_BY_CHANNEL = {
+    "wwc": "PASSIVE_AGENTS_WWC",
+    "wpp-cloud": "PASSIVE_AGENTS_WPP_CLOUD",
+}
+
+# Legacy active agents that do not live in the env JSON because
+# they read their UUID from a dedicated env var.
+ACTIVE_AGENT_MAPPINGS: Dict[str, List[OnboardingAgent]] = {
     "wpp-cloud": [
         AbandonedCartAgent(),
     ],
 }
 
-
-def _build_passive_agents(agents_map: Dict[str, str]) -> List[PassiveAgent]:
-    """Creates PassiveAgent instances from a name-to-UUID mapping."""
-    return [
-        PassiveAgent(uuid=uuid, name=name) for name, uuid in agents_map.items() if uuid
-    ]
+# Overrides for entries in PASSIVE_AGENTS_<CHANNEL>: when a code
+# matches, the default PassiveAgent is replaced by the registered
+# class (typically an ActiveAgent subclass adding credential or
+# template setup on top of the standard app-assign).
+# Maps channel_code → {agent_code: AgentClass}.
+PASSIVE_AGENT_OVERRIDES: Dict[str, Dict[str, Type[OnboardingAgent]]] = {
+    "wpp-cloud": {
+        "one_click_payment": OneClickPaymentAgent,
+    },
+}
 
 
 def get_channel_agents(channel_code: str) -> List[OnboardingAgent]:
     """
     Returns the list of OnboardingAgent instances for a channel.
 
-    Combines passive agents (loaded from env vars) with active agents
-    (hardcoded) for the given channel.
+    Combines env-driven agents (default ``PassiveAgent``, overridden
+    by a registered class when the code is in
+    ``PASSIVE_AGENT_OVERRIDES``) with the hardcoded active agents
+    from ``ACTIVE_AGENT_MAPPINGS``.
 
     Raises:
         ValueError: If channel_code is not supported.
     """
     if channel_code not in SUPPORTED_CHANNELS:
         raise ValueError(
-            f"Unsupported channel '{channel_code}'. " f"Supported: {SUPPORTED_CHANNELS}"
+            f"Unsupported channel '{channel_code}'. Supported: {SUPPORTED_CHANNELS}"
         )
 
-    passive_settings = {
-        "wwc": "PASSIVE_AGENTS_WWC",
-        "wpp-cloud": "PASSIVE_AGENTS_WPP_CLOUD",
-    }
+    uuid_by_code = getattr(settings, PASSIVE_AGENTS_ENV_BY_CHANNEL[channel_code], {})
+    overrides = PASSIVE_AGENT_OVERRIDES.get(channel_code, {})
 
-    agents_map = getattr(settings, passive_settings[channel_code], {})
-    agents: List[OnboardingAgent] = _build_passive_agents(agents_map)
+    # Catch typos / partial deploys: an override registered in code
+    # but absent from the env would be silently skipped otherwise.
+    missing_codes = [code for code in overrides if code not in uuid_by_code]
+    if missing_codes:
+        logger.warning(
+            f"Passive agent overrides registered for channel "
+            f"'{channel_code}' but missing from env: {missing_codes}. "
+            f"These agents will not be integrated."
+        )
+
+    agents: List[OnboardingAgent] = [
+        _instantiate_agent(code, uuid, overrides)
+        for code, uuid in uuid_by_code.items()
+        if uuid
+    ]
+    # ACTIVE_AGENT_MAPPINGS is appended separately: these agents are
+    # not env-driven (they have their own dedicated env vars).
     agents.extend(ACTIVE_AGENT_MAPPINGS.get(channel_code, []))
-
     return agents
+
+
+def _instantiate_agent(
+    code: str,
+    uuid: str,
+    overrides: Dict[str, Type[OnboardingAgent]],
+) -> OnboardingAgent:
+    """Picks the override class for ``code`` or falls back to PassiveAgent."""
+    display_name = code.replace("_", " ").title()
+    agent_cls = overrides.get(code)
+    if agent_cls is None:
+        return PassiveAgent(uuid=uuid, name=display_name)
+
+    logger.info(
+        f"Overriding default PassiveAgent with {agent_cls.__name__} "
+        f"for code='{code}'"
+    )
+    return agent_cls(uuid=uuid, name=display_name)

--- a/retail/projects/usecases/onboarding_agents/agents.py
+++ b/retail/projects/usecases/onboarding_agents/agents.py
@@ -22,8 +22,8 @@ from retail.services.nexus.service import NexusService
 logger = logging.getLogger(__name__)
 
 
-WPP_FLOW_CREDENTIAL_NAME = "wpp_flow_uuid"
-WPP_FLOW_CREDENTIAL_LABEL = "WhatsApp Flow UUID"
+WHATSAPP_CVV_FLOW_CREDENTIAL_NAME = "WHATSAPP_CVV_FLOW_ID"
+WHATSAPP_CVV_FLOW_CREDENTIAL_LABEL = "WhatsApp CVV Flow ID"
 
 
 class AbandonedCartAgent(ActiveAgent):
@@ -119,14 +119,15 @@ class OneClickPaymentAgent(ActiveAgent):
         credentials_response = nexus_service.create_agent_credentials(
             project_uuid=context.project_uuid,
             agent_uuid=self.uuid,
-            credentials=[self._build_wpp_flow_credential(context.flow_id)],
+            credentials=[self._build_cvv_flow_credential(context.flow_id)],
         )
         if credentials_response is None:
             return None
 
         logger.info(
             f"One-Click Payment agent {self.uuid} integrated with "
-            f"wpp_flow_uuid credential for project={context.project_uuid}"
+            f"{WHATSAPP_CVV_FLOW_CREDENTIAL_NAME} credential for "
+            f"project={context.project_uuid}"
         )
 
         return {
@@ -135,10 +136,10 @@ class OneClickPaymentAgent(ActiveAgent):
         }
 
     @staticmethod
-    def _build_wpp_flow_credential(flow_id: str) -> dict:
+    def _build_cvv_flow_credential(flow_id: str) -> dict:
         return {
-            "name": WPP_FLOW_CREDENTIAL_NAME,
-            "label": WPP_FLOW_CREDENTIAL_LABEL,
+            "name": WHATSAPP_CVV_FLOW_CREDENTIAL_NAME,
+            "label": WHATSAPP_CVV_FLOW_CREDENTIAL_LABEL,
             "is_confidential": True,
             "value": flow_id,
         }

--- a/retail/projects/usecases/onboarding_agents/agents.py
+++ b/retail/projects/usecases/onboarding_agents/agents.py
@@ -22,6 +22,10 @@ from retail.services.nexus.service import NexusService
 logger = logging.getLogger(__name__)
 
 
+WPP_FLOW_CREDENTIAL_NAME = "wpp_flow_uuid"
+WPP_FLOW_CREDENTIAL_LABEL = "WhatsApp Flow UUID"
+
+
 class AbandonedCartAgent(ActiveAgent):
     """
     Active agent for abandoned cart notifications via WhatsApp Cloud.
@@ -76,3 +80,73 @@ class AbandonedCartAgent(ActiveAgent):
         )
 
         return {"integrated_agent_uuid": str(integrated_agent.uuid)}
+
+
+class OneClickPaymentAgent(ActiveAgent):
+    """
+    Active agent for the One-Click Payment flow on WhatsApp Cloud.
+
+    Integration steps:
+
+    1. Standard Nexus app-assign (same call PassiveAgent makes).
+    2. Bind the ``wpp_flow_uuid`` credential on the agent — the value
+       is the Meta Flow id created earlier by
+       ``ConfigureOneClickPaymentUseCase`` and passed through the
+       AgentContext.
+
+    Instantiated by ``get_channel_agents`` when the env JSON for the
+    channel contains the code registered in ``PASSIVE_AGENT_OVERRIDES``
+    (so the UUID still comes from ``PASSIVE_AGENTS_WPP_CLOUD`` like
+    every other agent).
+    """
+
+    name = "One Click Payment"
+
+    def __init__(self, uuid: str = "", name: str = ""):
+        if uuid:
+            self.uuid = uuid
+        if name:
+            self.name = name
+
+    def integrate(self, context: AgentContext, nexus_service: NexusService) -> dict:
+        self._validate_uuid()
+        self._validate_flow_id(context)
+
+        assign_response = nexus_service.integrate_agent(context.project_uuid, self.uuid)
+        if assign_response is None:
+            return None
+
+        credentials_response = nexus_service.create_agent_credentials(
+            project_uuid=context.project_uuid,
+            agent_uuid=self.uuid,
+            credentials=[self._build_wpp_flow_credential(context.flow_id)],
+        )
+        if credentials_response is None:
+            return None
+
+        logger.info(
+            f"One-Click Payment agent {self.uuid} integrated with "
+            f"wpp_flow_uuid credential for project={context.project_uuid}"
+        )
+
+        return {
+            "agent_assignment": assign_response,
+            "credentials": credentials_response,
+        }
+
+    @staticmethod
+    def _build_wpp_flow_credential(flow_id: str) -> dict:
+        return {
+            "name": WPP_FLOW_CREDENTIAL_NAME,
+            "label": WPP_FLOW_CREDENTIAL_LABEL,
+            "is_confidential": True,
+            "value": flow_id,
+        }
+
+    def _validate_flow_id(self, context: AgentContext) -> None:
+        if not context.flow_id:
+            raise ValueError(
+                f"One-Click Payment agent '{self.name}' requires "
+                f"context.flow_id. Ensure ConfigureOneClickPaymentUseCase "
+                f"ran before agent integration for the wpp-cloud channel."
+            )

--- a/retail/projects/usecases/onboarding_agents/base.py
+++ b/retail/projects/usecases/onboarding_agents/base.py
@@ -5,19 +5,23 @@ from typing import Optional
 from retail.services.nexus.service import NexusService
 
 
-@dataclass
+@dataclass(frozen=True)
 class AgentContext:
     """Shared context passed to every agent during integration.
 
-    Core fields are always set. Channel-specific fields (app_uuid,
-    channel_uuid) are populated when the channel provides them —
-    e.g. wpp-cloud stores these after channel creation.
+    Immutable so agents cannot mutate state seen by the next agent
+    in the integration sequence. Core fields are always set;
+    channel-specific fields (app_uuid, channel_uuid, flow_id) are
+    populated when the channel provides them — e.g. wpp-cloud stores
+    app_uuid + channel_uuid after the channel is created, and
+    flow_id after the One-Click Payment Meta Flow is created.
     """
 
     project_uuid: str
     vtex_account: str
     app_uuid: Optional[str] = None
     channel_uuid: Optional[str] = None
+    flow_id: Optional[str] = None
 
 
 class OnboardingAgent(ABC):

--- a/retail/projects/usecases/onboarding_orchestrator.py
+++ b/retail/projects/usecases/onboarding_orchestrator.py
@@ -30,8 +30,11 @@ class OnboardingOrchestrator:
     Orchestrates post-crawl configuration:
       1. Channel creation (10-20%)       -- dispatches to the channel-specific use case
       2. Nexus manager + upload (20-75%) -- configures agent and uploads content
-      3. Agent integration (75-100%)     -- integrates Nexus agents for the channel
-      4. One-Click Payment (wpp-cloud)   -- registers keys + Flow with Meta and payment-ms
+      3. One-Click Payment (wpp-cloud)   -- registers keys + creates+publishes Meta Flow
+                                            (runs BEFORE agent integration so the
+                                            One-Click Payment agent can consume the
+                                            published flow_id as a credential)
+      4. Agent integration (75-100%)     -- integrates Nexus agents for the channel
 
     Each step is sequential. If any step fails, progress freezes
     at the last saved value and the error propagates.
@@ -46,10 +49,10 @@ class OnboardingOrchestrator:
 
             ConfigureAgentBuilderUseCase().execute(vtex_account, contents)
 
-            IntegrateAgentsUseCase().execute(vtex_account)
-
             if channel_code in CHANNELS_WITH_ONE_CLICK_PAYMENT:
                 ConfigureOneClickPaymentUseCase().execute(vtex_account)
+
+            IntegrateAgentsUseCase().execute(vtex_account)
         except Exception as exc:
             mark_onboarding_failed(vtex_account, str(exc))
             raise

--- a/retail/services/nexus/service.py
+++ b/retail/services/nexus/service.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from retail.interfaces.clients.nexus.client import NexusClientInterface
 from retail.clients.exceptions import CustomAPIException
@@ -47,6 +47,30 @@ class NexusService:
             logger.error(
                 f"Error {e.status_code} when removing agent {agent_uuid} "
                 f"from project {project_uuid}."
+            )
+            return None
+
+    def create_agent_credentials(
+        self,
+        project_uuid: str,
+        agent_uuid: str,
+        credentials: List[Dict],
+    ) -> Optional[Dict]:
+        """
+        Creates credentials on a Nexus agent for a project.
+        """
+        try:
+            return self.nexus_client.create_agent_credentials(
+                project_uuid=project_uuid,
+                agent_uuid=agent_uuid,
+                credentials=credentials,
+            )
+        except CustomAPIException as e:
+            # Body omitted to avoid leaking credential values if
+            # Nexus echoes the request payload in error responses.
+            logger.error(
+                f"Error {e.status_code} when creating credentials on "
+                f"agent {agent_uuid} for project {project_uuid}."
             )
             return None
 

--- a/retail/services/tests/test_nexus.py
+++ b/retail/services/tests/test_nexus.py
@@ -143,3 +143,44 @@ class TestNexusService(TestCase):
         result = self.service.configure_agent_attributes(self.project_uuid, payload)
 
         self.assertIsNone(result)
+
+    def test_create_agent_credentials_success(self):
+        credentials = [
+            {
+                "name": "wpp_flow_uuid",
+                "label": "WhatsApp Flow UUID",
+                "is_confidential": True,
+                "value": "flow-meta-123",
+            }
+        ]
+        expected = {
+            "message": "Credentials created successfully",
+            "created_credentials": ["wpp_flow_uuid"],
+        }
+        self.mock_nexus_client.create_agent_credentials.return_value = expected
+
+        result = self.service.create_agent_credentials(
+            project_uuid=self.project_uuid,
+            agent_uuid=self.agent_uuid,
+            credentials=credentials,
+        )
+
+        self.mock_nexus_client.create_agent_credentials.assert_called_once_with(
+            project_uuid=self.project_uuid,
+            agent_uuid=self.agent_uuid,
+            credentials=credentials,
+        )
+        self.assertEqual(result, expected)
+
+    def test_create_agent_credentials_returns_none_on_api_exception(self):
+        self.mock_nexus_client.create_agent_credentials.side_effect = (
+            CustomAPIException(status_code=502, detail="bad gateway")
+        )
+
+        result = self.service.create_agent_credentials(
+            project_uuid=self.project_uuid,
+            agent_uuid=self.agent_uuid,
+            credentials=[],
+        )
+
+        self.assertIsNone(result)

--- a/retail/settings.py
+++ b/retail/settings.py
@@ -347,7 +347,7 @@ if USE_META:
 
 # One-Click Payment microservice (WhatsApp Cloud onboarding final step).
 PAYMENT_REST_ENDPOINT = env.str("PAYMENT_REST_ENDPOINT", default="")
-PAYMENT_FLOW_NAME = env.str("PAYMENT_FLOW_NAME", default="flow_confirmacao_pagamento")
+PAYMENT_FLOW_NAME = env.str("PAYMENT_FLOW_NAME", default="payment_confirmation_flow")
 
 ORDER_STATUS_AGENT_UUID = env.str("ORDER_STATUS_AGENT_UUID", default="")
 ABANDONED_CART_AGENT_UUID = env.str("ABANDONED_CART_AGENT_UUID", default="")


### PR DESCRIPTION
## What

- Reordered the wpp-cloud onboarding so the One-Click Payment step (Meta encrypted Flow creation + publish) runs before agent integration, persisting the resulting `flow_id` in `onboarding.config.payment`.
- Added a `OneClickPaymentAgent` that, on top of the standard Nexus app-assign, calls the Nexus credentials endpoint to bind `wpp_flow_uuid` with the `flow_id` available in the agent context.
- Introduced a registry that maps `(channel, agent_code) → AgentClass` so a code listed in the passive-agents env can be overridden by a class with custom integration logic, without touching the orchestrator or any other agent.

## Why

The One-Click Payment Nexus agent needs the published Meta Flow id at runtime to execute the encrypted checkout. Storing it as a Nexus credential keeps the agent self-sufficient and avoids re-querying Meta on every execution. The registry pattern lets future agents that need extra setup (credentials, templates, etc.) plug in with a single line, while every other passive agent keeps the existing behavior unchanged.