### PR TITLE
fix: Make One-Click Payment Meta Flow name unique per channel

### DIFF
--- a/retail/projects/tests/test_configure_one_click_payment.py
+++ b/retail/projects/tests/test_configure_one_click_payment.py
@@ -100,9 +100,12 @@ class TestConfigureOneClickPaymentUseCase(TestCase):
         self.mock_meta_service.register_public_key.assert_called_once_with(
             phone_number_id="phone-1", public_key_pem="-----PUB-----"
         )
+        expected_flow_name = (
+            f"payment_confirmation_flow_{self.flow_object_uuid.split('-', 1)[0]}"
+        )
         self.mock_meta_service.create_flow.assert_called_once_with(
             waba_id="waba-1",
-            name="payment_confirmation_flow",
+            name=expected_flow_name,
             categories=PAYMENT_FLOW_CATEGORIES,
             endpoint_uri=(
                 f"https://payment.test/v1/channels/{self.flow_object_uuid}"

--- a/retail/projects/usecases/configure_one_click_payment.py
+++ b/retail/projects/usecases/configure_one_click_payment.py
@@ -237,10 +237,11 @@ class ConfigureOneClickPaymentUseCase:
     def _create_meta_flow(
         self, waba_id: str, channel_uuid: str, endpoint_uri: str
     ) -> Dict[str, Any]:
+        flow_name = self._build_flow_name(channel_uuid)
         try:
             flow = self.meta_service.create_flow(
                 waba_id=waba_id,
-                name=settings.PAYMENT_FLOW_NAME,
+                name=flow_name,
                 categories=PAYMENT_FLOW_CATEGORIES,
                 endpoint_uri=endpoint_uri,
                 flow_json=build_payment_flow_json(),
@@ -248,7 +249,7 @@ class ConfigureOneClickPaymentUseCase:
         except CustomAPIException as exc:
             raise OneClickPaymentConfigError(
                 f"Failed to create Meta Flow for waba_id={waba_id} "
-                f"channel_uuid={channel_uuid}: {exc}"
+                f"channel_uuid={channel_uuid} name={flow_name}: {exc}"
             ) from exc
 
         if not flow or not flow.get("id"):
@@ -258,6 +259,19 @@ class ConfigureOneClickPaymentUseCase:
             )
 
         return flow
+
+    @staticmethod
+    def _build_flow_name(channel_uuid: str) -> str:
+        """Builds a unique Flow name per channel.
+
+        Meta requires Flow names to be unique inside a WABA, so we
+        derive the name from ``settings.PAYMENT_FLOW_NAME`` + the
+        first segment of ``channel_uuid``. Using the channel uuid
+        (instead of a timestamp) keeps the name deterministic, so
+        retries always target the same Flow.
+        """
+        suffix = channel_uuid.split("-", 1)[0]
+        return f"{settings.PAYMENT_FLOW_NAME}_{suffix}"
 
     def _publish_flow(self, flow_id: str) -> None:
         try:


### PR DESCRIPTION
## What

`ConfigureOneClickPaymentUseCase` now suffixes the Meta Flow name with the first segment of the `channel_uuid` (e.g. `payment_confirmation_flow_ee6c3d50`). The error message on create failure also includes the resolved name to ease triage.

## Why

Meta rejected the second wpp-cloud onboarding in the same WABA with `error_subcode=4016019` because the Flow name `payment_confirmation_flow` was already taken. The per-channel suffix guarantees uniqueness; using the `channel_uuid` (not a timestamp) keeps the name deterministic so retries hit the same Flow.