### PR TITLE
refactor: streamline exception messages and improve documentation

### DIFF
--- a/retail/agents/domains/agent_integration/exceptions.py
+++ b/retail/agents/domains/agent_integration/exceptions.py
@@ -15,10 +15,9 @@ class GlobalRuleInternalServerError(APIException):
 
 
 class DirectSendTemplateUnavailableError(APIException):
-    """Raised at agent-assignment time when neither the project-resolved
-    language nor the pt_BR fallback returns usable content for a
-    required template (FR-003d).
-    """
+    """Raised when neither the project locale nor the ``pt_BR`` fallback
+    returns usable content. Anchor: FR-003d (see
+    ``specs/002-direct-send-broadcasts/spec.md``)."""
 
     status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
     default_code = "direct_send_template_unavailable"
@@ -43,10 +42,9 @@ class DirectSendTemplateUnavailableError(APIException):
 
 
 class DirectSendUnsupportedComponentError(APIException):
-    """Raised at agent-assignment time when Meta's library catalog
-    returns a template whose components are outside the Direct Send
-    supported set (Decision 12 — defensive).
-    """
+    """Raised when a library-catalog template carries components outside
+    the Direct Send supported set. Anchor: Decision 12 (see
+    ``specs/002-direct-send-broadcasts/spec.md``)."""
 
     status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
     default_code = "direct_send_unsupported_component"

--- a/retail/agents/domains/agent_integration/serializers.py
+++ b/retail/agents/domains/agent_integration/serializers.py
@@ -118,13 +118,7 @@ class ReadIntegratedAgentSerializer(serializers.Serializer):
     direct_send = serializers.SerializerMethodField("get_direct_send")
 
     def get_direct_send(self, obj):
-        """Read-only Direct Send flag from ``IntegratedAgent.config``.
-
-        Stored as an optional key inside the existing ``config``
-        JSONField (data-model.md §1 Decision). Absence is the
-        canonical legacy marker and is interpreted as ``False``
-        (FR-005).
-        """
+        """Read-only Direct Send flag (defaults to ``False`` on absence)."""
         return bool(obj.config.get("direct_send", False))
 
     def get_webhook_url(self, obj):

--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -96,16 +96,11 @@ class AssignAgentUseCase:
 
     @property
     def meta_service(self) -> MetaServiceInterface:
-        """Lazily construct ``MetaService`` only when the Direct Send branch
-        actually needs it.
+        """Lazily construct ``MetaService`` only when Direct Send needs it.
 
-        ``MetaClient.__init__`` reads ``settings.META_SYSTEM_USER_ACCESS_TOKEN``,
-        which is only configured under ``USE_LAMBDA=True``. Eager
-        construction in ``__init__`` would break every legacy-cohort
-        assignment whose tests don't inject a meta_service mock — the
-        Direct Send fetch is the ONLY consumer (`_create_library_templates`
-        Direct Send branch), so deferring construction also avoids
-        instantiating an unused HTTP client on every legacy assignment.
+        Eager construction breaks legacy-cohort tests because
+        ``MetaClient.__init__`` reads ``META_SYSTEM_USER_ACCESS_TOKEN``,
+        which is only configured under ``USE_LAMBDA=True``.
         """
         if self._meta_service is None:
             self._meta_service = MetaService()
@@ -114,14 +109,8 @@ class AssignAgentUseCase:
     def _resolve_direct_send_flag(self, agent: Agent, app_uuid: UUID) -> bool:
         """Decide whether the assignment should take the Direct Send path.
 
-        Two signals must both be true (FR-019, contract
-        ``integrations-channel-app.md`` §4):
-
-        - the agent is the OrderStatus agent
-          (``settings.ORDER_STATUS_AGENT_UUID``);
-        - the channel-app reports ``config.direct_send=True``.
-
-        On any failure the conservative default is ``False`` (FR-005).
+        Anchor: FR-019 (two-signal AND: OrderStatus agent + channel-app
+        flag) / FR-005 (conservative ``False`` on any failure).
         """
         order_status_agent_uuid = getattr(settings, "ORDER_STATUS_AGENT_UUID", "")
         if not order_status_agent_uuid or str(agent.uuid) != order_status_agent_uuid:
@@ -155,9 +144,6 @@ class AssignAgentUseCase:
         ignore_templates_slugs = self._get_ignore_templates_slugs(ignore_templates)
 
         initial_config = self._build_initial_config(agent, project)
-        # FR-001 / SC-004: write the key only when True; absence is the
-        # canonical legacy marker and writing False on the legacy cohort
-        # would expand the persisted config shape and break SC-004 / SC-007.
         if direct_send:
             initial_config["direct_send"] = True
 
@@ -385,14 +371,8 @@ class AssignAgentUseCase:
     ) -> None:
         """Persist library-catalog templates locally for the Direct Send path.
 
-        For every pre-approved spec, fetches the template content from
-        Meta's library catalog in the project-resolved language. If the
-        project locale is missing AND it is not already ``pt_BR``,
-        retries in ``pt_BR`` (FR-003c). If both attempts fail, raises
-        :class:`DirectSendTemplateUnavailableError` so the surrounding
-        ``@transaction.atomic`` block rolls back the whole assignment
-        (FR-003d). Skips every Integrations Engine template-creation
-        call (Decision 5).
+        Anchor: FR-003c (pt_BR fallback) / FR-003d (atomic rollback) /
+        Research Decision 5 (skip Integrations Engine).
         """
         template_builder = TemplateBuilderMixin()
         project_language = integrated_agent.config.get(
@@ -454,15 +434,11 @@ class AssignAgentUseCase:
         integrated_agent: IntegratedAgent,
         project_language: str,
     ):
-        """Fetch the template content with a ``pt_BR`` per-template fallback.
+        """Fetch template content with a ``pt_BR`` per-template fallback.
 
-        Returns ``(content, actual_language)`` on success. Raises
-        :class:`DirectSendTemplateUnavailableError` when neither the
-        project locale nor ``pt_BR`` returns content (FR-003d). The
-        first-locale fetch swallows adapter rejections so the ``pt_BR``
-        retry can fire per FR-003c (c); the retry itself propagates
-        adapter rejections so the surrounding ``@transaction.atomic``
-        rolls back.
+        Returns ``(content, actual_language)`` on success; raises
+        :class:`DirectSendTemplateUnavailableError` when both fail.
+        Anchor: FR-003c / FR-003d.
         """
         content = self._safely_fetch_direct_send_metadata(
             pre_approved.name, project_language
@@ -504,16 +480,12 @@ class AssignAgentUseCase:
     def _safely_fetch_direct_send_metadata(
         self, template_name: str, language: str
     ) -> Optional[Dict[str, Any]]:
-        """First-locale fetch with FR-003c routing for adapter rejections.
+        """First-locale fetch that translates adapter rejections to ``None``.
 
-        Translates ``DirectSendUnsupportedComponentError`` into "no
-        usable content" (returns ``None``) so the caller's ``pt_BR``
-        retry can fire per FR-003c (c) — but ONLY when a retry is
-        actually available (``language`` is non-``pt_BR``). When the
-        first-locale fetch IS already ``pt_BR``, no retry is possible,
-        so the exception propagates and the operator sees the specific
-        ``direct_send_unsupported_component`` code instead of the more
-        generic ``direct_send_template_unavailable`` (FR-003d).
+        When ``language`` is already ``pt_BR`` no retry is available,
+        so the exception propagates verbatim so operators see the
+        specific ``direct_send_unsupported_component`` code rather
+        than the generic unavailable code. Anchor: FR-003c / FR-003d.
         """
         try:
             return fetch_meta_library_template_metadata(

--- a/retail/agents/domains/agent_webhook/services/broadcast.py
+++ b/retail/agents/domains/agent_webhook/services/broadcast.py
@@ -412,15 +412,11 @@ class Broadcast:
         """Send broadcast message via flows service.
 
         ``dispatch_context`` carries the commercial origin (order_form_id /
-        order_id) of the broadcast so the persisted BroadcastMessage row
-        can later be matched against an ``invoiced`` event for conversion
-        attribution. Defaults to ``None`` for non-commercial dispatches.
+        order_id) so the persisted BroadcastMessage row can later be
+        matched against an ``invoiced`` event for conversion attribution.
         """
         project_uuid = str(integrated_agent.project.uuid)
         vtex_account = integrated_agent.project.vtex_account
-        # FR-014c(d) / T116(h): path-aware accessor so the Direct Send
-        # dispatch log line continues to emit the template name after
-        # ``msg.template`` is dropped from the Direct Send wire shape.
         msg_payload = message.get("msg", {})
         template_name = msg_payload.get("direct_send_template_name") or msg_payload.get(
             "template", {}
@@ -620,25 +616,12 @@ class Broadcast:
     def get_current_template(
         self, integrated_agent: IntegratedAgent, data: Dict[str, Any]
     ) -> Optional[Template]:
-        """
-        Get current template from integrated agent templates.
+        """Resolve the dispatchable ``Template`` by name, or ``None`` on skip.
 
-        Expectation: the agent/Lambda must return the stable template base
-        name (Template.name), e.g., "payment_confirmation_2" or
-        "payment_approved".
-
-        The lookup uses only ``Template.name`` and ensures the template is
-        active and has a non-null ``current_version``. The status
-        classification happens in Python so a single SQL query (with
-        ``current_version`` eagerly joined via ``select_related``) covers
-        every branch: ``APPROVED`` returns the Template; every other
-        outcome — including the no-row case — routes through the unified
-        ``_log_dispatch_skipped_due_to_status`` helper with the
-        ``version_status`` discriminator (``NOT_FOUND`` when no row matched,
-        the actual ``Version.status`` otherwise) and returns ``None``
-        (FR-012, FR-027 Exception clause, FR-039 "Dispatch-gate skip
-        (unified shape)", FR-044 ``project_uuid`` + ``vtex_account`` are
-        top-level keys).
+        ``APPROVED`` returns the Template; every other outcome (including
+        no-row) routes through ``_log_dispatch_skipped_due_to_status``.
+        Anchor: FR-012 / FR-039 (see
+        ``specs/002-direct-send-broadcasts/spec.md``).
         """
         template_name = data.get("template")
         project_uuid = str(integrated_agent.project.uuid)
@@ -683,21 +666,11 @@ class Broadcast:
         version_status: str,
         data: Dict[str, Any],
     ) -> None:
-        """Emit the unified FR-039 "Dispatch-gate skip" audit log line.
+        """Emit the unified "Dispatch-gate skip" audit log line.
 
-        Single observability shape for every non-``APPROVED`` skip class at
-        the dispatch gate: ``NOT_FOUND`` (no row matched the requested
-        name), ``PAUSED`` / ``FLAGGED`` (the US3 dispatch-disabling
-        states), and every other pre-existing non-``APPROVED``
-        ``Version.status`` value (``PENDING``, ``REJECTED``, ``IN_APPEAL``,
-        ``LOCKED``, ``DISABLED``, ``DELETED``, ``PENDING_DELETION``). The
-        ``version_status`` discriminator carries the skip class so log
-        consumers can route on each class independently without parser
-        changes (FR-027 Exception clause).
-
-        Both ``project_uuid`` and ``vtex_account`` are top-level
-        structured fields (FR-044) so operators can filter by either
-        tenant identifier.
+        Anchor: FR-039 (single shape for every non-``APPROVED`` skip
+        class) + FR-027 Exception clause + FR-044 (top-level tenant
+        keys).
         """
         logger.warning(
             f"[BroadcastDispatch] skipped_due_to_status: "
@@ -716,23 +689,13 @@ class Broadcast:
         template: Template,
         integrated_agent: IntegratedAgent,
     ) -> Optional[Dict[str, Any]]:
-        """Build the Direct Send broadcast payload.
+        """Build the Direct Send broadcast payload, or ``None`` on refusal.
 
-        Wire shape: ``contracts/messaging-gateway-payload.md`` §3 —
-        Retail substitutes every ``{{N}}`` placeholder server-side and
-        emits ``msg.direct_send=true`` + ``msg.category="utility"``.
-
-        Refuses to emit (returns ``None`` + WARNING audit-log entry with
-        the ``[BroadcastDispatch] skipped_due_to_direct_send_validation``
-        shape pinned by FR-039) when (a) the template name fails
-        ``is_valid_direct_send_template_name`` (FR-017 / Decision 7),
-        (b) ``template.metadata.body`` is missing or empty (Direct Send
-        Beta requires a body component), or (c) any post-substitution
-        component exceeds Meta's documented length limits — body ≤ 1024,
-        header.text ≤ 60, footer ≤ 60, button ``display_text`` / ``title``
-        ≤ 20 (constants in ``direct_send_constants``). Button ``url`` is
-        NOT length-checked here per contract §3.3 (URLs can be much
-        longer than the 20-char ``display_text`` ceiling).
+        Refusal reasons emit ``skipped_due_to_direct_send_validation``
+        WARNING and return ``None``. Anchor: FR-014a / FR-014b / FR-014c
+        / FR-014d / FR-017 / FR-039 (see
+        ``specs/002-direct-send-broadcasts/spec.md``;
+        ``contracts/messaging-gateway-payload.md`` §3).
         """
         template_variables = dict(data.get("template_variables") or {})
         contact_urn = data.get("contact_urn")
@@ -804,16 +767,6 @@ class Broadcast:
             )
             return None
 
-        # FR-014c: the local template name is emitted as a top-level
-        # sibling key (``direct_send_template_name``) — no nested
-        # ``msg.template`` block on the Direct Send path.
-        # FR-014c(f): ``language`` is resolved internally (above) so
-        # downstream persistence and datalake calls keep their locale
-        # context, but the wire MUST NOT carry locale on the Direct
-        # Send path — no ``msg.locale`` / ``msg.language``.
-        # FR-014d: the substituted body is emitted under ``msg.text``;
-        # the storage key ``Template.metadata["body"]`` and the local
-        # variable ``substituted_body`` stay unchanged (wire-only rename).
         msg: Dict[str, Any] = {
             "direct_send": True,
             "category": "utility",
@@ -876,13 +829,11 @@ class Broadcast:
         reason: str,
         data: Dict[str, Any],
     ) -> None:
-        """Emit the FR-039 Direct Send validation skip audit log line.
+        """Emit the Direct Send validation skip audit log line.
 
-        ``project_uuid`` is a top-level structured field (FR-044) so
-        operators can filter by tenant. The ``reason`` discriminator
-        pins the refusal class (``naming_rule`` / ``empty_body`` /
-        ``component_length_limit``) so log consumers can route on each
-        class independently (research Decision 7).
+        Anchor: FR-039 (refusal shape) + FR-044 (top-level
+        ``project_uuid``) + Research Decision 7 (``reason``
+        discriminator).
         """
         logger.warning(
             f"[BroadcastDispatch] skipped_due_to_direct_send_validation: "
@@ -897,12 +848,9 @@ class Broadcast:
     ) -> Optional[Dict[str, Any]]:
         """Build broadcast message from lambda response data.
 
-        Routes between the legacy ``build_broadcast_template_message``
-        and the new ``build_direct_send_message`` based on the
-        ``IntegratedAgent.config["direct_send"]`` snapshot taken at
-        assignment time (data-model.md §1; research Decision 11). The
-        flag lives inside the existing ``config`` JSONField; absence
-        is the canonical legacy marker per FR-001 / FR-005 / FR-025.
+        Routes between legacy and Direct Send paths based on
+        ``IntegratedAgent.config["direct_send"]``. Anchor: FR-001 /
+        FR-005 / FR-025 (absence is the canonical legacy marker).
         """
         project_uuid = str(integrated_agent.project.uuid)
         vtex_account = integrated_agent.project.vtex_account
@@ -978,9 +926,6 @@ class Broadcast:
         """
 
         # Extract template name from lambda data or message.
-        # FR-014c: the Direct Send wire shape carries the local
-        # template name on ``msg.direct_send_template_name``; the legacy
-        # shape continues to nest it under ``msg.template.name``.
         template_name = ""
         if lambda_data and "template" in lambda_data:
             template_name = lambda_data["template"]

--- a/retail/agents/domains/agent_webhook/services/direct_send_button_overrides.py
+++ b/retail/agents/domains/agent_webhook/services/direct_send_button_overrides.py
@@ -1,31 +1,9 @@
-"""Per-``(template_name, language)`` button-label override map (FR-003g).
+"""Per-``(template_name, language)`` URL-button label override map.
 
-A small data-driven map consulted at fetch time inside
-``_validate_and_normalize_buttons`` ONLY when an upstream URL button's
-``text`` for an entry of ``type == "URL"`` would otherwise fail the
-existing ``MAX_BUTTON_LABEL_LENGTH`` check (Session 2026-05-22 Q5–Q9).
-
-Scope and rules (FR-003g(a)–(h)):
-
-- The override applies EXCLUSIVELY to the single URL button per template
-  (FR-003f caps URL count at ≤1). QUICK_REPLY overflows continue to
-  raise per FR-003f.c — the override mechanism is NOT in scope for
-  QUICK_REPLY in v1.
-- The override is consulted ONLY when the upstream label would
-  otherwise overflow. Labels that already fit the 20-char ceiling are
-  persisted verbatim; the map is NEVER consulted in that case
-  (FR-003g(b) "trigger conditional on overflow").
-- An override value that itself exceeds ``MAX_BUTTON_LABEL_LENGTH``
-  MUST raise ``DirectSendUnsupportedComponentError(component_type="buttons")``
-  — the override is a remediation, not a length-check bypass
-  (FR-003g(h)).
-- Per-call branching on ``template_name`` inside the adapter is
-  forbidden (FR-003g(a)). The adapter consults the map ONLY via
-  ``(template_name, language)`` lookup.
-- Audit is INFO-log-only at the override site; no flag is persisted on
-  ``Template.metadata.direct_send`` (FR-003g(f)).
-
-Adding any further entry is a spec amendment (FR-003g(g)).
+Source of truth for the FR-003g remediation table. Consumed by
+``_meta_library_template_fetch._resolve_url_button_label_override``.
+Adding entries is a spec amendment (FR-003g(g)); see
+``specs/002-direct-send-broadcasts/spec.md`` for the normative rules.
 """
 
 DIRECT_SEND_BUTTON_LABEL_OVERRIDES: dict[tuple[str, str], str] = {

--- a/retail/agents/domains/agent_webhook/services/direct_send_constants.py
+++ b/retail/agents/domains/agent_webhook/services/direct_send_constants.py
@@ -1,28 +1,10 @@
-"""Direct Send Beta per-component length limits.
+"""Direct Send Beta per-component character limits.
 
-Single source of truth for the per-component character limits Meta
-enforces on Direct Send Beta v1 messages. Imported by:
-
-- ``direct_send_payload_builder`` / ``Broadcast.build_direct_send_message``
-  (dispatch-time post-substitution check — T013), and
-- ``adapt_meta_library_template_response`` in
-  ``retail/templates/usecases/_meta_library_template_fetch.py``
-  (assignment-time pre-substitution check — T023).
-
-References:
-
-- ``contracts/meta-library-catalog.md`` §5 (Direct Send Beta supported
-  component set and per-component limits).
-- ``contracts/messaging-gateway-payload.md`` §3.1 (length limits per
-  message component on the Direct Send wire shape).
-
-``MAX_BUTTON_LABEL_LENGTH`` is named generically because it bounds
-BOTH ``cta_url.display_text`` (the visible button label, NOT the URL
-itself — URLs can be much longer, see
-``contracts/messaging-gateway-payload.md`` §3.3) AND ``reply.title``.
-If Meta ever updates either limit independently, split into
-``MAX_CTA_DISPLAY_TEXT_LENGTH`` + ``MAX_REPLY_TITLE_LENGTH`` (same
-value at v1).
+Enforced by ``Broadcast._exceeds_direct_send_length_limits`` at dispatch
+and by ``_meta_library_template_fetch._validate_*`` at assignment.
+Sourced from ``contracts/meta-library-catalog.md`` §5 and
+``contracts/messaging-gateway-payload.md`` §3.1; see
+``specs/002-direct-send-broadcasts/spec.md`` for the normative rules.
 """
 
 MAX_BODY_LENGTH = 1024

--- a/retail/agents/domains/agent_webhook/services/direct_send_payload_builder.py
+++ b/retail/agents/domains/agent_webhook/services/direct_send_payload_builder.py
@@ -1,30 +1,8 @@
 """Direct Send payload-building helpers.
 
-Pure functions used by ``Broadcast.build_direct_send_message`` to
-turn a Direct Send-enabled ``Template.metadata`` + Lambda
-``template_variables`` into the wire shape pinned by
-``contracts/messaging-gateway-payload.md`` §3.
-
-Two responsibilities:
-
-- ``substitute_template_variables`` — substitute ``{{N}}`` placeholders
-  (whitespace-tolerant) with values from a positional dict (research
-  Decision 6). Missing indices log a WARNING and substitute to empty
-  string; extra indices are silently ignored.
-- ``is_valid_direct_send_template_name`` — enforce Meta's Direct Send
-  Beta identifier rule (snake_case + ≤ 512 chars, research Decision 7
-  / FR-017).
-
-The header / footer / cta / quick_replies builders consume the
-``Template.metadata`` shape produced by ``_get_template_info`` /
-``adapt_meta_library_template_response`` (data-model.md §3).
-
-FR-014a / FR-014b wire shape (Session 2026-05-22 Q4 / Q10) — the
-Direct Send path NEVER emits ``msg.buttons`` (LEGACY-ONLY):
-
-- CTA URL → ``msg.interaction_type = "cta_url"`` +
-  ``msg.cta_message = {display_text, url}`` siblings on ``msg``.
-- QUICK_REPLY → flat ``msg.quick_replies = ["title 1", ...]`` array.
+Pure functions that translate ``Template.metadata`` + Lambda variables
+into the Direct Send wire shape. Anchor: FR-013 / FR-014a / FR-014b /
+FR-017 (see ``specs/002-direct-send-broadcasts/spec.md``).
 """
 
 import logging
@@ -47,10 +25,9 @@ def substitute_template_variables(
 ) -> str:
     """Replace every ``{{N}}`` placeholder with ``str(variables[str(N)])``.
 
-    Missing indices substitute to empty string and emit a WARNING log
-    so operators can detect the rule-engine gap without halting the
-    broadcast. Extra indices in ``variables`` are silently ignored
-    (research Decision 6 + spec edge cases).
+    Missing indices substitute to empty string and emit a WARNING so
+    operators see rule-engine gaps without halting the broadcast.
+    Anchor: FR-013 / Research Decision 6.
     """
     if not text:
         return text
@@ -68,11 +45,9 @@ def substitute_template_variables(
 
 
 def is_valid_direct_send_template_name(name: str) -> bool:
-    """Return True iff ``name`` satisfies Meta's Direct Send identifier rule.
+    """Return True iff ``name`` matches ``^[a-z0-9_]+$`` and ``len <= 512``.
 
-    The rule is ``^[a-z0-9_]+$`` with length ≤ 512 (research
-    Decision 7, FR-017). Names that fail this check MUST NOT be sent
-    through Direct Send; the dispatcher refuses to emit a payload.
+    Anchor: FR-017 / Research Decision 7.
     """
     if not name or len(name) > _MAX_TEMPLATE_NAME_LENGTH:
         return False
@@ -86,18 +61,9 @@ def build_direct_send_header(
     template_name: str,
     image_url: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Build the ``msg.header`` sub-object for the Direct Send payload.
+    """Build the ``msg.header`` sub-object, or ``None`` when absent.
 
-    Honours the discriminated-union shape pinned by
-    ``contracts/messaging-gateway-payload.md`` §3.2:
-
-    - ``IMAGE`` header → ``{"type": "image", "image_url": <url>}`` —
-      requires ``image_url`` (typically pulled from the Lambda's
-      ``template_variables.image_url``); returns ``None`` when the URL
-      is missing.
-    - ``TEXT`` header → ``{"type": "text", "text": <substituted>}``.
-
-    Returns ``None`` when the template has no header.
+    Anchor: ``contracts/messaging-gateway-payload.md`` §3.2.
     """
     header = metadata.get("header")
     if not header:
@@ -125,7 +91,7 @@ def build_direct_send_footer(
     *,
     template_name: str,
 ) -> Optional[str]:
-    """Build the ``msg.footer`` text for the Direct Send payload."""
+    """Build the ``msg.footer`` text, or ``None`` when absent."""
     footer = metadata.get("footer")
     if not footer:
         return None
@@ -140,14 +106,9 @@ def build_direct_send_cta_message(
     *,
     template_name: str,
 ) -> Optional[Dict[str, Any]]:
-    """Build the ``msg.cta_message`` sub-object for the Direct Send payload.
+    """Build the ``msg.cta_message`` sub-object, or ``None`` when no URL button.
 
-    Reads the single ``URL`` button from ``metadata.buttons`` (FR-003f
-    caps URL count at ≤1 at fetch time) and emits the FR-014a wire
-    shape ``{display_text, url}`` with both fields substituted
-    server-side. Returns ``None`` when no URL button is present so
-    the dispatch builder skips ``msg.interaction_type`` and
-    ``msg.cta_message``.
+    Anchor: FR-014a (URL count is capped at fetch time by FR-003f).
     """
     raw_buttons = metadata.get("buttons") or []
     for btn in raw_buttons:
@@ -173,14 +134,10 @@ def build_direct_send_quick_replies(
     *,
     template_name: str,
 ) -> Optional[List[str]]:
-    """Build the ``msg.quick_replies`` flat array for the Direct Send payload.
+    """Build the flat ``msg.quick_replies`` array, or ``None`` when absent.
 
-    Reads ``QUICK_REPLY`` entries from ``metadata.buttons`` and emits
-    the FR-014b wire shape — a flat list of post-substitution title
-    strings (no wrapping object, no ``sub_type`` / ``id`` field; Meta
-    library catalog's ``id`` is intentionally not carried on the wire).
-    Returns ``None`` when no QUICK_REPLY entry is present so the
-    dispatch builder skips ``msg.quick_replies``.
+    Anchor: FR-014b — Meta library catalog's ``id`` is intentionally
+    dropped, only post-substituted titles travel on the wire.
     """
     raw_buttons = metadata.get("buttons") or []
     titles = [

--- a/retail/agents/tests/services/test_broadcast.py
+++ b/retail/agents/tests/services/test_broadcast.py
@@ -144,10 +144,9 @@ class BroadcastHandlerTest(TestCase):
         self.assertIsNone(result)
 
     def _stub_template_lookup(self, template) -> MagicMock:
-        """Wire ``templates.filter(...).select_related(...).first()`` to
-        return ``template`` (or ``None``) in a single chain. The
-        implementation issues exactly one ``filter()`` call per
-        ``get_current_template`` invocation and classifies the version
+        """Stub the single ``filter().select_related().first()`` lookup
+        chain that ``get_current_template`` exercises per invocation.
+        The actual ``Version.status`` value is classified
         status in Python (US3 / T031).
         """
         mock_filter = MagicMock()
@@ -158,10 +157,9 @@ class BroadcastHandlerTest(TestCase):
     def _assert_dispatch_skip_audit(
         self, audit_line: str, *, expected_version_status: str
     ) -> None:
-        """Assert the unified ``[BroadcastDispatch] skipped_due_to_status``
-        audit log shape per FR-039 + FR-044 (US3 / T029):
-        prefix, top-level ``project_uuid`` + ``vtex_account``, ``agent``,
-        ``template``, ``version_status``, and the ``event`` payload.
+        """Assert the unified Dispatch-gate skip audit shape.
+
+        Anchor: FR-039 + FR-044 (top-level tenant keys).
         """
         self.assertIn("[BroadcastDispatch] skipped_due_to_status:", audit_line)
         self.assertIn(f"project_uuid={self.mock_agent.project.uuid}", audit_line)
@@ -174,7 +172,7 @@ class BroadcastHandlerTest(TestCase):
         self.assertIn("event=", audit_line)
 
     def test_get_current_template_paused_returns_none_and_logs_audit(self):
-        """Story 3 AS1 + FR-039 unified Dispatch-gate skip shape (T029)."""
+        """PAUSED returns None and logs unified shape. Anchor: FR-039."""
         data = {
             "template": "order_update",
             "contact_urn": "whatsapp:5511",
@@ -211,7 +209,7 @@ class BroadcastHandlerTest(TestCase):
         self.assertIn("ORDER-1", audit_lines[0])
 
     def test_get_current_template_flagged_returns_none_and_logs_audit(self):
-        """Story 3 AS2 — same assertion for FLAGGED (T029)."""
+        """FLAGGED returns None and logs unified shape. Anchor: FR-039."""
         data = {
             "template": "order_update",
             "contact_urn": "whatsapp:5511",
@@ -244,12 +242,7 @@ class BroadcastHandlerTest(TestCase):
         self.assertIn("ORDER-2", audit_lines[0])
 
     def test_get_current_template_not_found_emits_unified_audit_shape(self):
-        """T029 — when no Template row matches the requested name,
-        ``get_current_template`` emits the unified audit shape with
-        ``version_status=NOT_FOUND`` (FR-027 Exception clause / FR-039
-        "Dispatch-gate skip (unified shape)"). Replaces the per-name miss
-        legacy line previously emitted at this gate.
-        """
+        """No row matched emits NOT_FOUND. Anchor: FR-027 Exception / FR-039."""
         data = {
             "template": "order_update",
             "contact_urn": "whatsapp:5511",
@@ -277,8 +270,6 @@ class BroadcastHandlerTest(TestCase):
         )
         self.assertIn("ORDER-3", audit_lines[0])
 
-        # The previously-legacy per-name miss line MUST NOT be emitted at
-        # this gate anymore (FR-027 Exception clause).
         self.assertEqual(
             [
                 msg
@@ -289,10 +280,7 @@ class BroadcastHandlerTest(TestCase):
         )
 
     def test_get_current_template_returns_template_after_resume_to_approved(self):
-        """Story 3 AS3 / SC-006 — after the version flips back to
-        APPROVED the next call returns the Template and emits no new
-        audit log entry (T029).
-        """
+        """APPROVED resume returns the Template and emits no new audit line."""
         data = {"template": "order_update", "contact_urn": "whatsapp:5511"}
         approved_template = MagicMock()
         approved_template.current_version.template_name = "order_update_v3"
@@ -319,16 +307,7 @@ class BroadcastHandlerTest(TestCase):
     def test_get_current_template_non_approved_other_states_emit_unified_audit_shape(
         self,
     ):
-        """T029 — pre-existing non-APPROVED states (PENDING, REJECTED,
-        IN_APPEAL, LOCKED, DISABLED, DELETED, PENDING_DELETION) emit the
-        SAME unified ``[BroadcastDispatch] skipped_due_to_status`` audit
-        shape as PAUSED/FLAGGED, with the actual status as the
-        ``version_status`` discriminator (FR-027 Exception clause /
-        FR-039 "Dispatch-gate skip (unified shape)"). Replaces the prior
-        regression that asserted these states KEPT the legacy
-        ``"Template not found ..."`` line — that line is now consolidated
-        into the audit shape at this gate.
-        """
+        """Pre-existing non-APPROVED states emit unified shape. Anchor: FR-027 / FR-039."""
         legacy_states = [
             "PENDING",
             "REJECTED",
@@ -382,17 +361,11 @@ class BroadcastHandlerTest(TestCase):
                         in msg
                     ],
                     [],
-                    f"state={state} must NOT emit the legacy per-name miss line "
-                    "(consolidated by FR-027 Exception clause)",
+                    f"state={state} must NOT emit the legacy per-name miss line",
                 )
 
     def test_get_current_template_paused_emits_audit_on_each_call(self):
-        """Spec edge case 'concurrent broadcasts targeting the same
-        paused template' — two sequential ``get_current_template``
-        calls against the same PAUSED template both return ``None`` and
-        both emit the audit log entry (proves the gate is per-event
-        and stateless) (T029).
-        """
+        """Two PAUSED calls each emit one audit line (per-event, stateless)."""
         data = {"template": "order_update", "contact_urn": "whatsapp:5511"}
         paused_template = MagicMock()
         paused_template.name = "order_update"
@@ -421,11 +394,7 @@ class BroadcastHandlerTest(TestCase):
             )
 
     def test_get_current_template_issues_single_filter_call(self):
-        """T031 strategy pin — ``get_current_template`` MUST issue
-        exactly one ``templates.filter(...)`` call per invocation. A
-        regression that re-introduced a sibling fallback query would
-        fail this test even on the happy path.
-        """
+        """Single-query strategy pin: exactly one ``templates.filter()`` per call."""
         data = {"template": "order_update", "contact_urn": "whatsapp:5511"}
         approved_template = MagicMock()
         approved_template.current_version.status = "APPROVED"
@@ -1057,29 +1026,10 @@ class BroadcastRecordingTest(TestCase):
 
 
 class LegacyBuildMessageSkippedOnNonApprovedStateTest(TestCase):
-    """T035 (US4 / Story 4 AS2 — FR-008 / FR-027 / FR-039 / FR-046).
+    """Legacy cohort path-independent dispatch gate.
 
-    For a Direct Send-DISABLED ``IntegratedAgent``, when the named
-    template's ``current_version.status`` is one of the pre-existing
-    non-``APPROVED`` states (PENDING, REJECTED, IN_APPEAL, LOCKED,
-    DISABLED, DELETED, PENDING_DELETION), ``Broadcast.build_message``
-    MUST:
-
-    - return ``None`` (no payload built, no Flows call follows),
-    - emit the **unified** ``[BroadcastDispatch] skipped_due_to_status:``
-      audit log via ``get_current_template`` (FR-027 Exception clause +
-      FR-039 "Dispatch-gate skip (unified shape)"),
-    - emit the legacy downstream ``"Template not found or has no
-      approved current version"`` warning UNCHANGED (FR-027 + FR-039
-      "Legacy downstream miss"),
-    - NOT invoke either ``build_broadcast_template_message`` or
-      ``build_direct_send_message``.
-
-    The dispatch gate is path-independent — same shape, same behavior on
-    the Direct Send and legacy cohorts. This test pins the assertion for
-    the legacy cohort specifically; the Direct Send cohort is covered by
-    the unified-shape regression in
-    ``test_get_current_template_non_approved_other_states_emit_unified_audit_shape``.
+    Anchor: FR-027 + FR-039 + FR-046 (the Direct Send cohort regression
+    lives in ``test_get_current_template_non_approved_other_states_emit_unified_audit_shape``).
     """
 
     _LEGACY_NON_APPROVED_STATES = [
@@ -1103,8 +1053,6 @@ class LegacyBuildMessageSkippedOnNonApprovedStateTest(TestCase):
         self.integrated_agent.channel_uuid = uuid4()
         self.integrated_agent.project.uuid = uuid4()
         self.integrated_agent.project.vtex_account = "legacy-store"
-        # Direct Send DISABLED — key absent from config (FR-001 / FR-005:
-        # absence is the canonical legacy marker).
         self.integrated_agent.config = {}
 
     def _stub_template_lookup(self, template):
@@ -1152,7 +1100,7 @@ class LegacyBuildMessageSkippedOnNonApprovedStateTest(TestCase):
                 self.assertEqual(
                     len(unified_audit_lines),
                     1,
-                    f"state={state} must emit the unified FR-039 audit line; "
+                    f"state={state} must emit one unified audit line; "
                     f"got: {captured.output}",
                 )
 
@@ -1164,7 +1112,6 @@ class LegacyBuildMessageSkippedOnNonApprovedStateTest(TestCase):
                 self.assertEqual(
                     len(downstream_miss_lines),
                     1,
-                    f"state={state} must keep the legacy downstream miss line "
-                    f"per FR-027 + FR-039 'Legacy downstream miss'; "
+                    f"state={state} must keep the legacy downstream miss line; "
                     f"got: {captured.output}",
                 )

--- a/retail/agents/tests/services/test_broadcast_direct_send.py
+++ b/retail/agents/tests/services/test_broadcast_direct_send.py
@@ -1,15 +1,7 @@
-"""Tests for ``Broadcast.build_direct_send_message`` (T011 cluster).
+"""Regression guards for ``Broadcast.build_direct_send_message``.
 
-Covers Story 1 acceptance scenarios — happy-path wire shape (AS1 /
-AS2 / AS3), quick-reply buttons (T011a), and the three Direct Send
-refusal classes — naming-rule (T011b), empty-body /
-component-length-limit (T011c), and the no-local-template edge case
-that routes through ``Broadcast.build_message`` (T011d).
-
-The audit-log shape pinned by these tests matches FR-039's
-``[BroadcastDispatch] skipped_due_to_direct_send_validation: ...``
-catalogue: ``project_uuid`` is the top-level key (FR-044), ``reason``
-is one of ``{naming_rule, empty_body, component_length_limit}``.
+Anchor: FR-014a / FR-014b / FR-014c / FR-014d / FR-017 / FR-039 /
+FR-044 (enforced at ``retail.agents.domains.agent_webhook.services.broadcast``).
 """
 
 import logging
@@ -62,23 +54,14 @@ def _make_integrated_agent(*, project_uuid=None, agent_uuid=None, direct_send=Tr
 
 
 class BuildDirectSendMessageHappyPathTest(TestCase):
-    """Story 1 AS1 / AS2 / AS3 — happy-path wire shape (T011)."""
+    """Happy-path Direct Send wire shape. Anchor: FR-014a / FR-014c / FR-014d."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
         self.integrated_agent = _make_integrated_agent()
 
     def test_as1_body_with_two_variables_substituted_and_direct_send_flag(self):
-        """AS1 — canonical Direct Send wire shape (FR-014c / FR-014d).
-
-        On the Direct Send dispatch path the substituted body is carried
-        under ``msg.text`` (FR-014d) and the local template name under
-        ``msg.direct_send_template_name`` (FR-014c). The wire MUST NOT
-        carry ``msg.template`` or ``msg.locale`` / ``msg.language``
-        (FR-014c(a) / FR-014c(f)) — locale is computed internally for
-        ``BroadcastMessage`` persistence and datalake events but is
-        intentionally omitted from the outbound payload.
-        """
+        """Canonical Direct Send wire shape. Anchor: FR-014c / FR-014d."""
         template = _make_template(
             body="Olá {{1}}, seu pedido {{2}} foi enviado.",
         )
@@ -114,10 +97,7 @@ class BuildDirectSendMessageHappyPathTest(TestCase):
         self.assertNotIn("attachments", result["msg"])
 
     def test_as2_image_header_and_cta_url_button(self):
-        """AS2 with FR-014a wire shape: CTA URL is emitted via
-        ``msg.interaction_type`` + ``msg.cta_message`` siblings, NOT
-        inside ``msg.buttons`` (which is LEGACY-ONLY).
-        """
+        """CTA URL is emitted via ``msg.cta_message``. Anchor: FR-014a."""
         template = _make_template(
             body="Olá {{1}}, seu pedido {{2}} chegou.",
             header={"header_type": "IMAGE", "text": "image-placeholder"},
@@ -236,21 +216,7 @@ class BuildDirectSendMessageHappyPathTest(TestCase):
 
 
 class BuildDirectSendMessageQuickReplyWireShapeTest(TestCase):
-    """T114 / FR-014b — QUICK_REPLY wire shape relocation.
-
-    On the Direct Send dispatch path, Quick Reply buttons MUST be
-    emitted as a top-level flat array of post-substitution title strings
-    on ``msg``: ``msg.quick_replies = ["title 1", ...]`` (no wrapping
-    object, no ``sub_type`` / ``id`` field). The QUICK_REPLY entries
-    MUST NOT appear inside ``msg.buttons`` — combined with FR-014a,
-    the Direct Send path NEVER emits a ``msg.buttons`` key.
-
-    SUPERSEDES the previous ``BuildDirectSendMessageQuickReplyButtonsTest``
-    class which asserted the pre-FR-014b ``msg.buttons[*].sub_type=reply``
-    shape (T011a). The original assertions were dropped from the
-    coverage floor when T011a was marked ``[~] SUPERSEDED by T114``;
-    this class restores coverage on the canonical wire shape.
-    """
+    """QUICK_REPLY wire shape on Direct Send. Anchor: FR-014b."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
@@ -299,10 +265,7 @@ class BuildDirectSendMessageQuickReplyWireShapeTest(TestCase):
         self.assertEqual(result["msg"]["quick_replies"], ["Sim", "Não", "Cancelar"])
 
     def test_id_field_is_not_carried_on_the_wire(self):
-        """Meta's library catalog ``id`` field is intentionally NOT
-        propagated to the Direct Send wire shape. Each element of
-        ``msg.quick_replies`` MUST be a plain string, not a dict.
-        """
+        """Meta's catalog ``id`` is dropped at the wire. Anchor: FR-014b."""
         template = _make_template(
             body="Body",
             buttons=[{"type": "QUICK_REPLY", "id": "yes_track", "text": "Acompanhar"}],
@@ -348,9 +311,7 @@ class BuildDirectSendMessageQuickReplyWireShapeTest(TestCase):
         )
 
     def test_combined_url_and_quick_replies_emit_parallel_siblings(self):
-        """FR-014b(f) — combined-case regression guard. Both surfaces
-        are independent on the wire and neither suppresses the other.
-        """
+        """URL + QUICK_REPLY surfaces are independent. Anchor: FR-014b(f)."""
         template = _make_template(
             body="Olá.",
             buttons=[
@@ -391,7 +352,7 @@ class BuildDirectSendMessageQuickReplyWireShapeTest(TestCase):
 
 
 class BuildDirectSendMessageNamingRuleRefusalTest(TestCase):
-    """FR-017 / Decision 7 — naming-rule refusal (T011b)."""
+    """Naming-rule refusal path. Anchor: FR-017 / Research Decision 7."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
@@ -437,12 +398,7 @@ class BuildDirectSendMessageNamingRuleRefusalTest(TestCase):
 
 
 class BuildDirectSendMessageMissingContactUrnTest(TestCase):
-    """Defensive guard — caller did not provide ``contact_urn``.
-
-    The rule engine MUST hand the recipient URN to dispatch; when it
-    doesn't, ``build_direct_send_message`` logs an ERROR and returns
-    ``None`` so no payload is emitted to Flows.
-    """
+    """Defensive guard against missing ``contact_urn``."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
@@ -590,10 +546,7 @@ class BuildDirectSendMessageLengthAndEmptyBodyRefusalTest(TestCase):
         self._assert_refusal_reason(captured.output, "component_length_limit")
 
     def test_cta_button_url_over_20_chars_is_allowed(self):
-        """``url`` is NOT length-checked at this gate (contract §3.3 —
-        URLs can be much longer than the 20-char ``display_text`` ceiling).
-        With FR-014a the URL is read from ``msg.cta_message.url``.
-        """
+        """``url`` bypasses the 20-char gate per contract §3.3."""
         long_url = "https://loja.com/track/" + "x" * 100
         template = _make_template(
             body="Olá.",
@@ -616,22 +569,7 @@ class BuildDirectSendMessageLengthAndEmptyBodyRefusalTest(TestCase):
 
 
 class BuildDirectSendMessageCtaUrlWireShapeTest(TestCase):
-    """T113 / FR-014a — CTA URL wire shape relocation.
-
-    On the Direct Send dispatch path, a CTA URL button (sourced from a
-    Meta library template ``buttons`` entry of ``type: "URL"``) MUST be
-    emitted on the wire as a top-level discriminator + sibling
-    sub-object on ``msg``: ``msg.interaction_type = "cta_url"`` +
-    ``msg.cta_message = {display_text: <substituted>, url: <substituted>}``.
-    The CTA URL entry MUST NOT appear inside ``msg.buttons``.
-
-    Variable substitution (FR-013) applies to BOTH
-    ``cta_message.display_text`` and ``cta_message.url``. The 20-char
-    post-substitution length validation continues to be enforced —
-    relocated from ``msg.buttons[*].display_text`` to
-    ``msg.cta_message.display_text``. The URL itself is NOT length-checked
-    here (contract §3.3 — URLs can be up to 2000 chars).
-    """
+    """CTA URL wire shape on Direct Send. Anchor: FR-013 / FR-014a."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
@@ -755,14 +693,7 @@ class BuildDirectSendMessageCtaUrlWireShapeTest(TestCase):
 
 
 class BuildMessageNoLocalTemplateEdgeCaseTest(TestCase):
-    """Spec edge case — Direct Send-enabled agent with no local template (T011d).
-
-    The dispatch must converge on the existing "template not found"
-    skip path: ``build_direct_send_message`` is NOT invoked, no
-    payload is built, no ``BroadcastMessage`` is persisted, and the
-    legacy WARNING shape (preserved bit-for-bit per FR-027 / FR-039)
-    is the only log line emitted.
-    """
+    """Direct Send-enabled agent with no local template. Anchor: FR-027 / FR-039."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
@@ -793,19 +724,7 @@ class BuildMessageNoLocalTemplateEdgeCaseTest(TestCase):
 
 
 class BuildDirectSendMessageTemplateNameWireShapeTest(TestCase):
-    """T116 / FR-014c — drop ``msg.template``, add
-    ``msg.direct_send_template_name``, drop wire locale.
-
-    On the Direct Send dispatch path the canonical wire shape carries
-    the local template name on the top-level sibling key
-    ``msg.direct_send_template_name``; the nested ``msg.template``
-    block emitted by earlier revisions is forbidden (FR-014c(a)).
-    Locale is computed internally for ``BroadcastMessage`` persistence
-    and datalake events but is NOT emitted on the wire — neither under
-    ``msg.template.locale`` (forbidden by FR-014c(a)) nor under
-    sibling keys ``msg.locale`` / ``msg.language`` (forbidden by
-    FR-014c(f)).
-    """
+    """Template-name wire shape on Direct Send. Anchor: FR-014c."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
@@ -844,13 +763,7 @@ class BuildDirectSendMessageTemplateNameWireShapeTest(TestCase):
             result["msg"]["direct_send_template_name"]["name"]  # noqa: B018
 
     def test_locale_is_dropped_from_the_wire(self):
-        """FR-014c(f) — no language hint on the wire.
-
-        The internal locale resolution helper (``_resolve_language``)
-        MUST still be invoked for persistence / datalake purposes; we
-        capture that side via ``_resolve_language`` being callable on
-        the handler (it remains a method, never deleted).
-        """
+        """No language hint on the wire. Anchor: FR-014c(f)."""
         template = _make_template(
             name="weni_order_shipped", body="Olá.", language="es_MX"
         )
@@ -867,10 +780,7 @@ class BuildDirectSendMessageTemplateNameWireShapeTest(TestCase):
         self.assertTrue(callable(getattr(self.handler, "_resolve_language", None)))
 
     def test_naming_rule_refusal_still_gates_the_wire_identifier(self):
-        """FR-014c(b) + FR-017 — invalid template names MUST be refused
-        BEFORE any wire emission so an invalid identifier never lands
-        in ``msg.direct_send_template_name``.
-        """
+        """Naming-rule gate runs before wire emission. Anchor: FR-014c(b) / FR-017."""
         template = _make_template(name="Weni-Order-Invoiced", body="Olá.")
         data = {"template_variables": {}, "contact_urn": "whatsapp:55"}
         with self.assertLogs(_BUILDER_LOGGER, level=logging.WARNING) as captured:
@@ -887,12 +797,7 @@ class BuildDirectSendMessageTemplateNameWireShapeTest(TestCase):
         )
 
     def test_audit_log_keeps_template_field_unchanged(self):
-        """FR-014c(d) — the audit-log ``template={...}`` field is
-        INTERNAL observability and MUST NOT be renamed alongside the
-        wire-shape relocation. Log consumers continue to filter on
-        ``template=<template_name>`` regardless of the wire-emission
-        location of the same value.
-        """
+        """Audit-log ``template=`` field is not renamed. Anchor: FR-014c(d)."""
         template = _make_template(name="weni_order_empty", body="")
         data = {"template_variables": {}, "contact_urn": "whatsapp:55"}
         with self.assertLogs(_BUILDER_LOGGER, level=logging.WARNING) as captured:
@@ -911,14 +816,7 @@ class BuildDirectSendMessageTemplateNameWireShapeTest(TestCase):
 
 
 class BuildDirectSendMessageBodyTextRenameWireShapeTest(TestCase):
-    """T117 / FR-014d — rename wire key ``msg.body`` → ``msg.text``.
-
-    Wire-only rename: ``Template.metadata["body"]`` storage,
-    ``MAX_BODY_LENGTH`` constant, the ``reason=empty_body`` audit-log
-    discriminator, and local variable identifiers are preserved
-    unchanged (FR-014d(c)). Only the outbound JSON-key spelling
-    changes on the Direct Send path.
-    """
+    """Wire-only ``msg.body`` -> ``msg.text`` rename. Anchor: FR-014d."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
@@ -987,12 +885,7 @@ class BuildDirectSendMessageBodyTextRenameWireShapeTest(TestCase):
         )
 
     def test_length_check_runs_against_substituted_body_not_wire_key(self):
-        """FR-014d(e) — the gate reads from the local
-        ``substituted_body`` variable, NOT from ``msg["body"]`` or
-        ``msg["text"]``. Refusal happens BEFORE ``msg`` is assembled,
-        so the wire-key rename cannot change where the limit reads
-        from.
-        """
+        """Length gate reads ``substituted_body`` pre-assembly. Anchor: FR-014d(e)."""
         long_body = "x" * 2048
         template = _make_template(body=long_body)
         data = {"template_variables": {}, "contact_urn": "whatsapp:55"}

--- a/retail/agents/tests/services/test_broadcast_direct_send_persistence.py
+++ b/retail/agents/tests/services/test_broadcast_direct_send_persistence.py
@@ -1,16 +1,4 @@
-"""End-to-end Direct Send persistence parity (T011e — FR-016 / SC-005).
-
-Drives ``Broadcast.build_message`` → ``Broadcast.send_message`` against
-a Direct Send-enabled fixture and asserts:
-
-- the happy path persists exactly one ``BroadcastMessage`` row with
-  the expected fields,
-- each Direct Send refusal class (naming-rule, empty body, length
-  limit) skips persistence entirely (no row written).
-
-``flows_service.send_whatsapp_broadcast`` is mocked at the boundary
-so the test captures the outbound payload without hitting Flows.
-"""
+"""End-to-end Direct Send persistence parity. Anchor: FR-016."""
 
 import logging
 
@@ -299,14 +287,7 @@ class BroadcastDirectSendPersistenceTest(TestCase):
         )
 
     def test_template_metadata_body_storage_key_is_preserved(self):
-        """T117(f) / FR-014d(c) — internal storage MUST keep ``body``.
-
-        The FR-014d rename only relocates the OUTBOUND wire key
-        (``msg.body`` → ``msg.text``). ``Template.metadata["body"]``
-        is internal storage written from Meta's library catalog response
-        and is preserved unchanged so persisted rows, log consumers,
-        and downstream tooling do not require migration.
-        """
+        """``Template.metadata["body"]`` is wire-rename-immune. Anchor: FR-014d(c)."""
         self.assertEqual(
             self.template.metadata["body"],
             "Olá {{1}}, seu pedido {{2}} foi enviado.",
@@ -314,11 +295,7 @@ class BroadcastDirectSendPersistenceTest(TestCase):
         self.assertNotIn("text", self.template.metadata)
 
     def test_send_message_log_line_carries_direct_send_template_name(self):
-        """T116(h) — ``Broadcast.send_message`` logging accessor MUST
-        be path-aware so the Direct Send dispatch log line continues to
-        emit the resolved template name after FR-014c drops
-        ``msg.template`` from the wire.
-        """
+        """Path-aware logging accessor after wire-shape change. Anchor: FR-014c."""
         message = self.handler.build_message(self.integrated_agent, self.lambda_data)
         self.assertIsNotNone(message)
 

--- a/retail/agents/tests/services/test_broadcast_legacy_datalake.py
+++ b/retail/agents/tests/services/test_broadcast_legacy_datalake.py
@@ -1,16 +1,4 @@
-"""Legacy datalake event snapshot tests (T035a — US4 / FR-020 / SC-008).
-
-Pins the EXACT key set, value types, and emission count of the
-``weni_datalake_sdk`` / ``CommerceWebhookPath`` event payload emitted by
-the legacy dispatch path (``Broadcast._register_broadcast_event``) for
-each template family pinned by T033 — body-only, image-header (s3-keyed)
-+ URL button, and image-header (direct URL) + PAYMENT_REQUEST buttons +
-``order_details``. Any drift in the datalake schema fails CI; consumers
-downstream depend on these field names and types.
-
-Mocks the SDK at the boundary with ``unittest.mock.patch`` so the test
-never hits real infra (Constitution Principle III).
-"""
+"""Legacy datalake event snapshot. Anchor: FR-020 / SC-008."""
 
 from datetime import datetime
 from typing import Any, Dict
@@ -44,16 +32,7 @@ _LEGACY_EVENT_ALLOWED_KEYS = _LEGACY_EVENT_REQUIRED_KEYS | _LEGACY_EVENT_OPTIONA
 
 
 def _assert_legacy_datalake_event_shape(test_case: TestCase, event_data: Dict[str, Any]):
-    """Assert the legacy datalake event matches the pre-feature baseline.
-
-    Pinned invariants:
-    - required keys (``_LEGACY_EVENT_REQUIRED_KEYS``) are always present,
-    - any additional key MUST belong to ``_LEGACY_EVENT_OPTIONAL_KEYS``
-      (``status`` is only emitted when ``lambda_data`` carries it),
-    - value types match the schema consumers depend on,
-    - the optional ``direct_send`` field MUST NOT appear on the legacy
-      path (FR-020 — the legacy emission stays byte-identical).
-    """
+    """Assert the legacy datalake event matches the pre-feature baseline."""
     keys = set(event_data.keys())
     missing = _LEGACY_EVENT_REQUIRED_KEYS - keys
     unexpected = keys - _LEGACY_EVENT_ALLOWED_KEYS
@@ -68,7 +47,7 @@ def _assert_legacy_datalake_event_shape(test_case: TestCase, event_data: Dict[st
     test_case.assertNotIn(
         "direct_send",
         event_data,
-        "Legacy datalake event MUST NOT carry a direct_send field (FR-020).",
+        "Legacy datalake event MUST NOT carry a direct_send field.",
     )
 
     test_case.assertIsInstance(event_data["template"], str)
@@ -96,9 +75,7 @@ def _assert_legacy_datalake_event_shape(test_case: TestCase, event_data: Dict[st
     }
 )
 class LegacyBroadcastDatalakeSnapshotTest(TestCase):
-    """FR-020 / SC-008 — legacy datalake event payload MUST stay
-    byte-identical (same keys, same value types, same emission count).
-    """
+    """Legacy datalake payload byte-identity. Anchor: FR-020 / SC-008."""
 
     def setUp(self):
         self.project = Project.objects.create(
@@ -158,7 +135,7 @@ class LegacyBroadcastDatalakeSnapshotTest(TestCase):
         self.assertNotIn(
             "direct_send",
             message.get("msg", {}),
-            "Legacy msg MUST NOT carry direct_send (FR-015 / SC-004).",
+            "Legacy msg MUST NOT carry direct_send.",
         )
         self.handler.send_message(message, self.integrated_agent, lambda_data)
         return message

--- a/retail/agents/tests/services/test_broadcast_legacy_observability.py
+++ b/retail/agents/tests/services/test_broadcast_legacy_observability.py
@@ -1,17 +1,4 @@
-"""Legacy Sentry / Elastic APM dispatch tag snapshot tests (T035b — US4 /
-FR-027 / SC-008).
-
-Pins the observability instrumentation on ``Broadcast.send_message``
-against a Direct Send-DISABLED fixture. The pre-feature baseline is
-empty — ``Broadcast.send_message`` does not emit any Sentry tags / APM
-contexts of its own; tenant identifiers are carried only through
-structured log lines and the datalake event payload (covered by T035a).
-
-The legacy observability snapshot pins this baseline so a future change
-that adds Sentry tags / APM contexts on the legacy path triggers a
-review (FR-027: legacy observability surface is preserved unchanged;
-the optional ``direct_send`` tag is absent or ``False``).
-"""
+"""Legacy Sentry / APM dispatch tag snapshot. Anchor: FR-027 / SC-008."""
 
 from typing import Dict
 from unittest.mock import MagicMock, call, patch
@@ -40,11 +27,8 @@ _APM_TAG_FUNCS = (
 )
 # Tracing primitives (``start_span`` / ``start_transaction``) are
 # deliberately NOT patched here — they are auto-instrumented by Sentry's
-# Django integration on every ORM call and would generate noise unrelated
-# to user-facing instrumentation. FR-027's "no Sentry / APM tag is
-# renamed or removed" rule scopes to the EXPLICIT tag/context setters
-# pinned above; automatic DB spans carry no tenant identifier in their
-# arguments and are outside the legacy observability surface.
+# Django integration on every ORM call. The legacy observability surface
+# is scoped to the EXPLICIT tag/context setters pinned above.
 
 
 @override_settings(
@@ -56,11 +40,7 @@ _APM_TAG_FUNCS = (
     }
 )
 class LegacyBroadcastObservabilitySnapshotTest(TestCase):
-    """FR-027 / SC-008 — legacy dispatch observability surface MUST NOT
-    drift. Concretely: no Sentry tag / APM context is emitted by
-    ``Broadcast.send_message`` on a Direct Send-DISABLED fixture, and no
-    ``direct_send`` tag is set on this path.
-    """
+    """Legacy dispatch observability surface non-drift. Anchor: FR-027 / SC-008."""
 
     def setUp(self):
         self.project = Project.objects.create(
@@ -111,12 +91,7 @@ class LegacyBroadcastObservabilitySnapshotTest(TestCase):
         }
 
     def _make_tag_captures(self) -> Dict[str, MagicMock]:
-        """Patch every Sentry / APM tag-setting boundary the broadcast
-        layer COULD call. The current baseline emits nothing — any
-        captured call would mean an observability instrumentation has
-        been added on the legacy path without going through the FR-027
-        review gate.
-        """
+        """Patch every Sentry/APM tag-setting boundary the broadcast layer could call."""
         captures: Dict[str, MagicMock] = {}
         for target in _SENTRY_TAG_FUNCS + _APM_TAG_FUNCS:
             patcher = patch(target, create=True)
@@ -132,7 +107,7 @@ class LegacyBroadcastObservabilitySnapshotTest(TestCase):
         self.assertNotIn(
             "direct_send",
             message.get("msg", {}),
-            "Legacy msg MUST NOT carry direct_send key (FR-015 / SC-004).",
+            "Legacy msg MUST NOT carry direct_send key.",
         )
 
         self.handler.send_message(message, self.integrated_agent, self.lambda_data)
@@ -151,11 +126,7 @@ class LegacyBroadcastObservabilitySnapshotTest(TestCase):
         )
 
     def test_legacy_dispatch_does_not_set_direct_send_tag(self):
-        """Even if a future PR introduces ANY Sentry/APM instrumentation,
-        the ``direct_send`` tag/context key MUST NOT be set with a truthy
-        value on the legacy path (FR-027: optional ``direct_send`` tag
-        is absent or ``False``).
-        """
+        """No truthy ``direct_send`` tag on the legacy path. Anchor: FR-027."""
         captures = self._make_tag_captures()
 
         message = self.handler.build_message(self.integrated_agent, self.lambda_data)
@@ -171,24 +142,13 @@ class LegacyBroadcastObservabilitySnapshotTest(TestCase):
             offending_calls,
             [],
             "Legacy path must not set direct_send=True on any Sentry/APM "
-            f"boundary (FR-027). Offending calls: {offending_calls}",
+            f"boundary. Offending calls: {offending_calls}",
         )
 
 
 def _call_sets_direct_send_true_tag(captured_call) -> bool:
     """Return True iff ``captured_call`` sets a truthy ``direct_send``
-    tag/context value.
-
-    Two surface shapes are accepted (the union of Sentry's and APM's
-    public signatures):
-
-    - ``f("direct_send", True)`` or ``f(key="direct_send", value=True)``
-      — the tag-name / tag-value positional or keyword form;
-    - ``f("context", {"direct_send": True, ...})`` — a context dict
-      where ``direct_send`` is one of the keys.
-
-    Either shape with a falsy value (``False`` / ``None`` / ``0``) is
-    spec-compliant per FR-027's "absent or ``False``" clause.
+    tag/context value (positional/keyword tag-name+value, or context dict).
     """
     args = captured_call.args
     kwargs = captured_call.kwargs
@@ -203,13 +163,7 @@ def _call_sets_direct_send_true_tag(captured_call) -> bool:
 
 
 class CallSetsDirectSendTrueTagHelperTest(TestCase):
-    """Unit-tests the pure helper used by the snapshot's assertion arm.
-
-    The helper is the contract by which ``test_legacy_dispatch_does_not_set_direct_send_tag``
-    classifies a captured Sentry/APM call as FR-027-compliant or
-    offending. Exercising every branch here guarantees the snapshot
-    guard itself is sound when drift eventually surfaces.
-    """
+    """Branch coverage for ``_call_sets_direct_send_true_tag``."""
 
     def test_positional_direct_send_true_is_offending(self):
         self.assertTrue(_call_sets_direct_send_true_tag(call("direct_send", True)))

--- a/retail/agents/tests/services/test_broadcast_legacy_payload.py
+++ b/retail/agents/tests/services/test_broadcast_legacy_payload.py
@@ -1,14 +1,4 @@
-"""Legacy broadcast payload snapshot tests (T033 — US4 / FR-015 / SC-004).
-
-Pins the EXACT byte-shape of the Flows broadcast payload emitted today by
-``Broadcast.build_broadcast_template_message`` for the three template
-families exercised by the OrderStatus fleet — body-only with positional
-variables, image-header (s3-keyed) plus URL button, and image-header
-(direct URL) plus PAYMENT_REQUEST buttons with ``order_details``. The
-Direct Send feature MUST NOT alter any of these shapes; any byte drift
-fails the snapshot and is treated as a regression
-(``contracts/messaging-gateway-payload.md`` §2).
-"""
+"""Legacy broadcast payload byte-shape snapshot. Anchor: FR-015."""
 
 from unittest.mock import MagicMock
 
@@ -23,18 +13,7 @@ _CONTACT_URN = "whatsapp:5598123456789"
 
 
 class LegacyBroadcastPayloadSnapshotTest(TestCase):
-    """FR-015 / SC-004 — legacy ``msg`` body MUST stay byte-identical.
-
-    The three scenarios below cover the OrderStatus template families
-    in production today: body-only with positional variables, image
-    header (s3-keyed) plus URL button, and image header (direct URL)
-    plus PAYMENT_REQUEST buttons combined with ``order_details``.
-
-    Each snapshot is the FULL expected message dict — keys, values,
-    types and array order are pinned (key ordering MAY differ per the
-    spec's "byte-identical" definition). A future change that adds or
-    removes any field on the legacy path will fail one of these tests.
-    """
+    """Legacy ``msg`` body byte-identity regression. Anchor: FR-015 / SC-004."""
 
     def setUp(self):
         self.handler = Broadcast(flows_service=MagicMock(), audit_func=MagicMock())
@@ -46,14 +25,7 @@ class LegacyBroadcastPayloadSnapshotTest(TestCase):
         return template
 
     def test_body_only_with_positional_variables(self):
-        """Scenario (a) — body + positional variables, no header / no buttons.
-
-        T116(g) / T117(g) — the FR-014c / FR-014d wire-shape rules are
-        Direct-Send-only. The legacy payload MUST continue to carry
-        ``msg.template = {name, locale, variables}`` byte-for-byte and
-        MUST NOT leak ``msg.direct_send_template_name`` or ``msg.text``
-        onto the legacy cohort.
-        """
+        """Body + variables, no header / buttons, no Direct-Send leakage."""
         template = self._make_template(template_name="weni_order_invoiced_1700000000")
         data = {
             "template_variables": {"1": "Maria", "2": "12345"},

--- a/retail/agents/tests/services/test_broadcast_tenant_isolation.py
+++ b/retail/agents/tests/services/test_broadcast_tenant_isolation.py
@@ -1,24 +1,4 @@
-"""Tenant-isolation regression guard (T035c — US1 / US4 / FR-040 /
-FR-042 / FR-045 / SC-010 (a)).
-
-Materializes SC-010 (a)'s audit query — ``BroadcastMessage.project_id ==
-BroadcastMessage.integrated_agent.project_id`` — as a CI-runnable
-assertion. Seeds two projects (one Direct Send-enabled, one legacy),
-dispatches a broadcast in each, then asserts:
-
-(i)   ``BroadcastMessage.project_id == BroadcastMessage.integrated_agent.project_id``
-      holds for every persisted row across both projects;
-(ii)  the order-status dedup cache key carries ``project_id=<A.id>`` and
-      never ``B.id`` (FR-040);
-(iii) the datalake event payload carries ``project=str(A.uuid)`` and
-      never ``B.uuid`` (FR-042);
-(iv)  the per-IntegratedAgent template lookup
-      ``integrated_agent.templates.filter(name=...)`` returns only the
-      IntegratedAgent's own templates even when both projects' Templates
-      share the same ``name`` (FR-045).
-
-A regression here is a hard tenant-isolation failure.
-"""
+"""Tenant-isolation regression guard. Anchor: FR-040 / FR-042 / FR-045 / SC-010."""
 
 from typing import Any, Dict
 from unittest.mock import MagicMock
@@ -53,11 +33,10 @@ _LAMBDA_VARIABLES = {"1": "Maria"}
     }
 )
 class TenantIsolationRegressionTest(TestCase):
-    """FR-040 / FR-042 / FR-045 / SC-010 — cross-tenant invariants on
-    the dispatch boundary.
+    """Cross-tenant invariants on the dispatch boundary.
 
-    Two projects share the same Template ``name`` to surface any lookup
-    that would accidentally cross-tenant scope.
+    Two projects share the same Template ``name`` to surface any
+    lookup that would accidentally cross-tenant scope.
     """
 
     def setUp(self):
@@ -157,9 +136,7 @@ class TenantIsolationRegressionTest(TestCase):
         return message
 
     def test_broadcast_message_project_matches_integrated_agent_project(self):
-        """SC-010 (a) — every persisted ``BroadcastMessage.project_id``
-        matches its ``integrated_agent.project_id``.
-        """
+        """``BroadcastMessage.project_id == integrated_agent.project_id``."""
         self._dispatch(self.ia_a)
         self._dispatch(self.ia_b)
 
@@ -172,8 +149,8 @@ class TenantIsolationRegressionTest(TestCase):
                 row.project_id,
                 row.integrated_agent.project_id,
                 "BroadcastMessage.project_id MUST match "
-                "BroadcastMessage.integrated_agent.project_id (FR-040 / "
-                f"SC-010 (a)). Row: {row}",
+                "BroadcastMessage.integrated_agent.project_id. "
+                f"Row: {row}",
             )
 
         project_ids = sorted(row.project_id for row in rows)
@@ -182,9 +159,7 @@ class TenantIsolationRegressionTest(TestCase):
         )
 
     def test_order_status_dedup_cache_key_carries_owning_project_id(self):
-        """FR-040 — the dedup cache key MUST scope by the OWNING
-        project, never by a peer tenant's identifier.
-        """
+        """Dedup cache key scopes by owning project. Anchor: FR-040."""
         usecase = AgentOrderStatusUpdateUsecase()
 
         order_status_dto_a = OrderStatusDTO(
@@ -241,18 +216,16 @@ class TenantIsolationRegressionTest(TestCase):
         self.assertIsNone(
             cache.get(cross_tenant_key_a_to_b),
             "Dedup cache key MUST NOT be writable under a peer tenant's "
-            "project_id (FR-040).",
+            "project_id.",
         )
         self.assertIsNone(
             cache.get(cross_tenant_key_b_to_a),
             "Dedup cache key MUST NOT be writable under a peer tenant's "
-            "project_id (FR-040).",
+            "project_id.",
         )
 
     def test_datalake_event_payload_carries_owning_project_uuid(self):
-        """FR-042 — every datalake event MUST tag the OWNING project,
-        never a peer tenant's UUID.
-        """
+        """Datalake event tags owning project. Anchor: FR-042."""
         self._dispatch(self.ia_a)
         self._dispatch(self.ia_b)
 
@@ -274,10 +247,7 @@ class TenantIsolationRegressionTest(TestCase):
         )
 
     def test_per_integrated_agent_template_lookup_is_tenant_scoped(self):
-        """FR-045 — ``integrated_agent.templates.filter(name=...)`` MUST
-        return only the OWNING IntegratedAgent's templates even when
-        both projects share the same Template ``name``.
-        """
+        """Template lookup is per-IntegratedAgent. Anchor: FR-045."""
         self.assertEqual(self.template_a.name, self.template_b.name)
 
         templates_a = list(
@@ -299,6 +269,5 @@ class TenantIsolationRegressionTest(TestCase):
         self.assertEqual(
             cross_tenant_lookup_a.count(),
             0,
-            "Per-IntegratedAgent template lookup MUST NOT cross "
-            "tenants (FR-045).",
+            "Per-IntegratedAgent template lookup MUST NOT cross tenants.",
         )

--- a/retail/agents/tests/services/test_direct_send_payload_builder.py
+++ b/retail/agents/tests/services/test_direct_send_payload_builder.py
@@ -1,11 +1,4 @@
-"""Tests for the Direct Send payload-builder helpers (T010).
-
-Covers ``substitute_template_variables`` (regex-based ``{{N}}``
-substitution with whitespace tolerance, missing-index warning,
-extra-index silent ignore) and ``is_valid_direct_send_template_name``
-(Meta's snake_case + ≤ 512 chars rule — research Decision 7 /
-FR-017).
-"""
+"""Tests for the Direct Send payload-builder helpers. Anchor: FR-013 / FR-017."""
 
 import logging
 
@@ -151,13 +144,7 @@ class BuildDirectSendHeaderEdgeCasesTest(TestCase):
 
 
 class BuildDirectSendCtaMessageTest(TestCase):
-    """T113 / FR-014a — pure helper for the ``cta_message`` sub-object.
-
-    Returns ``None`` when no ``URL`` button is present (the dispatch
-    path skips ``msg.interaction_type`` / ``msg.cta_message``); returns
-    ``{display_text, url}`` for the single URL button per template
-    (FR-003f caps URL count at ≤1 at fetch time).
-    """
+    """Helper for the ``cta_message`` sub-object. Anchor: FR-014a."""
 
     def test_returns_none_when_metadata_has_no_buttons(self):
         result = build_direct_send_cta_message(
@@ -196,12 +183,7 @@ class BuildDirectSendCtaMessageTest(TestCase):
 
 
 class BuildDirectSendQuickRepliesTest(TestCase):
-    """T114 / FR-014b — pure helper for the ``quick_replies`` flat array.
-
-    Returns ``None`` when no ``QUICK_REPLY`` button is present; returns
-    a list of substituted title strings otherwise. The list length is
-    capped at ≤3 by FR-003f's fetch-time guard.
-    """
+    """Helper for the ``quick_replies`` flat array. Anchor: FR-014b."""
 
     def test_returns_none_when_metadata_has_no_buttons(self):
         result = build_direct_send_quick_replies(

--- a/retail/agents/tests/usecases/test_assign_agent.py
+++ b/retail/agents/tests/usecases/test_assign_agent.py
@@ -925,23 +925,7 @@ class AssignAgentUseCaseTest(TestCase):
     def test_legacy_assignment_preserves_direct_send_absent_and_integrations_calls(
         self, mock_create_library_use_case
     ):
-        """T034 (US4 / Story 2 AS2) — legacy assignment (Direct Send DISABLED).
-
-        Verifies the byte-shape of the legacy assignment branch when
-        ``IntegrationsService.get_channel_app`` reports the channel
-        does NOT have Direct Send enabled. Asserts:
-
-        - ``IntegratedAgent.config`` does NOT carry the ``direct_send``
-          key (FR-001 / FR-005 / SC-004 / SC-007 — absence is the
-          canonical legacy marker; writing ``False`` would expand the
-          persisted config shape and break byte-identical preservation
-          per T026's conditional-write contract).
-        - ``CreateLibraryTemplateUseCase.execute`` and ``notify_integrations``
-          fire on the library-sourced spec (matches today).
-        - ``IntegrationsService.fetch_templates_from_user`` fires for
-          the customer-sourced spec (matches today).
-        - Zero new calls, zero removed calls on ``integrations_service``.
-        """
+        """Legacy assignment preserves config + integrations calls. Anchor: FR-001 / FR-005."""
         mock_integrations_service = MagicMock()
         mock_integrations_service.get_channel_app.return_value = {
             "config": {"direct_send": False}

--- a/retail/agents/tests/usecases/test_assign_direct_send.py
+++ b/retail/agents/tests/usecases/test_assign_direct_send.py
@@ -1,18 +1,4 @@
-"""Direct Send assignment branch — Phase 4 (US2).
-
-Pins the contract for ``AssignAgentUseCase`` when the WhatsApp channel
-has Direct Send enabled (per
-``contracts/integrations-channel-app.md`` §4):
-
-- T018  — ``_resolve_direct_send_flag`` paths.
-- T018a — Story 2 AS1 happy path (FR-001, FR-002, FR-003, SC-003).
-- T018b — pt_BR per-template fallback (FR-003c, Story 2 AS4).
-- T018c — atomic rollback when both languages fail (FR-003d, AS5).
-- T018d — atomic rollback when Meta returns an unsupported component
-  (Decision 12).
-- T018e — re-assignment after ``is_active=False`` re-fetches every
-  template (FR-003a, "snapshot at assignment time").
-"""
+"""Direct Send assignment branch. Anchor: FR-001 / FR-002 / FR-003 (a/c/d)."""
 
 import logging
 
@@ -255,10 +241,6 @@ class AssignDirectSendHappyPathTest(AssignDirectSendBaseTest):
             self.assertIn("fetched_at", direct_send_meta)
             self.assertEqual(direct_send_meta.get("requested_language"), "pt_BR")
             self.assertEqual(direct_send_meta.get("actual_language"), "pt_BR")
-            # FR-014d(c) / T117(f): Meta's ``body`` field is persisted
-            # under ``Template.metadata["body"]`` verbatim; the FR-014d
-            # wire-key rename (``msg.body`` → ``msg.text``) does NOT
-            # leak into storage.
             self.assertIn("body", template.metadata)
             self.assertNotIn("text", template.metadata)
 
@@ -285,7 +267,7 @@ class AssignDirectSendHappyPathTest(AssignDirectSendBaseTest):
 
 
 class AssignDirectSendFallbackTest(AssignDirectSendBaseTest):
-    """T018b — pt_BR per-template fallback (FR-003c, Story 2 AS4)."""
+    """pt_BR per-template fallback. Anchor: FR-003c."""
 
     def setUp(self):
         super().setUp()
@@ -344,7 +326,7 @@ class AssignDirectSendFallbackTest(AssignDirectSendBaseTest):
 
 
 class AssignDirectSendAtomicRollbackBothLanguagesTest(AssignDirectSendBaseTest):
-    """T018c — both project locale AND pt_BR return None (FR-003d / AS5)."""
+    """Both locale fetches return None. Anchor: FR-003d."""
 
     def setUp(self):
         super().setUp()
@@ -392,7 +374,7 @@ class AssignDirectSendAtomicRollbackBothLanguagesTest(AssignDirectSendBaseTest):
 
 
 class AssignDirectSendAtomicRollbackUnsupportedComponentTest(AssignDirectSendBaseTest):
-    """T018d — adapter raises DirectSendUnsupportedComponentError (Decision 12)."""
+    """Adapter raises ``DirectSendUnsupportedComponentError``. Anchor: Decision 12."""
 
     def setUp(self):
         super().setUp()
@@ -445,15 +427,7 @@ class AssignDirectSendAtomicRollbackUnsupportedComponentTest(AssignDirectSendBas
 class AssignDirectSendAdapterRejectionRoutesThroughFallbackTest(
     AssignDirectSendBaseTest
 ):
-    """T108 routing — adapter rejection on first locale routes through pt_BR.
-
-    FR-003c (c) treats "HTTP 200 with malformed JSON or a schema the
-    local adapter rejects" identically to a missing translation: the
-    use case retries in ``pt_BR`` before failing atomically (FR-003d).
-    Pinned here at the use-case boundary so a future refactor that
-    propagates ``DirectSendUnsupportedComponentError`` directly to the
-    caller — skipping the FR-003c fallback — fails this regression.
-    """
+    """Adapter rejection on first locale routes through pt_BR. Anchor: FR-003c / FR-003d."""
 
     def setUp(self):
         super().setUp()

--- a/retail/agents/tests/usecases/test_order_status_agent_resolution_direct_send.py
+++ b/retail/agents/tests/usecases/test_order_status_agent_resolution_direct_send.py
@@ -1,13 +1,4 @@
-"""FR-031 official-agent precedence regression on the Direct Send
-cohort (T014b).
-
-When the order-status resolution finds BOTH an official agent
-(matched on ``settings.ORDER_STATUS_AGENT_UUID``) AND a custom agent
-with ``parent_agent_uuid`` for the same project, the official agent
-MUST take precedence — a single event MUST NEVER dispatch through
-both agents simultaneously. This regression test pins that contract
-specifically for the Direct Send cohort.
-"""
+"""Direct Send official-agent precedence regression. Anchor: FR-031."""
 
 import logging
 

--- a/retail/agents/tests/usecases/test_order_status_dedup_direct_send.py
+++ b/retail/agents/tests/usecases/test_order_status_dedup_direct_send.py
@@ -1,30 +1,4 @@
-"""FR-028 / FR-029 / FR-030 / FR-039 dedup regression on the Direct
-Send cohort (T014a + T014c + T014d).
-
-Pins the canonical idempotency tuple
-``(project, integrated_agent.uuid, order_id, current_state)`` on the
-Direct Send path:
-
-- Two invocations with the same tuple collapse into ONE outbound
-  Flows POST and ONE ``BroadcastMessage`` row (T014a).
-- The second invocation emits the documented ``duplicate_skipped``
-  INFO log shape (FR-039, T014a).
-- The cache key matches the five-segment shape pinned by FR-029
-  (T014a).
-- Two invocations sharing ``(project, agent, order_id)`` but differing
-  in ``current_state`` MUST dispatch as TWO distinct logical broadcasts
-  (FR-030, T014c). Direct counter-evidence that the dedup gate keys on
-  ``current_state`` — a refactor dropping that component from the key
-  would silently merge two distinct logical broadcasts into one and
-  fail this test.
-- The unpause race (PAUSED → APPROVED flip during the dedup window of
-  an in-flight broadcast for the same template) MUST NOT auto-replay —
-  the dedup cache key was populated by the original PAUSED-skip
-  attempt, and the subsequent webhook (within the dedup window) skips
-  via the FR-028 duplicate-skip gate even though the version status is
-  now APPROVED (T014d). Pins the spec Edge Case "an event that arrived
-  during the dedup window of an earlier PAUSED-skip will NOT
-  auto-replay; the next webhook is the trigger".
+"""Direct Send dedup regression guards. Anchor: FR-028 / FR-029 / FR-030 / FR-039.
 
 The legacy cohort is already covered by the pre-feature dedup tests
 in ``test_order_status_update.py``; this file is the Direct
@@ -221,19 +195,7 @@ class OrderStatusDedupOnDirectSendTest(TestCase):
         self.assertEqual(segments[4], "shipped")
 
     def test_different_current_state_dispatches_as_distinct_logical_broadcasts(self):
-        """FR-030 (T014c): two events differing ONLY in ``current_state``
-        MUST both dispatch as separate logical broadcasts.
-
-        Same ``(project, integrated_agent.uuid, order_id)`` triple,
-        different ``current_state`` values → distinct dedup cache keys
-        → both pass the dedup gate → two outbound Flows POSTs → two
-        ``BroadcastMessage`` rows. ``BroadcastMessage`` does not store
-        ``current_state`` directly (the column is absent on the model,
-        see ``retail/broadcasts/models.py``); the two rows are matched
-        to their originating invocations via the distinct ``broadcast_id``
-        values returned by the Flows mock. The shared ``order_id``
-        confirms both rows belong to the same physical order.
-        """
+        """Different ``current_state`` -> distinct logical broadcasts. Anchor: FR-030."""
         self.flows_service.send_whatsapp_broadcast.side_effect = [
             {
                 "id": 9001,
@@ -300,29 +262,7 @@ class OrderStatusDedupOnDirectSendTest(TestCase):
         self.assertEqual(second_segments[4], "shipped")
 
     def test_unpause_race_within_dedup_window_does_not_auto_replay(self):
-        """T014d / spec Edge Case — PAUSED → APPROVED flip during the
-        dedup window of an in-flight broadcast for the same template
-        MUST NOT auto-replay.
-
-        Steps:
-        1. Template ``current_version.status`` starts at ``PAUSED``.
-        2. Invoke ``execute(...)`` once → dispatch is skipped via the
-           FR-039 unified ``[BroadcastDispatch] skipped_due_to_status``
-           audit shape; the dedup cache key IS populated (the dedup
-           gate accepted the event BEFORE the version-status read).
-        3. Flip the version status to ``APPROVED`` (simulating the
-           unpause race).
-        4. Invoke ``execute(...)`` again with the SAME canonical
-           idempotency tuple — the dedup gate now skips the event
-           via the FR-028 ``[ORDER_STATUS] duplicate_skipped`` audit
-           shape; no Flows POST and no ``BroadcastMessage`` row.
-
-        Pins the spec edge case "an event that arrived during the
-        dedup window of an earlier PAUSED-skip will NOT auto-replay;
-        the next webhook is the trigger" against a future refactor
-        that moved the version-status read BEFORE the dedup cache
-        write (which would silently re-fire the dispatch on unpause).
-        """
+        """Unpause race within dedup window does not auto-replay. Anchor: FR-028."""
         version = Version.objects.get(template__name="weni_order_shipped")
         version.status = "PAUSED"
         version.save(update_fields=["status"])

--- a/retail/templates/adapters/direct_send_sample_translator.py
+++ b/retail/templates/adapters/direct_send_sample_translator.py
@@ -1,30 +1,12 @@
 """Direct Send sample-validation translator.
 
-Pure-function module that turns a ``ValidateTemplateSampleDTO`` into the
-Meta ``message_samples`` wire-shape dict pinned by
-``specs/004-template-sample-validation/contracts/meta-message-samples.md``.
-
-Four discriminated shapes are produced:
-
-- **Shape 1** ``text`` — non-interactive payload (no buttons). Reduces
-  to the bare ``{"type": "text", "text": {"body": ...}}`` for pure
-  body-only payloads, OR widens to the extended Shape 1b super-shape
-  ``{"type": "text", "header": {...}?, "footer": {...}?, "text": {...}}``
-  when the no-button payload also carries a ``template_header`` and / or
-  ``template_footer`` (per FR-004 post-clarification 2026-05-26 round 2 /
-  A13). Empirically validated against the live ``message_samples`` API.
-- **Shape 2** ``interactive.cta_url`` — exactly one ``URL``-type button.
-- **Shape 3** ``interactive.button`` — 1–3 ``QUICK_REPLY`` buttons.
-
-The function is pure: no DB access, no I/O, no Django imports. Callers
-MUST resolve any base64 → S3 URL for IMAGE headers BEFORE invoking the
-translator (the upload happens upstream in the use case per A9 /
-Research Decision 6) and pass the resolved URL via ``resolved_header_url``.
-
-The ``{{N}}`` placeholder substitution reuses
-``substitute_template_variables`` from the Direct Send broadcast
-renderer so the outbound sample matches what the eventual broadcast
-will render (US2's lockstep guarantee per A7 / FR-004e).
+Pure-function module that turns a ``ValidateTemplateSampleDTO`` into
+the Meta ``message_samples`` wire-shape dict. Reuses the Direct Send
+broadcast renderer's ``substitute_template_variables`` so the outbound
+sample matches what the eventual broadcast will render (US2 lockstep
+guarantee). Anchor: FR-004 / FR-004a / FR-004b / FR-004c / FR-004e
+(see ``specs/004-template-sample-validation/spec.md`` and
+``contracts/meta-message-samples.md``).
 """
 
 from __future__ import annotations
@@ -63,22 +45,12 @@ def build_meta_sample_body(
     *,
     resolved_header_url: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Convert a validated sample-validation DTO to Meta's ``message_samples`` wire shape.
+    """Convert the DTO to the Meta ``message_samples`` wire shape.
 
-    Dispatches on the payload shape (body-only / URL button / reply
-    buttons) per FR-004 / FR-004b / FR-004c, substitutes ``{{N}}``
-    placeholders using ``dto.template_body_params`` as the positional
-    substitution source (FR-004e / Research Decision 9 — ``dto.parameters``
-    is NOT consulted), and emits the discriminated-union wire shape.
-
-    Args:
-        dto: Validated DTO with the operator-supplied content.
-        resolved_header_url: For IMAGE-header payloads, the S3 URL the
-            use case obtained by uploading the base64 blob upstream.
-            Ignored on TEXT headers and on payloads without a header.
-
-    Returns:
-        Dict in the Meta ``message_samples`` wire shape (Shape 1, 2, or 3).
+    Substitution source is ``dto.template_body_params`` only;
+    ``dto.parameters`` is intentionally not consulted (the rule-engine
+    code-gen input is the wrong source for the outbound sample).
+    Anchor: FR-004 / FR-004e / Decision 9.
     """
     template_name = dto.template_uuid
     variables = _variables_from_body_params(dto.template_body_params)
@@ -125,14 +97,10 @@ def build_meta_sample_body(
 def _variables_from_body_params(
     template_body_params: Optional[List[Any]],
 ) -> Dict[str, str]:
-    """Build the positional-index → value dict consumed by ``substitute_template_variables``.
+    """Build the positional-index -> value dict.
 
-    Maps ``template_body_params[0]`` → ``"1"``, ``[1]`` → ``"2"``, ...
-    Research Decision 9 pins this as the SOLE substitution source for
-    the outbound sample (the request body's ``parameters`` field —
-    used by custom templates to feed the rule-engine code generator
-    on the PATCH path — is a different input shape and is not
-    consulted here).
+    Maps ``template_body_params[0]`` to ``"1"``, ``[1]`` to ``"2"``,
+    etc. Anchor: Decision 9.
     """
     if not template_body_params:
         return {}
@@ -157,16 +125,7 @@ def _build_header_subobject(
     resolved_header_url: Optional[str],
     template_name: str,
 ) -> Optional[Dict[str, Any]]:
-    """Build the ``interactive.header`` discriminated-union value.
-
-    Three modes per the header-shape table in ``contracts/meta-message-samples.md``:
-
-    - TEXT header → ``{"type": "text", "text": "<substituted>"}``.
-    - IMAGE header whose source was base64 → ``{"type": "image", "image": {"link": resolved_header_url}}``.
-    - IMAGE header whose source was already an HTTP(S) URL → ``{"type": "image", "image": {"link": header}}``.
-
-    Returns ``None`` for absent headers so callers can omit the key.
-    """
+    """Build the ``interactive.header`` value, or ``None`` when absent."""
     if not header:
         return None
 
@@ -181,12 +140,7 @@ def _build_header_subobject(
 
 
 def _looks_like_image_header(header: str) -> bool:
-    """Return ``True`` when ``header`` is an HTTP(S) URL or a base64 data URI.
-
-    Mirrors the heuristic used by the existing ``HeaderTransformer`` /
-    ``TemplateMetadataHandler`` so the wire-shape dispatch agrees with
-    the local metadata persistence path.
-    """
+    """Return ``True`` when ``header`` is an HTTP(S) URL or base64 data URI."""
     if header.startswith(_IMAGE_HEADER_PROTOCOLS):
         return True
     if header.startswith(_BASE64_DATA_URI_PREFIX):
@@ -203,18 +157,10 @@ def _build_text_shape(
     resolved_header_url: Optional[str],
     template_name: str,
 ) -> Dict[str, Any]:
-    """Assemble the Shape 1 / extended Shape 1b (``text``) wire body.
+    """Assemble the ``text`` wire body (Shape 1 / extended Shape 1b).
 
-    The bare Shape 1 (no header AND no footer) reduces bit-identically
-    to ``{"type": "text", "text": {"body": <substituted>}}``. The
-    extended Shape 1b widens this with optional ``header`` and / or
-    ``footer`` top-level keys when the no-button payload carries them
-    — an empirically-validated super-shape pinned by spec A13 /
-    FR-004 post-clarification 2026-05-26 round 2.
-
-    Optional keys are ABSENT (not ``null``) when the corresponding
-    input field is missing — degenerate Shape 1b reduces to Shape 1
-    so legacy body-only callers see no observable change.
+    Optional ``header`` / ``footer`` keys are absent (not ``null``) so
+    the bare body-only case is byte-identical to Shape 1. Anchor: FR-004.
     """
     body: Dict[str, Any] = {"type": "text", "text": {"body": substituted_body}}
 
@@ -278,23 +224,13 @@ def _build_cta_url_action_parameters(
     variables: Dict[str, str],
     template_name: str,
 ) -> Dict[str, str]:
-    """Resolve the CTA URL button's ``{display_text, url}`` pair per FR-004b.
+    """Resolve the CTA URL button's ``{display_text, url}`` pair.
 
-    The URL field is accepted in three shapes (mirroring the existing
-    ``UpdateLibraryTemplateButtonSerializer`` contract and the
-    broadcast renderer's URL normalization at dispatch time, so the
-    sample submitted to Meta stays in lockstep with what the eventual
-    broadcast will render — see US2):
-
-    - Already-flat string with the placeholder embedded
-      (``"https://x/{{1}}"``) — preserved verbatim.
-    - Nested ``{base_url, url_suffix_example}`` — normalized via
-      ``ensure_protocol`` + ``append_placeholder_if_needed``.
-    - Nested ``{base_url}`` only — ``ensure_protocol`` only, no
-      placeholder appended.
-
-    The placeholder substitution always fires last so the wire body
-    carries the fully-resolved URL.
+    Three accepted URL shapes (flat string, nested
+    ``{base_url, url_suffix_example}``, nested ``{base_url}``) collapse
+    to a canonical flat string before substitution, mirroring the
+    broadcast renderer so sample and broadcast stay in lockstep.
+    Anchor: FR-004b.
     """
     raw_url = url_button.get("url")
     resolved_url = _normalize_cta_url(raw_url)
@@ -369,12 +305,7 @@ def _build_reply_button_entries(
     variables: Dict[str, str],
     template_name: str,
 ) -> List[Dict[str, Any]]:
-    """Render each reply button as ``{"type": "reply", "reply": {"id", "title"}}``.
-
-    The ``reply.id`` is derived deterministically from the button text
-    per FR-004c (see ``_derive_reply_id``) and tiebroken on
-    duplicate-within-payload with a ``_2`` / ``_3`` positional suffix.
-    """
+    """Render reply buttons; duplicates get a ``_2``/``_3`` suffix. Anchor: FR-004c."""
     entries: List[Dict[str, Any]] = []
     seen_ids: Dict[str, int] = {}
 
@@ -389,19 +320,7 @@ def _build_reply_button_entries(
 
 
 def _derive_reply_id(text: str) -> str:
-    """Derive a deterministic ``reply.id`` from a button label per FR-004c.
-
-    Pipeline (matches ``contracts/meta-message-samples.md`` "Deterministic
-    reply.id derivation"):
-
-    1. Lowercase.
-    2. Replace every non-alphanumeric run with a single underscore.
-    3. Strip leading and trailing underscores.
-    4. Truncate to ``_REPLY_ID_MAX_LENGTH`` (64) characters — well under
-       WhatsApp's documented 256-char cap for ``reply.id``, leaving
-       headroom for the duplicate-tiebreaker suffix and keeping
-       audit-log lines tidy.
-    """
+    """Lowercase, non-alnum to ``_``, strip ``_``, truncate. Anchor: FR-004c."""
     if not text:
         return ""
 
@@ -413,7 +332,7 @@ def _derive_reply_id(text: str) -> str:
 
 
 def _disambiguate_reply_id(base_id: str, seen_ids: Dict[str, int]) -> str:
-    """Append ``_2`` / ``_3`` suffix on duplicate-within-payload per FR-004c."""
+    """Append ``_2`` / ``_3`` suffix on duplicate-within-payload."""
     if base_id not in seen_ids:
         seen_ids[base_id] = 1
         return base_id

--- a/retail/templates/adapters/url_normalization.py
+++ b/retail/templates/adapters/url_normalization.py
@@ -1,22 +1,9 @@
 """URL normalization helpers for WhatsApp template URL buttons.
 
-Pure stateless utilities shared by:
-
-- The push-path ``ButtonTransformer``
-  (``retail/templates/adapters/template_library_to_custom_adapter.py``),
-  which maps Meta's library-catalog buttons to the Integrations Engine
-  template-translation payload at push time.
-- The fetch-path Direct Send adapter
-  (``retail/templates/usecases/_meta_library_template_fetch.py``),
-  which normalizes Meta's library-catalog buttons into the local
-  ``Template.metadata.buttons`` canonical shape at agent-assignment
-  time.
-
-Both paths MUST agree on a single normalization heuristic so
-``metadata.buttons[*].url`` stores one canonical shape regardless of
-upstream variance (FR-003f). Keeping the helpers in their own module
-preserves that single source of truth without coupling either consumer
-to the other's class layout.
+Single source of truth shared by the push-path ``ButtonTransformer``
+and the fetch-path Direct Send adapter; both paths agree on a single
+heuristic so ``metadata.buttons[*].url`` stores one canonical shape.
+Anchor: FR-003f.
 """
 
 
@@ -26,8 +13,8 @@ PLACEHOLDER_PATTERN = "{{1}}"
 def ensure_protocol(url: str) -> str:
     """Add ``https://`` prefix when ``url`` lacks an HTTP scheme.
 
-    Empty / ``None`` values pass through unchanged so callers can use
-    the helper as a no-op on absent inputs.
+    Empty values pass through unchanged so callers can use the helper
+    as a no-op on absent inputs.
     """
     if not url:
         return url
@@ -37,12 +24,7 @@ def ensure_protocol(url: str) -> str:
 
 
 def append_placeholder_if_needed(url: str) -> str:
-    """Append ``{{1}}`` to ``url`` when it carries no placeholder yet.
-
-    Collapses the nested ``{base_url, url_suffix_example}`` upstream
-    shape and a flat URL that already contains ``{{1}}`` onto the same
-    canonical flat-string form (FR-003f).
-    """
+    """Append ``{{1}}`` to ``url`` when it carries no placeholder yet."""
     if PLACEHOLDER_PATTERN in url:
         return url
     return url + PLACEHOLDER_PATTERN
@@ -51,10 +33,9 @@ def append_placeholder_if_needed(url: str) -> str:
 def looks_like_url(value: str) -> bool:
     """Return True when ``value`` resembles an HTTP URL.
 
-    Heuristic: an explicit ``http(s)://`` scheme OR a string containing
-    both a ``.`` and a ``/`` (domain + path indicator). Used to decide
-    whether ``ensure_protocol`` should fire on an example/suffix value
-    that may be a plain identifier rather than a real URL.
+    Heuristic: explicit ``http(s)://`` scheme OR a string carrying both
+    a ``.`` and a ``/``. Lets push-path identifier examples like
+    ``"123"`` pass through ``normalize_url_if_needed`` unchanged.
     """
     if not value:
         return False
@@ -64,12 +45,7 @@ def looks_like_url(value: str) -> bool:
 
 
 def normalize_url_if_needed(value: str) -> str:
-    """Apply ``ensure_protocol`` only when ``value`` resembles a URL.
-
-    Lets push-path examples like ``"123"`` pass through unchanged (they
-    are not URLs) while still prepending ``https://`` to genuine URLs
-    that are missing the scheme.
-    """
+    """Apply ``ensure_protocol`` only when ``value`` resembles a URL."""
     if looks_like_url(value):
         return ensure_protocol(value)
     return value

--- a/retail/templates/exceptions.py
+++ b/retail/templates/exceptions.py
@@ -13,33 +13,15 @@ class CustomTemplateAlreadyExists(APIException):
 
 
 class NotDirectSendEligibleError(Exception):
-    """Raised when the template's IntegratedAgent does not have
-    ``direct_send`` enabled per FR-002a.
-
-    The view translates this exception to HTTP 400 with body
-    ``{"detail": "Template is not Direct Send-eligible",
-    "error_code": "not_direct_send_eligible"}`` per FR-007e.
-    """
+    """Template's IntegratedAgent has no ``direct_send``. Anchor: FR-002a."""
 
 
 class WabaNotConfiguredError(Exception):
-    """Raised when the project's ``ProjectOnboarding`` config does not
-    carry a ``wpp-cloud`` channel's ``waba_id`` per FR-005a.
-
-    The view translates this exception to HTTP 400 with body
-    ``{"detail": "WABA not configured for this project",
-    "error_code": "waba_not_configured"}`` per FR-007d.
-    """
+    """Project channel has no ``waba_id``. Anchor: FR-005a."""
 
 
 class MetaSampleUnavailableError(Exception):
-    """Raised when the outbound Meta ``message_samples`` call failed
-    (``CustomAPIException`` or an unexpected exception) per FR-005c.
-
-    Carries the original HTTP status code (when known) and the raw
-    Meta error envelope so the view can surface them on the HTTP 502
-    response body per FR-007b.
-    """
+    """Meta ``message_samples`` call failed. Anchor: FR-005c."""
 
     def __init__(
         self,
@@ -54,12 +36,7 @@ class MetaSampleUnavailableError(Exception):
 
 
 class MetaInvalidResponseError(Exception):
-    """Raised when Meta returned HTTP 200 but the body lacks a
-    ``category`` field or carries ``success: false`` per FR-005b.
-
-    Carries the raw Meta response body verbatim so the view can
-    surface it on the HTTP 502 response body per FR-007b.
-    """
+    """Meta returned 200 with no usable ``category``. Anchor: FR-005b."""
 
     def __init__(
         self,

--- a/retail/templates/serializers.py
+++ b/retail/templates/serializers.py
@@ -203,12 +203,10 @@ class TemplateMetricsRequestSerializer(serializers.Serializer):
 class ValidateTemplateSampleSerializer(UpdateTemplateContentSerializer):
     """Serializer for ``POST /api/v3/templates/<uuid>/sample/``.
 
-    Field set is byte-for-byte compatible with
-    ``UpdateTemplateContentSerializer`` (FR-003 / FR-014). The subclass
-    layers on FR-003a length caps + button-mode disjointness and the
-    FR-002b ``Project-Uuid`` header ↔ body ``project_uuid`` equality
-    check. Domain-level gating (Direct-Send eligibility, WABA
-    resolution, Meta classification) lives in the use case.
+    Schema-compatible with ``UpdateTemplateContentSerializer``; layers
+    on length caps, button-mode disjointness, and the ``Project-Uuid``
+    header / body equality check. Anchor: FR-002b / FR-003 / FR-003a /
+    FR-014 (see ``specs/004-template-sample-validation/spec.md``).
     """
 
     _BODY_MAX_LENGTH = 1024
@@ -273,15 +271,12 @@ class ValidateTemplateSampleSerializer(UpdateTemplateContentSerializer):
         return value
 
     def validate_project_uuid(self, value: str) -> str:
-        """FR-002b — refuse when ``Project-Uuid`` header diverges from body.
+        """Refuse on ``Project-Uuid`` header / body divergence.
 
-        ``HasProjectPermission`` authorizes against the HTTP header; the
-        use case's WABA resolution uses the body's ``project_uuid``.
-        Without this equality check, an operator authorized for project A
-        could route a Meta sample call to project B's WABA (SC-008).
-        The check is permissive when the header is absent so unit tests
-        can be written without forging an HTTP request — ``HasProjectPermission``
-        is the front-line gate for missing-header requests.
+        Without this check, an operator authorized for project A could
+        route a sample call to project B's WABA. Permissive when the
+        header is absent (``HasProjectPermission`` is the front-line
+        gate). Anchor: FR-002b / SC-008.
         """
         request = self.context.get("request")
         header_project_uuid = request.headers.get("Project-Uuid") if request else None
@@ -304,11 +299,9 @@ class ValidateTemplateSampleSerializer(UpdateTemplateContentSerializer):
     def _is_plain_text_header(self, header: str) -> bool:
         """Return ``True`` only when the header is operator-typed text.
 
-        Image headers (HTTP(S) URLs, base64 data URIs, already-uploaded
-        S3 URLs) are exempt from the ``_HEADER_TEXT_MAX_LENGTH`` cap.
-        Reuses the existing ``HeaderTransformer`` heuristics so the
-        wire-shape dispatch (translator) and the validation gate stay
-        aligned.
+        Image headers (HTTP(S) URLs, base64 data URIs, S3 URLs) are
+        exempt from the length cap. Reuses ``HeaderTransformer`` so
+        the validation gate and wire-shape dispatch stay aligned.
         """
         transformer = HeaderTransformer()
         if header.startswith(("http://", "https://")):

--- a/retail/templates/strategies/update_template_strategies.py
+++ b/retail/templates/strategies/update_template_strategies.py
@@ -223,33 +223,12 @@ class UpdateNormalTemplateStrategy(UpdateTemplateStrategy, TemplateBuilderMixin)
     def _build_and_persist_metadata(
         self, template: Template, payload: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Build canonical metadata, persist it, and sync agent-side config.
+        """Build canonical metadata, persist it, sync agent-side config.
 
-        Three sequential steps, each at the same level of abstraction:
-
-        1. ``_update_common_metadata`` builds the canonical metadata.
-        2. ``template.save(update_fields=["metadata"])`` persists it
-           (only the metadata column — the rest of the row is untouched,
-           which is correct for Normal templates that never edit
-           ``rule_code`` / ``start_condition`` / ``variables`` here).
-        3. ``_sync_abandoned_cart_image_config`` flips the abandoned-cart
-           agent's ``header_image_type`` when the template gains or
-           loses an image header.
-
-        Returns ``translation_payload`` so the caller can hand it to
-        ``_notify_integrations`` (the PATCH endpoint's update flow,
-        which pushes the new content to the Integrations engine) or
-        simply discard it (the sample-validation flow, which does not
-        notify per FR-006 / A10 because Direct Send dispatch reads
-        local ``metadata`` directly and the Integrations push would
-        race with the next Direct Send broadcast).
-
-        Both endpoints remain operational and serve different shapes
-        of update: PATCH is the canonical content-update path for
-        every template (Direct Send-eligible or not, normal or
-        custom); ``POST /sample/`` is an additive pre-validation path
-        that gates the local update on Meta's UTILITY verdict for
-        Direct Send-eligible templates only (FR-002a).
+        Returns ``translation_payload`` so PATCH callers can push to
+        Integrations; sample-validation discards it because pushing
+        would race with the next Direct Send broadcast. Anchor: FR-002a
+        / FR-006 (see ``specs/004-template-sample-validation/spec.md``).
         """
         updated_metadata, translation_payload = self._update_common_metadata(
             template, payload
@@ -265,24 +244,13 @@ class UpdateNormalTemplateStrategy(UpdateTemplateStrategy, TemplateBuilderMixin)
     def _create_approved_current_version(
         self, template: Template, payload: Dict[str, Any]
     ) -> Version:
-        """Create a Version with ``status=APPROVED`` and advance the template's pointer.
+        """Insert APPROVED Version row and repoint ``current_version``.
 
-        Sample-validation composition per Research Decision 4 / FR-006a /
-        FR-006d: the Meta sample verdict IS the approval signal, so the
-        new Version row is persisted with ``"APPROVED"`` directly
-        (instead of the model's default ``"PENDING"`` that the PATCH
-        endpoint relies on and that ``TemplatesStatusWebhook`` flips
-        asynchronously) and
-        ``Template.current_version`` is repointed inline — the very next
-        Direct Send dispatch reads the new content with no cache lag
-        (SC-004).
-
-        Three writes per call: INSERT the Version row, UPDATE its
-        ``status`` to APPROVED, UPDATE ``Template.current_version_id``.
-        Each is a single-row write under Django's default per-statement
-        transaction (Research Decision 8 — no ``@transaction.atomic``
-        wrap; partial-failure modes are operationally safe per
-        ``data-model.md`` §1).
+        Three single-row writes under Django's default per-statement
+        transaction; no ``@transaction.atomic`` wrap — partial-failure
+        modes are operationally safe (next Direct Send dispatch reads
+        the new content with no cache lag). Anchor: FR-006a / FR-006d
+        / Decision 4 / Decision 8.
         """
         version = self._create_version(
             template=template,

--- a/retail/templates/tests/adapters/test_direct_send_sample_translator.py
+++ b/retail/templates/tests/adapters/test_direct_send_sample_translator.py
@@ -1,18 +1,7 @@
 """Tests for the Direct Send sample-validation translator.
 
-Pure-function tests covering the four discriminated wire shapes
-(non-interactive ``text`` — pure body-only Shape 1 and extended Shape
-1b with optional ``header`` and / or ``footer``; ``interactive.cta_url``;
-``interactive.button``), variable substitution, deterministic
-``reply.id`` derivation, header sub-object dispatch, and the
-``parameters`` exclusion rule (Research Decision 9).
-
-The Phase 3c clarification (2026-05-26 round 2 / A13) widened Shape 1
-into a super-shape that carries optional ``header`` and / or ``footer``
-top-level keys for no-button payloads. The
-``BuildMetaSampleBodyExtendedShape1bTest`` class below pins the four
-no-button-with-extras combinations end-to-end at the translator
-boundary.
+Anchor: FR-004 / Decision 9 (see
+``specs/004-template-sample-validation/spec.md``).
 """
 
 from unittest import TestCase
@@ -341,19 +330,7 @@ class BuildMetaSampleBodyHeaderDispatchTest(TestCase):
 
 
 class BuildMetaSampleBodyExtendedShape1bTest(TestCase):
-    """Extended Shape 1b — no-button payloads with optional header / footer.
-
-    Pins FR-004 (post-clarification 2026-05-26 round 2) / FR-004a / A13:
-    no-button payloads emit a four-key super-shape ``{"type": "text",
-    "header": {...}?, "footer": {...}?, "text": {"body": ...}}``. The
-    optional keys are ABSENT (not ``null``) when the input field is
-    missing — degenerate Shape 1b reduces bit-identically to Shape 1.
-
-    The bug case (test (a) below) reproduces the literal payload
-    reported 2026-05-26: ``{template_body, template_header: "Pedido
-    recebido", template_button: []}`` was producing ``{"type": "text",
-    "text": {"body": ...}}`` with the header silently dropped.
-    """
+    """No-button payloads emit extended Shape 1b. Anchor: FR-004 / FR-004a."""
 
     def test_text_header_no_footer_no_buttons_emits_extended_shape_1b(self):
         dto = _dto(

--- a/retail/templates/tests/adapters/test_url_normalization.py
+++ b/retail/templates/tests/adapters/test_url_normalization.py
@@ -1,11 +1,4 @@
-"""Unit tests for the shared URL normalization helpers.
-
-Pins the contract of the pure functions in
-``retail/templates/adapters/url_normalization.py``. Both the push-path
-``ButtonTransformer`` and the fetch-path Direct Send adapter depend on
-this contract; any drift here is a FR-003f regression that affects
-``metadata.buttons[*].url`` shape on both paths.
-"""
+"""Unit tests for the shared URL normalization helpers. Anchor: FR-003f."""
 
 from django.test import TestCase
 

--- a/retail/templates/tests/strategies/test_update_template_strategies.py
+++ b/retail/templates/tests/strategies/test_update_template_strategies.py
@@ -482,14 +482,10 @@ class UpdateNormalTemplateStrategyTest(TestCase):
     def test_update_template_composes_helpers_and_notifies_integrations(
         self, mock_task
     ):
-        """Regression — the PATCH endpoint's composition is preserved byte-for-byte.
+        """PATCH endpoint composition preserved byte-for-byte.
 
-        ``update_template`` delegates to ``_build_and_persist_metadata`` for the
-        metadata-rewrite half and to the existing ``_create_version_and_notify``
-        for the version-create + Integrations-push half. The PATCH endpoint
-        remains the canonical content-update path for every template (FR-014);
-        the sample-validation flow added by spec 004 is additive and shares
-        the metadata helper but skips the notify step (per FR-006 / A10).
+        Sample-validation flow shares the metadata helper but skips the
+        notify step. Anchor: FR-014 (spec 002) / FR-006 (spec 004).
         """
         self.metadata_handler.build_metadata.return_value = {
             "body": "Updated body",

--- a/retail/templates/tests/usecases/test_meta_library_template_fetch.py
+++ b/retail/templates/tests/usecases/test_meta_library_template_fetch.py
@@ -1,33 +1,12 @@
-"""Tests for the Direct Send library-catalog fetch helpers (T017 / T107–T111).
+"""Tests for the Direct Send library-catalog fetch helpers.
 
-Covers:
+Anchor: FR-003c / FR-003d / FR-003e / FR-003f / FR-003g / Decision 9
+/ Decision 12 (see ``specs/002-direct-send-broadcasts/spec.md``).
 
-- ``adapt_meta_library_template_response`` — pure adapter shared
-  between push-time validation (legacy) and the Direct Send
-  assignment branch. Validates components against the supported set
-  per ``contracts/meta-library-catalog.md`` §5 and raises
-  ``DirectSendUnsupportedComponentError`` on any violation
-  (Decision 12).
-- ``fetch_meta_library_template_metadata`` — Direct-Send-only HTTP
-  wrapper. Calls the service's exact-match fetch and delegates the
-  response to the adapter above (research Decision 9).
-
-Phase 8 fold-in (Session 2026-05-22 — T107–T111) extends the adapter's
-contract with:
-
-- FR-003e — ``header`` is a plain text string at fetch time; any
-  non-string, non-null ``header`` is treated as a malformed response
-  and raises ``DirectSendUnsupportedComponentError(component_type="header")``.
-- FR-003f — ``buttons[*].type`` outside ``{URL, QUICK_REPLY}`` raises
-  ``DirectSendUnsupportedComponentError`` with ``component_type`` set
-  to the rejected type string. URL-button entries are normalized from
-  EITHER a flat ``url`` string OR the legacy nested
-  ``{base_url, url_suffix_example}`` shape to a single canonical flat
-  string via ``_ensure_protocol`` + ``_append_placeholder_if_needed``.
-- Q3 drop-rule — auxiliary curation fields (``body_param_types``,
-  ``attributes``, ``topic``, ``usecase``, ``industry``, ``id``) MUST
-  be dropped at fetch time; only the dispatch-relevant subset
-  ``{header, body, body_params, footer, buttons, category, language}``
+Q3 drop-rule — auxiliary curation fields (``body_param_types``,
+``attributes``, ``topic``, ``usecase``, ``industry``, ``id``) MUST
+be dropped at fetch time; only the dispatch-relevant subset
+``{header, body, body_params, footer, buttons, category, language}``
   is propagated to ``TemplateInfo.metadata``.
 """
 
@@ -239,15 +218,7 @@ class FetchMetaLibraryTemplateMetadataTest(TestCase):
 
 
 class HeaderPlainStringNormalizationTest(TestCase):
-    """T107 — FR-003e header plain-string canonical normalization.
-
-    Meta's library catalog ALWAYS returns ``header`` either absent or as
-    a plain text string. The adapter MUST normalize it to the canonical
-    Retail-internal shape ``{header_type: "TEXT", text: <string>}``
-    (``data-model.md §3``) that ``Broadcast.build_direct_send_message``
-    and the legacy ``Broadcast.build_broadcast_template_message`` both
-    consume via ``header["header_type"]``.
-    """
+    """Plain-string header -> ``{header_type, text}``. Anchor: FR-003e."""
 
     def test_normalizes_plain_string_header_to_canonical_shape(self):
         raw = _typical_response(header="Pedido enviado")
@@ -271,16 +242,7 @@ class HeaderPlainStringNormalizationTest(TestCase):
 
 
 class HeaderDictShapeRejectionTest(TestCase):
-    """T108 — FR-003e: dict-shape header is malformed at fetch time.
-
-    Any non-string, non-null ``header`` raises
-    ``DirectSendUnsupportedComponentError(component_type="header")``
-    so the use case routes through FR-003c (pt_BR retry) and then
-    FR-003d (atomic rollback). The pre-FR-003e dict ``{type, text}``
-    shape is REJECTED — image / media headers on Direct Send-path
-    Templates arise EXCLUSIVELY from post-assignment edits via the
-    ``update_template`` endpoint (FR-026), never from the fetch path.
-    """
+    """Dict-shape header is malformed at fetch. Anchor: FR-003e."""
 
     def test_rejects_dict_header_with_type_text(self):
         raw = _typical_response(header={"type": "TEXT", "text": "Pedido"})
@@ -319,16 +281,7 @@ class HeaderDictShapeRejectionTest(TestCase):
 
 
 class ButtonStrictPerTypeRejectionTest(TestCase):
-    """T109 — FR-003f: strict per-type rejection at fetch time.
-
-    Any ``buttons[*].type`` outside ``{URL, QUICK_REPLY}`` — including
-    ``PHONE_NUMBER``, ``PAYMENT_REQUEST``, ``ORDER_DETAILS``,
-    ``COPY_CODE``, ``FLOW``, or any future Meta-curated value — raises
-    ``DirectSendUnsupportedComponentError(component_type=<type>)`` so
-    the use case routes through FR-003c → FR-003d. Pinned per-type so
-    a future refactor that adds a generic catch-all branch is still
-    observable as the spec-intended behaviour rather than a coincidence.
-    """
+    """Strict per-type button rejection. Anchor: FR-003f."""
 
     def _raw_with_button_type(self, btn_type: str, **extra) -> dict:
         return _typical_response(
@@ -384,16 +337,7 @@ class ButtonStrictPerTypeRejectionTest(TestCase):
 
 
 class ButtonUrlShapeNormalizationTest(TestCase):
-    """T110 — FR-003f: dual URL-button shape normalization.
-
-    URL-button entries arrive in EITHER (a) flat ``url`` string OR
-    (b) legacy nested ``{base_url, url_suffix_example}`` shape; both
-    MUST normalize to a flat ``url`` string at persist time via the
-    same ``_ensure_protocol`` + ``_append_placeholder_if_needed``
-    heuristic the push-path ``ButtonTransformer`` already applies, so
-    ``metadata.buttons`` stores a single canonical shape regardless of
-    upstream variance.
-    """
+    """Dual URL-button shape normalization. Anchor: FR-003f."""
 
     def test_flat_url_string_is_preserved_with_placeholder(self):
         raw = _typical_response(
@@ -488,18 +432,7 @@ class ButtonUrlShapeNormalizationTest(TestCase):
 
 
 class AuxiliaryFieldDropTest(TestCase):
-    """T111 — Session 2026-05-22 Q3: auxiliary curation fields are dropped.
-
-    Meta's library catalog may carry auxiliary curation fields
-    (``body_param_types``, ``attributes``, ``topic``, ``usecase``,
-    ``industry``, ``id``). The adapter MUST drop all of them — only the
-    dispatch-relevant subset ``{header, body, body_params, footer,
-    buttons, category, language}`` propagates to
-    ``TemplateInfo.metadata``. The ``direct_send`` audit sub-object is
-    added by ``AssignAgentUseCase._create_library_templates`` at write
-    time, NOT by the adapter, so this test MUST NOT expect it on the
-    adapter return value.
-    """
+    """Auxiliary curation fields are dropped at fetch."""
 
     _FORBIDDEN_AUXILIARY_KEYS = (
         "body_param_types",
@@ -540,7 +473,7 @@ class AuxiliaryFieldDropTest(TestCase):
                 metadata,
                 msg=(
                     f"auxiliary curation field {key!r} must be dropped from "
-                    f"metadata at fetch time per Session 2026-05-22 Q3"
+                    f"metadata at fetch time"
                 ),
             )
 
@@ -572,21 +505,7 @@ class AuxiliaryFieldDropTest(TestCase):
 
 
 class ButtonLabelOverrideMapTest(TestCase):
-    """T112 — FR-003g per-(template_name, language) button-label override map.
-
-    The override map is consulted ONLY when an upstream URL button's
-    ``text`` would otherwise overflow ``MAX_BUTTON_LABEL_LENGTH``. The
-    map is a remediation for Meta's library catalog occasionally
-    publishing button labels longer than the 20-char ceiling on
-    locale-translated variants (the canonical real-world example is
-    ``order_canceled_3``'s ``"Ver detalhes do pedido"`` in ``pt_BR``
-    and ``"Ver detalles del pedido"`` in ``es``).
-
-    Per FR-003g(a) the override applies only at the URL button surface;
-    QUICK_REPLY overflows still raise. Per FR-003g(h) an override value
-    that itself overflows MUST raise (override is a remediation, not
-    a length-check bypass).
-    """
+    """Per-(template_name, language) URL-button label override map. Anchor: FR-003g."""
 
     _OVERLONG_PT = "Ver detalhes do pedido"
     _OVERRIDE_PT = "Detalhes do pedido"
@@ -759,9 +678,7 @@ class ButtonLabelOverrideMapTest(TestCase):
 
 
 class FetchMetaLibraryTemplateMetadataLanguagePropagationTest(TestCase):
-    """T112 — language argument MUST be propagated to the adapter so the
-    override map can be consulted on overflow per FR-003g.
-    """
+    """``language`` is forwarded to the adapter. Anchor: FR-003g."""
 
     def test_language_is_forwarded_to_adapter_for_override_lookup(self):
         meta_service = MagicMock()

--- a/retail/templates/tests/usecases/test_update_template.py
+++ b/retail/templates/tests/usecases/test_update_template.py
@@ -84,10 +84,7 @@ class UpdateTemplateUseCaseTest(TestCase):
     def test_execute_persists_paused_as_is_and_does_not_promote_current_version(
         self,
     ):
-        """US3 / T030a — FR-026: PAUSED is accepted and persisted as-is
-        on the named ``Version``; the template's ``current_version`` FK
-        is unchanged (APPROVED-only promotion logic does not fire).
-        """
+        """PAUSED is persisted as-is, no promotion. Anchor: FR-026."""
         previous_current_version = self.template.current_version
 
         payload = {"version_uuid": str(self.version_uuid), "status": "PAUSED"}
@@ -103,7 +100,7 @@ class UpdateTemplateUseCaseTest(TestCase):
     def test_execute_persists_flagged_as_is_and_does_not_promote_current_version(
         self,
     ):
-        """US3 / T030a — FR-026: same contract as PAUSED for FLAGGED."""
+        """FLAGGED same contract as PAUSED. Anchor: FR-026."""
         previous_current_version = self.template.current_version
 
         payload = {"version_uuid": str(self.version_uuid), "status": "FLAGGED"}
@@ -119,10 +116,7 @@ class UpdateTemplateUseCaseTest(TestCase):
     def test_execute_persists_pending_as_is_and_does_not_promote_current_version(
         self,
     ):
-        """US3 / T030a regression — existing PENDING contract unchanged
-        (defensive check so the FR-026 substitution rule cannot
-        accidentally widen the promotion branch).
-        """
+        """PENDING contract regression. Anchor: FR-026."""
         previous_current_version = self.template.current_version
 
         payload = {"version_uuid": str(self.version_uuid), "status": "PENDING"}

--- a/retail/templates/tests/usecases/test_validate_template_sample.py
+++ b/retail/templates/tests/usecases/test_validate_template_sample.py
@@ -1,19 +1,4 @@
-"""Unit tests for ``ValidateTemplateSampleUseCase`` happy paths (T017 / US1).
-
-Mocks the ``MetaService`` boundary so no live external provider is
-involved (Constitution Principle III). Each test asserts the four
-US1 acceptance properties:
-
-- Local state outcome (Version + Template.current_version + metadata).
-- Result wrapper shape (``category``, ``template_updated``).
-- Audit-log sequence with the FR-008b log-level discipline.
-- Wire-shape correctness on the outbound Meta call (for shape-specific cells).
-
-US2 lockstep tests (T020 / T021) also live here — they pin the
-metadata-shape parity between the sample endpoint and the legacy
-PATCH endpoint, and the FR-006 / A10 guarantee that the sample
-endpoint NEVER fires ``task_create_template.delay(...)``.
-"""
+"""Tests for ``ValidateTemplateSampleUseCase``. Anchor: FR-006 / FR-008b."""
 
 import logging
 from unittest.mock import MagicMock, patch
@@ -64,15 +49,7 @@ _WABA_ID = "987654321"
     META_SYSTEM_USER_ACCESS_TOKEN="test-token",
 )
 class _UseCaseTestBase(TestCase):
-    """Shared fixtures: Direct Send-eligible Template + mocked integrations.
-
-    Per the 2026-05-26 clarification (FR-005a / A2), the use case now
-    resolves the WABA id via ``IntegrationsService.get_channel_app(
-    "wpp-cloud", app_uuid)`` instead of reading a local ``ProjectOnboarding``
-    row. Tests inject a ``MagicMock(spec=IntegrationsServiceInterface)``
-    whose ``get_channel_app`` returns the canonical
-    ``{"config": {"waba": {"id": _WABA_ID}}}`` shape (Phase 3b).
-    """
+    """Shared fixtures: Direct Send-eligible Template + mocked integrations."""
 
     def setUp(self):
         super().setUp()
@@ -399,7 +376,7 @@ class BlockedProjectStillProcessesTest(_UseCaseTestBase):
 
 
 class DirectSendEligibilityGateTest(_UseCaseTestBase):
-    """Pre-condition gate (FR-002a) — verify gating happens BEFORE Meta call."""
+    """Eligibility gate runs before the Meta call. Anchor: FR-002a."""
 
     def test_template_without_integrated_agent_raises_not_eligible(self):
         non_eligible_template = Template.objects.create(
@@ -426,15 +403,7 @@ class DirectSendEligibilityGateTest(_UseCaseTestBase):
 
 
 class ZeroProjectOnboardingQueryRegressionTest(_UseCaseTestBase):
-    """T036 step 3 — pin that ``ProjectOnboarding`` is never read.
-
-    Per the 2026-05-26 clarification + data-model.md §3, the WABA-id
-    resolution flows exclusively through
-    ``IntegrationsService.get_channel_app(...)``. A regression that
-    re-introduces a ``ProjectOnboarding.objects.*`` read would silently
-    degrade the SC-008 / FR-005a guarantee that the integrations engine
-    is the sole authoritative source for channel-app state.
-    """
+    """WABA resolution never reads ``ProjectOnboarding``. Anchor: FR-005a / SC-008."""
 
     def test_utility_request_never_reads_project_onboarding(self):
         self.meta_service.submit_template_sample.return_value = {
@@ -458,17 +427,7 @@ class ZeroProjectOnboardingQueryRegressionTest(_UseCaseTestBase):
 
 
 class LegacyPatchEndpointMetadataParityTest(_UseCaseTestBase):
-    """T020 / US2 — sample-endpoint metadata MUST equal legacy PATCH metadata.
-
-    Both endpoints write ``Template.metadata`` through the SAME
-    refactored helper ``UpdateNormalTemplateStrategy._build_and_persist_metadata``
-    (Phase 2 / T008). A regression that diverged the two paths would
-    silently break the SC-005 / US2 promise that the frontend can
-    swap the legacy PATCH and the new sample endpoint without ANY
-    rendering difference. This test submits byte-identical input
-    payloads through both paths against two sibling templates and
-    asserts the resulting ``metadata`` dicts are equal.
-    """
+    """Sample / legacy PATCH metadata parity. Anchor: SC-005."""
 
     def _build_legacy_template(self) -> Template:
         return Template.objects.create(
@@ -535,17 +494,7 @@ class LegacyPatchEndpointMetadataParityTest(_UseCaseTestBase):
 
 
 class TaskCreateTemplateNotFiredTest(_UseCaseTestBase):
-    """T021 / US2 — sample endpoint MUST NOT push to Integrations on UTILITY.
-
-    Per FR-006 / A10, ``task_create_template.delay(...)`` is structurally
-    absent from the sample-endpoint composition because Direct Send
-    dispatch reads local ``Template.metadata`` directly and an
-    Integrations push would race with the next Direct Send broadcast
-    (Meta error 132021 "A template with the same name already exists"
-    per ``docs/direct-send-api-beta-integration.md:976``). A regression
-    that re-introduced the push would silently break the next Direct
-    Send dispatch after every operator edit.
-    """
+    """Sample endpoint MUST NOT push to Integrations. Anchor: FR-006."""
 
     @patch(TASK_CREATE_TEMPLATE_PATH)
     def test_utility_classification_does_not_enqueue_create_template_task(
@@ -563,19 +512,7 @@ class TaskCreateTemplateNotFiredTest(_UseCaseTestBase):
 
 
 class _FailurePathAssertionMixin:
-    """Shared assertions for US3 failure-path tests (T022–T027c).
-
-    Centralizes the three structural guarantees every failure path
-    MUST honor per FR-005c / FR-006c / spec.md US3:
-
-    - The local template's ``metadata``, ``current_version``, and the
-      current Version's ``status`` are byte-identical pre/post (no
-      side-effects on a failure path).
-    - The audit log emits the FR-008a-mandated event at the
-      FR-008b-mandated log level.
-    - The Meta sample API is NOT called on pre-Meta failure paths
-      (callers opt in by passing ``meta_call_expected=False``).
-    """
+    """Shared failure-path assertions. Anchor: FR-005c / FR-006c / FR-008a / FR-008b."""
 
     def _snapshot_local_state(self, template: Template) -> dict:
         return {
@@ -601,17 +538,7 @@ class _FailurePathAssertionMixin:
 
 
 class MetaUnavailableErrorPathTest(_FailurePathAssertionMixin, _UseCaseTestBase):
-    """T022 / US3 — Meta-unavailable propagates as MetaSampleUnavailableError.
-
-    Two failure modes flow through ``_call_meta_sample_api`` and the
-    ``except`` blocks: (a) ``CustomAPIException`` raised by the Meta
-    client (HTTP 5xx, network timeout — carries a parseable error
-    envelope); (b) any other unexpected exception (carries no
-    envelope). Both surface as ``MetaSampleUnavailableError`` per
-    FR-005c, preserve the original ``status_code`` / ``meta_response``
-    when present, and emit ``meta_error`` at ERROR level with
-    ``exc_info=True`` per FR-008b.
-    """
+    """Meta-unavailable -> ``MetaSampleUnavailableError``. Anchor: FR-005c."""
 
     def test_custom_api_exception_propagates_with_envelope_and_status_code(self):
         upstream_envelope = {"error": {"message": "rate limited", "code": 130472}}
@@ -658,16 +585,7 @@ class MetaUnavailableErrorPathTest(_FailurePathAssertionMixin, _UseCaseTestBase)
 
 
 class MetaInvalidResponseErrorPathTest(_FailurePathAssertionMixin, _UseCaseTestBase):
-    """T023 / US3 — Meta returned HTTP 200 but the body is unusable.
-
-    Four invalid response shapes collapse to ``MetaInvalidResponseError``
-    per FR-005b / FR-005c: ``success: false`` (even when ``category``
-    is present — success-false wins), missing ``category`` key, empty
-    ``category`` string, and ``success: false`` together with a present
-    ``category``. The exception preserves the raw Meta body verbatim
-    so the view's HTTP 502 response can carry it (FR-007b). The
-    ``meta_invalid_response`` event fires at WARNING per FR-008b.
-    """
+    """Meta 200 with unusable body -> ``MetaInvalidResponseError``. Anchor: FR-005b."""
 
     INVALID_META_BODIES = [
         ("success_false_with_error_envelope", {"success": False, "error": {"code": 1}}),
@@ -706,21 +624,7 @@ class MetaInvalidResponseErrorPathTest(_FailurePathAssertionMixin, _UseCaseTestB
 
 
 class WabaNotConfiguredErrorPathTest(_FailurePathAssertionMixin, _UseCaseTestBase):
-    """T024 / US3 — WABA-not-configured collapses three modes to one error.
-
-    Per the 2026-05-26 Q3 clarification, three integrations-side
-    failure modes — infra failure (``None``), no app for the supplied
-    ``app_uuid`` (also ``None``), and app exists but config has no
-    ``waba_id`` — all surface as ``WabaNotConfiguredError``. The
-    audit-log ``integrations_response_present`` discriminates infra /
-    missing-app (``False``) from app-exists-but-no-waba (``True``)
-    per FR-008a. The Meta API is NOT called on any of the five cases
-    (gate runs upstream of the Meta call per FR-005a ordering).
-
-    Also pins the data-model.md §3 regression: ``ProjectOnboarding``
-    is never read by this endpoint — the integrations engine is the
-    sole authoritative source for WABA-id resolution.
-    """
+    """WABA resolution failures collapse to one error. Anchor: FR-005a / FR-008a."""
 
     INFRA_FAILURE_CASE = (
         "infra_failure_service_swallowed_custom_api_exception",
@@ -799,18 +703,7 @@ class WabaNotConfiguredErrorPathTest(_FailurePathAssertionMixin, _UseCaseTestBas
 
 
 class NotDirectSendEligibleErrorPathTest(_FailurePathAssertionMixin, _UseCaseTestBase):
-    """T025 / US3 — non-eligible templates fail upstream of WABA + Meta.
-
-    Three eligibility-failure modes per data-model.md §4: (a) the
-    template has no ``IntegratedAgent`` FK (custom template never
-    assigned), (b) the agent's ``config`` is empty, (c) the agent's
-    ``config["direct_send"]`` is falsy. The gate runs BEFORE WABA
-    resolution and BEFORE the Meta call per data-model.md §9
-    sequencing — both upstreams MUST be untouched on any of the
-    three failure modes. The ``not_direct_send_eligible`` event
-    fires at WARNING level per FR-008b carrying the IntegratedAgent
-    UUID (or ``None``) and the resolved flag.
-    """
+    """Eligibility gate runs upstream of WABA + Meta. Anchor: FR-002a / FR-008b."""
 
     def test_orphan_template_without_integrated_agent_raises(self):
         orphan_template = Template.objects.create(
@@ -889,18 +782,7 @@ class NotDirectSendEligibleErrorPathTest(_FailurePathAssertionMixin, _UseCaseTes
 
 
 class PartialFailureAfterUtilityPathTest(_FailurePathAssertionMixin, _UseCaseTestBase):
-    """T027 / US3 — local update fails AFTER Meta classified as UTILITY.
-
-    When Meta has already classified the sample as UTILITY but the
-    local update raises (DB write fails, S3 upload fails), the use
-    case re-raises the original exception unmodified — there is no
-    rollback of the Meta sample because Meta's sample API is
-    fire-and-forget per FR-006c. The
-    ``local_update_failed_after_meta_approval`` event fires at ERROR
-    level with ``exc_info=True`` AND carries the Meta sample id when
-    Meta returned one — that id is the only thread an operator can
-    grep against the Meta-side log trail.
-    """
+    """Local update failure after Meta UTILITY. Anchor: FR-006c."""
 
     def test_strategy_failure_after_utility_propagates_and_emits_error_event(self):
         mock_strategy = MagicMock()
@@ -938,20 +820,7 @@ class PartialFailureAfterUtilityPathTest(_FailurePathAssertionMixin, _UseCaseTes
 
 
 class FlaggedToApprovedRecoveryChannelTest(_UseCaseTestBase):
-    """T027c / US3 — sample endpoint is the third FLAGGED → APPROVED channel.
-
-    Spec.md Edge Case "FLAGGED → APPROVED via sample endpoint":
-    when spec 003's ``template_correct_category_detection`` webhook
-    flags a template (Meta downgraded its category), the operator
-    can recover by re-submitting through the sample endpoint with a
-    UTILITY-classifying payload. A new APPROVED Version is created
-    and ``current_version`` advances to it; the prior FLAGGED Version
-    is retained verbatim in ``template.versions`` so the audit trail
-    survives. The ``template_updated`` audit-log line carries
-    ``previous_current_version_status=FLAGGED`` per FR-008a /
-    data-model.md §1 — this is the operator-facing signal that the
-    sample-validation channel un-flagged the template.
-    """
+    """Sample endpoint as FLAGGED -> APPROVED recovery channel. Anchor: FR-008a."""
 
     def setUp(self):
         super().setUp()

--- a/retail/templates/tests/usecases/test_validate_template_sample_broadcast_parity.py
+++ b/retail/templates/tests/usecases/test_validate_template_sample_broadcast_parity.py
@@ -1,26 +1,4 @@
-"""Lockstep parity tests for sample validation / Direct Send broadcast (T019 / US2).
-
-Pins SC-004: a UTILITY-classifying sample submission produces local
-template state that ``Broadcast.build_direct_send_message`` renders
-on the very next dispatch attempt with dispatch-time variables
-substituted into the NEW content.
-
-There is no cache lag and no asynchronous convergence window —
-``Template.current_version`` is advanced in-line by the sample
-endpoint, and the dispatcher reads the new
-``current_version.template_name`` plus ``Template.metadata`` directly
-on its next call. A regression that broke this lockstep guarantee
-(asynchronous Integrations push, write-behind cache, divergence
-between the sample-time and dispatch-time renderers) would let the
-operator believe the broadcast carries the new content while it
-still carries the prior one.
-
-The test exercises the REAL ``ValidateTemplateSampleUseCase`` against
-a database-backed Template + Version stack and the REAL
-``Broadcast`` renderer. Only the external boundaries are mocked
-(MetaService, IntegrationsService, S3 metadata handler) per
-Constitution Principle III.
-"""
+"""Sample-validation / Direct Send broadcast lockstep. Anchor: SC-004."""
 
 from unittest.mock import MagicMock, patch
 from uuid import uuid4

--- a/retail/templates/tests/views/test_validate_template_sample_schema_parity.py
+++ b/retail/templates/tests/views/test_validate_template_sample_schema_parity.py
@@ -1,26 +1,4 @@
-"""Schema-parity tests for ``POST /api/v3/templates/<uuid>/sample/`` (T028 / US4).
-
-Pins the structural contract the frontend depends on:
-
-- **Request schema parity (FR-014)**: ``ValidateTemplateSampleSerializer``
-  exposes exactly the same field set as ``UpdateTemplateContentSerializer``
-  so the frontend can serialize the same form state it sends to the
-  legacy ``PATCH /api/v3/templates/<uuid>/`` endpoint. The subclass
-  only layers on additional ``validate_*`` methods (FR-003a / FR-002b);
-  it does NOT add, remove, or rename any field. A drift here would
-  silently break the frontend integration.
-
-- **Response schema parity (SC-005)**: the HTTP 200 response wrapper
-  has exactly four top-level keys ``{category, template_updated,
-  template, meta_sample_response}`` and the ``template`` field is
-  byte-for-byte equal to ``ReadTemplateSerializer(template).data`` —
-  the same shape the legacy ``GET /api/v3/templates/<uuid>/`` returns.
-  The frontend can substitute the response's ``template`` field
-  directly into its display state without a second round-trip.
-
-Both tests break loudly if anyone renames a serializer field or drops
-a key from the wrapper, which is the structural guarantee US4 owns.
-"""
+"""Schema-parity tests for the sample endpoint. Anchor: FR-014 / SC-005."""
 
 from unittest.mock import patch
 from uuid import uuid4
@@ -67,12 +45,7 @@ _EXPECTED_WRAPPER_KEYS = {
 
 
 class ValidateTemplateSampleRequestSchemaParityTest(TestCase):
-    """T028 (a) — request field set equals ``UpdateTemplateContentSerializer``'s.
-
-    Pure structural test — no DB rows, no HTTP roundtrip. Compares the
-    declared serializer field sets so the assertion breaks the moment
-    anyone adds, removes, or renames a field in either class.
-    """
+    """Request field set parity with the legacy PATCH serializer."""
 
     def test_field_set_matches_update_template_content_serializer(self):
         legacy_fields = set(UpdateTemplateContentSerializer().fields.keys())
@@ -81,13 +54,7 @@ class ValidateTemplateSampleRequestSchemaParityTest(TestCase):
         self.assertEqual(sample_fields, legacy_fields)
 
     def test_sample_serializer_inherits_from_update_template_content_serializer(self):
-        """Structural guard: the subclass relationship is the source of parity.
-
-        If a future refactor breaks the inheritance link (e.g. copies
-        fields by hand instead of extending), the first test above could
-        still pass but would no longer benefit from automatic propagation
-        of upstream field additions. This test pins the inheritance.
-        """
+        """Inheritance link is the source of parity."""
         self.assertTrue(
             issubclass(
                 ValidateTemplateSampleSerializer, UpdateTemplateContentSerializer
@@ -98,15 +65,7 @@ class ValidateTemplateSampleRequestSchemaParityTest(TestCase):
 @with_test_settings
 @patch(INTEGRATIONS_SERVICE_PATCH_PATH)
 class ValidateTemplateSampleResponseSchemaParityTest(BaseTestMixin, APITestCase):
-    """T028 (b) — HTTP 200 ``template`` field equals ``ReadTemplateSerializer``'s.
-
-    Submits a UTILITY-mocked sample request and verifies (1) the wrapper
-    has exactly four top-level keys (FR-007 / FR-007a) and (2) the
-    ``template`` field is byte-for-byte equal to the data
-    ``ReadTemplateSerializer(template).data`` produces independently on
-    the same template instance. Pins SC-005 — the frontend renders the
-    response without a follow-up GET.
-    """
+    """HTTP 200 ``template`` equals ``ReadTemplateSerializer``. Anchor: FR-007 / SC-005."""
 
     def setUp(self):
         super().setUp()

--- a/retail/templates/tests/views/test_validate_template_sample_view.py
+++ b/retail/templates/tests/views/test_validate_template_sample_view.py
@@ -1,17 +1,7 @@
-"""View tests for ``POST /api/v3/templates/<uuid>/sample/`` (T018 / US1 + SC-008).
+"""View tests for ``POST /api/v3/templates/<uuid>/sample/``.
 
-Covers the HTTP boundary for the happy path (HTTP 200 UTILITY +
-MARKETING), the auth gates (401 / 403 / 404), serializer-level
-validation (400), and the FR-002b ``project_uuid_mismatch`` defense
-with the WARNING-level audit-log line emitted by the view per T016.
-
-Phase 3b (T037): the WABA-id resolution path was switched to call
-``IntegrationsService.get_channel_app("wpp-cloud", dto.app_uuid)`` per
-FR-005a / A2. A class-level patch guards the
-``IntegrationsService`` symbol the use-case ``__init__`` resolves so
-that even if a future refactor drops the per-test
-``ValidateTemplateSampleUseCase`` mock, the integrations engine is
-never reached from a unit test (defense-in-depth — no live network).
+Anchor: FR-002b / FR-005a / SC-008 (see
+``specs/004-template-sample-validation/spec.md``).
 """
 
 from unittest.mock import patch
@@ -319,19 +309,7 @@ _BUG_REPORT_WABA_ID = "100200300400500"
 class ValidateTemplateSampleViewExtendedShape1bIntegrationTest(
     BaseTestMixin, APITestCase
 ):
-    """T041 / Phase 3c — end-to-end integration test for the bug-report case.
-
-    Unlike the upstream ``ValidateTemplateSampleViewTest`` (which patches
-    the entire ``ValidateTemplateSampleUseCase`` to assert on the HTTP
-    boundary in isolation), this class lets the real use case execute
-    against patched ``IntegrationsService`` and ``MetaService`` so the
-    extended Shape 1b wire body is observed at the actual ``MetaService``
-    boundary (the only mock surface). This pins spec AS4 / FR-004
-    (post-clarification) end-to-end: the bug case reported 2026-05-26
-    (``{template_body, template_header: "Pedido recebido", template_button:
-    []}``) MUST emit ``{"type": "text", "header": {"type": "text", "text":
-    "Pedido recebido"}, "text": {"body": ...}}`` and update local state.
-    """
+    """End-to-end no-button-with-header wire body regression. Anchor: FR-004."""
 
     def setUp(self):
         super().setUp()
@@ -489,17 +467,7 @@ class ValidateTemplateSampleViewExtendedShape1bIntegrationTest(
 @with_test_settings
 @patch(INTEGRATIONS_SERVICE_PATCH_PATH)
 class ValidateTemplateSampleViewErrorPathTest(BaseTestMixin, APITestCase):
-    """T026 / US3 — view-level error-path HTTP boundary contract.
-
-    For each of the four use-case domain exceptions, patches
-    ``ValidateTemplateSampleUseCase.execute`` to raise it and asserts
-    the deterministic response shape pinned by
-    ``contracts/sample-endpoint-request-response.md`` (FR-007 / FR-007b /
-    FR-007d / FR-007e). The optional ``meta_response`` body field is
-    present only when the raised exception carries one (FR-007b — the
-    upstream Meta envelope is forwarded verbatim so the frontend can
-    surface Meta's error code without a second round-trip).
-    """
+    """View-level domain-exception HTTP boundary. Anchor: FR-007 / FR-007b."""
 
     def setUp(self):
         super().setUp()
@@ -656,29 +624,7 @@ META_SERVICE_PATCH_PATH_SC008 = "retail.services.meta.service.MetaService"
 @patch(META_SERVICE_PATCH_PATH_SC008)
 @patch(INTEGRATIONS_SERVICE_PATCH_PATH)
 class ValidateTemplateSampleViewCrossTenantIsolationTest(BaseTestMixin, APITestCase):
-    """T027b / US3 / SC-008 — cross-tenant isolation structural guarantee.
-
-    Per the 2026-05-26 Q2 trust-the-frontend clarification, the spec
-    pins SC-008 enforcement to exactly TWO structural checks:
-    (a) ``HasProjectPermission`` on the view rejects operators
-        unauthorized for the claimed project via Connect's
-        authorization API (HTTP 403 before any business logic runs);
-    (b) The serializer-layer FR-002b ``Project-Uuid`` header ↔ body
-        ``project_uuid`` equality check refuses cross-tenant routing
-        at the entry point (HTTP 400 with
-        ``error_code = "project_uuid_mismatch"``).
-
-    The frontend-supplied ``app_uuid`` is explicitly trusted and is
-    NOT cross-checked against the loaded template's
-    ``integrated_agent.channel_uuid`` or the integrations response's
-    ``project_uuid``. The residual exposure (compromised frontend or
-    token-holding bypass caller) is a documented known limitation —
-    see the clarification record at ``spec.md`` Q2-2026-05-26.
-
-    This test class pins case (1) of SC-008 by structurally asserting
-    that no upstream (MetaService / IntegrationsService) is reached
-    AND no DB write fires on a project_uuid mismatch.
-    """
+    """Cross-tenant isolation structural guarantee. Anchor: FR-002b / SC-008."""
 
     def setUp(self):
         super().setUp()

--- a/retail/templates/usecases/_meta_library_template_fetch.py
+++ b/retail/templates/usecases/_meta_library_template_fetch.py
@@ -1,36 +1,11 @@
-"""Direct Send library-catalog fetch helpers.
+"""Direct Send library-catalog fetch + adaptation helpers.
 
-Two helpers split per research Decision 9 / data-model.md §5:
-
-- :func:`adapt_meta_library_template_response` — pure adapter shared
-  between the legacy push-time validation flow
-  (``ValidatePreApprovedTemplatesUseCase._get_template_info``) and the
-  Direct Send-enabled assignment branch
-  (``AssignAgentUseCase._create_library_templates``). Validates the
-  raw library-catalog response against the Direct Send Beta supported
-  set per ``contracts/meta-library-catalog.md`` §5 and raises
-  :class:`DirectSendUnsupportedComponentError` on any violation
-  (Decision 12).
-- :func:`fetch_meta_library_template_metadata` — Direct-Send-only HTTP
-  wrapper. Calls the service's exact-match fetch and delegates the
-  response to :func:`adapt_meta_library_template_response`.
-
-The split preserves Decision 4's "push-time keeps fuzzy semantics"
-guarantee while extracting the response-shaping drift risk.
-
-The four rejection branches (header shape, button type, length/count
-overflow, malformed JSON) collapse to a single exception class
-(``DirectSendUnsupportedComponentError``) so the use case keeps a
-single FR-003c → FR-003d routing path. ``component_type`` carries a
-stable discriminator:
-
-- ``"header"`` — header shape OR header length issues (FR-003e)
-- ``"<button.type>"`` — specific button type outside ``{URL, QUICK_REPLY}``
-  (FR-003f); e.g. ``"PHONE_NUMBER"``, ``"PAYMENT_REQUEST"``,
-  ``"ORDER_DETAILS"``, ``"COPY_CODE"``, ``"FLOW"``
-- ``"body"`` / ``"footer"`` / ``"buttons"`` — length or count overflow
-  on a known component
-- ``"malformed"`` — missing required keys, structural violations
+Validates raw library-catalog responses against the Direct Send Beta
+supported set and shapes them into the local ``Template.metadata``
+form. Anchor: FR-003c / FR-003d / FR-003e / FR-003f / FR-003g /
+Research Decision 9 / Decision 12 (see
+``specs/002-direct-send-broadcasts/spec.md`` and
+``contracts/meta-library-catalog.md`` §5).
 """
 
 import logging
@@ -75,21 +50,11 @@ def adapt_meta_library_template_response(
 ) -> Optional[TemplateInfo]:
     """Validate and shape a library-catalog response into ``TemplateInfo``.
 
-    Returns ``None`` when ``raw is None``. Otherwise validates the
-    components against the Direct Send Beta supported set
-    (``contracts/meta-library-catalog.md`` §5) and shapes the response
-    into the local ``Template.metadata`` form consumed by
-    ``Broadcast.build_direct_send_message`` (data-model.md §3).
-    Raises :class:`DirectSendUnsupportedComponentError` on any
-    violation so the assignment use case routes through FR-003c →
-    FR-003d (Decision 12).
-
-    ``language`` is the locale the Direct Send fetch is occurring in
-    (project locale or ``pt_BR`` fallback). When provided AND a URL
-    button's text would overflow ``MAX_BUTTON_LABEL_LENGTH``, the
-    per-``(template_name, language)`` override map is consulted to
-    remediate the overflow (FR-003g). Defaults to ``None`` so the
-    legacy push-time validation flow remains source-compatible.
+    Returns ``None`` when ``raw is None``; raises
+    :class:`DirectSendUnsupportedComponentError` on any unsupported
+    component. ``language`` is consulted for the FR-003g URL-button
+    label override; ``None`` keeps the legacy push-path source-compat.
+    Anchor: FR-003c / FR-003d / FR-003g / Decision 12.
     """
     if raw is None:
         return None
@@ -123,15 +88,10 @@ def fetch_meta_library_template_metadata(
     template_name: str,
     language: str,
 ) -> Optional[TemplateInfo]:
-    """Fetch and adapt a library template via the Direct Send path.
+    """Exact-match Direct Send library fetch + adapt.
 
-    Calls
-    :py:meth:`MetaServiceInterface.fetch_library_template_by_name_and_language`
-    (exact-match) and delegates the response to
-    :func:`adapt_meta_library_template_response`. The service swallows
-    HTTP failures and returns ``None``; the adapter raises
-    :class:`DirectSendUnsupportedComponentError` on validation
-    violations.
+    HTTP failures surface as ``None``; adapter rejections raise
+    :class:`DirectSendUnsupportedComponentError`.
     """
     raw = meta_service.fetch_library_template_by_name_and_language(
         template_name, language
@@ -157,17 +117,9 @@ def _validate_body(raw: Dict[str, Any], *, template_name: str) -> str:
 def _validate_and_normalize_header(
     raw: Dict[str, Any], *, template_name: str
 ) -> Optional[Dict[str, Any]]:
-    """Normalize Meta's plain-string ``header`` to the canonical shape.
+    """Normalize Meta's plain-string ``header`` to ``{header_type, text}``.
 
-    FR-003e: Meta's library catalog ALWAYS returns ``header`` either
-    absent or as a plain text string. Any non-string, non-null shape
-    (including the pre-FR-003e dict ``{type, text}``) is treated as
-    malformed and raises ``DirectSendUnsupportedComponentError(
-    component_type="header")`` so the use case routes through
-    FR-003c → FR-003d. Plain-string headers are length-validated
-    against ``MAX_HEADER_TEXT_LENGTH`` and normalized to the
-    canonical Retail-internal shape ``{header_type: "TEXT",
-    text: <string>}`` (data-model.md §3).
+    Anchor: FR-003e (any non-null, non-string shape is malformed).
     """
     header = raw.get("header")
     if header is None:
@@ -205,19 +157,9 @@ def _validate_and_normalize_buttons(
 ) -> Optional[List[Dict[str, Any]]]:
     """Validate types and normalize URL-button shapes.
 
-    FR-003f: ``buttons[*].type`` outside ``{URL, QUICK_REPLY}`` raises
-    ``DirectSendUnsupportedComponentError(component_type=<type>)``;
-    URL-button entries accept either a flat ``url`` string OR the
-    legacy nested ``{base_url, url_suffix_example}`` shape and are
-    normalized to a single flat-string canonical form via the shared
-    ``ensure_protocol`` + ``append_placeholder_if_needed`` helpers
-    (push-path ``ButtonTransformer`` agrees on the same heuristic).
-
-    FR-003g: when a URL button's text would otherwise overflow
-    ``MAX_BUTTON_LABEL_LENGTH`` AND a ``(template_name, language)``
-    entry exists in ``DIRECT_SEND_BUTTON_LABEL_OVERRIDES``, the
-    override value replaces the upstream label and the length check
-    is re-run. QUICK_REPLY overflows continue to raise.
+    Anchor: FR-003f (type allowlist + dual URL-shape normalization
+    shared with the push-path ``ButtonTransformer``) / FR-003g
+    (URL-button label override on overflow).
     """
     raw_buttons = raw.get("buttons")
     if raw_buttons is None:
@@ -283,14 +225,11 @@ def _resolve_url_button_label_override(
     template_name: str,
     language: Optional[str],
 ) -> str:
-    """Look up the URL button label override for ``(template_name, language)``.
+    """Look up the URL-button label override for ``(template_name, language)``.
 
-    The override is applied ONLY when the upstream label overflowed
-    ``MAX_BUTTON_LABEL_LENGTH`` (the caller has already confirmed the
-    overflow). Per FR-003g(h) the override value itself MUST satisfy
-    the same length ceiling; an override that overflows raises
-    ``DirectSendUnsupportedComponentError`` (the map is a remediation,
-    not a length-check bypass). Per FR-003g(f) audit is INFO-log-only.
+    Caller has already confirmed the upstream overflow. An override
+    that itself overflows raises (the map is a remediation, not a
+    length-check bypass). Anchor: FR-003g(f) / FR-003g(h).
     """
     override_key = (template_name, language)
     override_map = direct_send_button_overrides.DIRECT_SEND_BUTTON_LABEL_OVERRIDES
@@ -317,13 +256,7 @@ def _resolve_url_button_label_override(
 
 
 def _flatten_url(url: Any, *, template_name: str) -> str:
-    """Collapse the two upstream URL shapes onto a flat string.
-
-    - Flat string: ensure protocol, preserve placeholders verbatim.
-    - Nested ``{base_url, url_suffix_example}``: ensure protocol on
-      ``base_url`` and append ``{{1}}`` when ``url_suffix_example``
-      signals a parameterizable suffix.
-    """
+    """Collapse flat-string and nested-dict URL shapes onto a flat string."""
     if isinstance(url, str):
         return ensure_protocol(url)
     if isinstance(url, dict) and isinstance(url.get("base_url"), str):

--- a/retail/templates/usecases/update_template.py
+++ b/retail/templates/usecases/update_template.py
@@ -49,10 +49,9 @@ class UpdateTemplateUseCase:
 
         status = payload.get("status")
 
-        # FR-026: PAUSED/FLAGGED are persisted as-is and MUST NOT be promoted
-        # to current_version. Do NOT add full_clean()/choices validation here —
-        # it would re-validate against historical choices and silently break
-        # dispatch-time gating (US3 / T031).
+        # No full_clean() here: it would re-validate against historical
+        # choices and silently break the PAUSED/FLAGGED dispatch-time
+        # gating. Anchor: FR-026.
         if status == "APPROVED":
             template = self._update_template_current_version(version, template)
 

--- a/retail/templates/usecases/validate_template_sample.py
+++ b/retail/templates/usecases/validate_template_sample.py
@@ -1,13 +1,6 @@
 """Validate-template-sample use case for the Direct Send pre-flight endpoint.
 
-This module hosts both the in-memory data classes and the orchestration
-behind ``POST /api/v3/templates/<uuid>/sample/`` (the feature pinned by
-``specs/004-template-sample-validation/``).
-
-The DTO is built by the view from
-``ValidateTemplateSampleSerializer.validated_data``; the result is
-shaped for ``Response(result.to_dict(), 200)`` per
-``contracts/sample-endpoint-request-response.md``.
+Anchor: ``specs/004-template-sample-validation/spec.md``.
 """
 
 import logging
@@ -45,14 +38,9 @@ LOG_TAG = "[TemplateSampleValidation]"
 class ValidateTemplateSampleDTO:
     """Validated, immutable payload passed from the view to the use case.
 
-    Built by the view from ``ValidateTemplateSampleSerializer.validated_data``;
-    consumed by ``ValidateTemplateSampleUseCase.execute(...)``. Carries the
-    nine validated input fields enumerated in ``data-model.md`` §7 — the
-    same field set the PATCH endpoint's ``UpdateTemplateContentSerializer``
-    accepts today (FR-003 / FR-014 — schema parity is a hard guarantee
-    so the frontend can call either endpoint with the same form state),
-    plus the ``template_uuid`` path-param the sample endpoint receives
-    on the URL.
+    Field set is schema-parallel with the PATCH endpoint's
+    ``UpdateTemplateContentSerializer`` plus the ``template_uuid``
+    path-param. Anchor: FR-003 / FR-014.
     """
 
     template_uuid: str
@@ -69,14 +57,8 @@ class ValidateTemplateSampleDTO:
 
 @dataclass(frozen=True)
 class ValidateTemplateSampleResult:
-    """Use-case return value shaped for the HTTP 200 response body.
-
-    The view shapes the HTTP body as ``Response(result.to_dict(), 200)``.
-    The wrapper exposes four top-level keys ``{category, template_updated,
-    template, meta_sample_response}`` per FR-007 / FR-007a, with the
-    ``template`` field serialized via the existing ``ReadTemplateSerializer``
-    so the frontend can substitute it directly into its display state
-    without re-fetching (SC-005).
+    """HTTP 200 response body shape ``{category, template_updated,
+    template, meta_sample_response}``. Anchor: FR-007 / FR-007a / SC-005.
     """
 
     category: str
@@ -96,14 +78,7 @@ class ValidateTemplateSampleResult:
 
 
 class EventName(str, Enum):
-    """Closed enumeration for the FR-008a ``event_name`` audit-log discriminator.
-
-    Every audit-log entry from the sample-validation endpoint MUST carry
-    exactly one of these tokens immediately after the
-    ``[TemplateSampleValidation]`` tag. Additive-only — future PRs MAY
-    add tokens but MUST NOT rename or remove existing ones (operator
-    dashboards filter on these literal strings).
-    """
+    """Closed audit-log ``event_name`` discriminator. Anchor: FR-008a (additive-only)."""
 
     RECEIVED = "received"
     META_SAMPLE_SUBMITTED = "meta_sample_submitted"
@@ -119,13 +94,7 @@ class EventName(str, Enum):
 
 
 class MetaSampleType(str, Enum):
-    """The Meta ``message_samples`` interactive sub-type, for audit logging.
-
-    Logged on the ``meta_sample_submitted`` event so dashboards can
-    compute the per-template-type sample-mix (text vs CTA URL vs reply
-    buttons) without re-parsing the request body. Pinned by
-    ``data-model.md`` §7.
-    """
+    """Meta ``message_samples`` interactive sub-type for audit logging."""
 
     TEXT = "text"
     INTERACTIVE_CTA_URL = "interactive.cta_url"
@@ -133,33 +102,14 @@ class MetaSampleType(str, Enum):
 
 
 class ValidateTemplateSampleUseCase:
-    """Orchestrate the ``POST /api/v3/templates/<uuid>/sample/`` happy path.
+    """Orchestrate the ``POST /api/v3/templates/<uuid>/sample/`` flow.
 
-    Loads the Template, gates on Direct-Send eligibility (FR-002a),
-    resolves the project's WABA id (FR-005a), translates the validated
-    DTO into Meta's ``message_samples`` wire shape (FR-004), submits the
-    sample to Meta (FR-005), and conditionally writes a new APPROVED
-    ``Version`` row + advances ``Template.current_version`` when Meta
-    classifies the sample as ``UTILITY`` (FR-006 / FR-006a / FR-006d).
-    Every observable step routes through ``_emit`` so the
-    ``[TemplateSampleValidation]`` audit-log shape is enforced
-    structurally (FR-008).
-
-    The use case is framework-agnostic per Constitution Principle I —
-    no rest_framework imports beyond the canonical ``NotFound`` raised
-    by the template-load step, which DRF translates into HTTP 404 (per
-    the legacy PATCH endpoint's precedent at
-    ``retail/templates/usecases/update_template_body.py``). All other
-    failure modes raise domain exceptions
-    (``NotDirectSendEligibleError`` / ``WabaNotConfiguredError`` /
-    ``MetaSampleUnavailableError`` / ``MetaInvalidResponseError``)
-    that the view translates into HTTP 400 / 502 responses per FR-007.
-
-    The serializer's FR-002b ``Project-Uuid`` header ↔ body
-    ``project_uuid`` equality check runs upstream; the use case treats
-    ``dto.project_uuid`` as the verified-trusted tenant identifier and
-    does not re-check the header (single point of enforcement on the
-    serializer layer per ``data-model.md`` §10).
+    Framework-agnostic except for DRF's ``NotFound`` on the
+    template-load miss (HTTP 404 parity with the legacy PATCH
+    endpoint). Domain failures raise dedicated exceptions translated
+    to HTTP 400/502 by the view. Anchor: FR-002a / FR-004 / FR-005
+    / FR-005a / FR-006 / FR-007 / FR-008 (see
+    ``specs/004-template-sample-validation/spec.md``).
     """
 
     _UTILITY_CATEGORY = "UTILITY"
@@ -212,12 +162,9 @@ class ValidateTemplateSampleUseCase:
         )
 
     def _load_template(self, template_uuid: str) -> Template:
-        """Load the template by UUID with the integrated agent prefetched.
+        """Load the template with the integrated agent prefetched.
 
-        ``select_related("integrated_agent")`` keeps the FR-002a gating
-        predicate a pure in-memory check after this single read. Raises
-        DRF's ``NotFound`` on miss so the view returns HTTP 404 (parity
-        with the legacy PATCH endpoint per FR-011).
+        Raises ``NotFound`` on miss -> HTTP 404. Anchor: FR-011.
         """
         try:
             return Template.objects.select_related("integrated_agent").get(
@@ -227,15 +174,7 @@ class ValidateTemplateSampleUseCase:
             raise NotFound(f"Template not found: {template_uuid}")
 
     def _gate_on_direct_send_eligibility(self, template: Template) -> None:
-        """FR-002a — refuse non-Direct-Send-eligible templates.
-
-        Two failure modes (``data-model.md`` §4): the template has no
-        ``IntegratedAgent`` FK (custom template never assigned), or the
-        agent's ``config["direct_send"]`` flag is falsy. Both surface as
-        a single ``NotDirectSendEligibleError`` distinguished only by
-        the audit-log ``direct_send_flag`` / ``integrated_agent_uuid``
-        fields so dashboards can split them at query time.
-        """
+        """Refuse non-Direct-Send-eligible templates. Anchor: FR-002a."""
         integrated_agent = template.integrated_agent
         direct_send_flag = (
             bool(integrated_agent.config.get(self._DIRECT_SEND_CONFIG_KEY))
@@ -254,19 +193,11 @@ class ValidateTemplateSampleUseCase:
         )
 
     def _resolve_waba_id(self, project_uuid: str, app_uuid: str) -> str:
-        """FR-005a / A2 — resolve the project's WABA id via integrations.
+        """Resolve the project's WABA id via integrations.
 
-        Calls ``IntegrationsService.get_channel_app("wpp-cloud", app_uuid)``
-        and reads ``app["config"]["waba"]["id"]`` — the same field path
-        ``ConfigureOneClickPaymentUseCase._fetch_channel_info`` consumes
-        at ``retail/projects/usecases/configure_one_click_payment.py:192``.
-        Three failure modes collapse to a single ``WabaNotConfiguredError``
-        per Q3-2026-05-26: (a) integrations infra failure (service returns
-        ``None`` after swallowing ``CustomAPIException``), (b) no app for
-        the supplied ``app_uuid`` (also ``None`` under the swallow
-        contract), (c) app exists but ``config["waba"]["id"]`` is missing
-        / empty. The audit-log ``integrations_response_present`` boolean
-        discriminates (a) / (b) from (c).
+        Three failure modes collapse to ``WabaNotConfiguredError``,
+        distinguishable via the ``integrations_response_present``
+        audit-log flag. Anchor: FR-005a.
         """
         app = self.integrations_service.get_channel_app(
             self._WPP_CLOUD_APPTYPE, app_uuid
@@ -285,13 +216,11 @@ class ValidateTemplateSampleUseCase:
     def _build_sample_body(
         self, dto: ValidateTemplateSampleDTO
     ) -> tuple[Dict[str, Any], MetaSampleType]:
-        """Translate the DTO into Meta's wire shape, uploading IMAGE base64 first.
+        """Translate the DTO into Meta's wire shape.
 
-        FR-004a / A9 — base64 IMAGE headers MUST be uploaded to S3
-        before the Meta call so the wire body carries a public URL and
-        the downstream metadata persistence (which calls
-        ``post_process_translation``) sees an already-resolved S3 URL
-        and skips a redundant re-upload (per ``TemplateMetadataHandler._is_s3_url``).
+        Base64 IMAGE headers are uploaded to S3 upfront so the
+        downstream metadata persistence sees an already-resolved S3
+        URL and skips a redundant re-upload. Anchor: FR-004a.
         """
         resolved_header_url = self._resolve_header_image_url(dto.template_header)
         sample_body = build_meta_sample_body(
@@ -325,11 +254,8 @@ class ValidateTemplateSampleUseCase:
     ) -> Dict[str, Any]:
         """Call Meta's ``message_samples`` endpoint and translate failures.
 
-        ``MetaService.submit_template_sample`` propagates exceptions
-        unmodified per FR-005c / Research Decision 5; this method is
-        the single point that catches them and raises the domain
-        ``MetaSampleUnavailableError`` so the view's exception-translation
-        block stays clean.
+        Single point that maps upstream exceptions to
+        ``MetaSampleUnavailableError``. Anchor: FR-005c / Decision 5.
         """
         try:
             return self.meta_service.submit_template_sample(waba_id, sample_body)
@@ -355,13 +281,11 @@ class ValidateTemplateSampleUseCase:
         return None
 
     def _extract_category(self, meta_response: Dict[str, Any]) -> str:
-        """Validate Meta's response carries a usable ``category`` field.
+        """Validate Meta returned a usable string ``category``.
 
-        Four invalid shapes collapse to ``MetaInvalidResponseError``
-        (FR-005b / FR-005c): ``success`` is explicitly ``false``; the
-        ``category`` key is missing; the ``category`` value is empty;
-        the value is non-string. The exception carries the raw Meta
-        body so the view surfaces it on the HTTP 502 response.
+        Four invalid shapes (false success, missing/empty/non-string
+        category) collapse to ``MetaInvalidResponseError``. Anchor:
+        FR-005b / FR-005c.
         """
         success = meta_response.get("success", True)
         category = meta_response.get("category")
@@ -387,16 +311,9 @@ class ValidateTemplateSampleUseCase:
         category: str,
         meta_response: Dict[str, Any],
     ) -> bool:
-        """Conditionally rewrite local state when Meta classifies as UTILITY.
+        """Rewrite local state only on Meta UTILITY classification.
 
-        On non-UTILITY (FR-005b / FR-006b) the local template is
-        untouched and ``update_skipped`` is emitted. On UTILITY
-        (FR-006 / FR-006a / FR-006d) the strategy's metadata helper
-        is composed with the APPROVED-version helper to perform the
-        four mandatory writes (data-model.md §9). Any exception in
-        the local-update half re-raises after emitting
-        ``local_update_failed_after_meta_approval`` at ERROR level
-        with ``exc_info=True`` (FR-006c / FR-008b).
+        Anchor: FR-006 / FR-006a / FR-006c / FR-006d / FR-008b.
         """
         if category != self._UTILITY_CATEGORY:
             self._emit_update_skipped(dto, template, category)
@@ -435,13 +352,7 @@ class ValidateTemplateSampleUseCase:
     def _strategy_payload(
         self, dto: ValidateTemplateSampleDTO
     ) -> Dict[str, Any]:
-        """Materialize the strategy's dict-style payload from the DTO.
-
-        The strategy interface predates the DTO (it is shared with the
-        legacy PATCH path) and expects a plain dict; this adapter keeps
-        the strategy layer unchanged and isolated from the new endpoint's
-        DTO shape.
-        """
+        """Materialize the legacy strategy's dict-style payload from the DTO."""
         return {
             "template_body": dto.template_body,
             "template_header": dto.template_header,
@@ -455,17 +366,10 @@ class ValidateTemplateSampleUseCase:
         }
 
     def _emit(self, event: EventName, level: int, **kv) -> None:
-        """Single emission point that knows the FR-008 log-line shape.
+        """Single emission point for the audit log-line shape.
 
-        Every audit-log entry for this endpoint MUST route through this
-        method — the ``[TemplateSampleValidation]`` tag, the
-        ``event_name: k=v ...`` shape, and the log-level discipline are
-        enforced structurally here so callers cannot drift from FR-008.
-
-        Customer-facing content (body, header, footer, button text) is
-        PII-redacted by callers BEFORE invocation per FR-008c — they
-        pass length / presence flags. Identifiers (UUIDs) are passed
-        verbatim per the same FR's carve-out.
+        Callers MUST pass length / presence flags for customer-facing
+        content (PII redaction). Anchor: FR-008 / FR-008c.
         """
         payload = " ".join(f"{key}={value}" for key, value in kv.items())
         message = f"{LOG_TAG} {event.value}: {payload}".replace("%", "%%")

--- a/retail/templates/views.py
+++ b/retail/templates/views.py
@@ -181,19 +181,10 @@ class TemplateViewSet(ViewSet):
 
     @action(detail=True, methods=["post"])
     def sample(self, request: Request, pk: UUID) -> Response:
-        """``POST /api/v3/templates/<uuid>/sample/`` — pre-validate against Meta.
+        """Thin DRF action for the sample-validation endpoint.
 
-        Thin DRF action wiring (Constitution Principle I): validate input
-        via ``ValidateTemplateSampleSerializer``, build the frozen DTO,
-        delegate to the use case, and translate any domain exception via
-        ``_sample_domain_error_to_response`` per FR-007 / FR-007b–e.
-
-        The serializer is instantiated with ``context={"request": request}``
-        so its FR-002b ``validate_project_uuid`` method can read the
-        ``Project-Uuid`` header for the cross-tenant isolation check
-        (SC-008). A mismatch surfaces as HTTP 400 with
-        ``error_code = "project_uuid_mismatch"`` and the audit-log
-        WARNING line emitted by ``_warn_project_uuid_mismatch``.
+        Anchor: FR-002b / FR-007 / SC-008 (see
+        ``specs/004-template-sample-validation/spec.md``).
         """
         request_serializer = ValidateTemplateSampleSerializer(
             data=request.data, context={"request": request}
@@ -217,15 +208,12 @@ class TemplateViewSet(ViewSet):
 
     @staticmethod
     def _sample_domain_error_to_response(exc: Exception) -> Response:
-        """Translate a sample-validation domain exception into its HTTP response.
+        """Translate a domain exception into its HTTP response.
 
-        ``_SAMPLE_DOMAIN_ERROR_HTTP_TRANSLATIONS`` is the single source of
-        truth for the four ``(status, detail, error_code)`` triples pinned
-        by ``contracts/sample-endpoint-request-response.md`` (FR-007 /
-        FR-007b–e). The ``meta_response`` field is forwarded verbatim when
-        the exception carries one — ``MetaInvalidResponseError`` always
-        sets it, ``MetaSampleUnavailableError`` sets it only when the
-        upstream provided a parseable error envelope (FR-007b).
+        ``_SAMPLE_DOMAIN_ERROR_HTTP_TRANSLATIONS`` is the single source
+        of truth for the four ``(status, detail, error_code)`` triples.
+        ``meta_response`` is forwarded verbatim when present. Anchor:
+        FR-007 / FR-007b.
         """
         http_status, detail, error_code = _SAMPLE_DOMAIN_ERROR_HTTP_TRANSLATIONS[
             type(exc)
@@ -255,14 +243,9 @@ class TemplateViewSet(ViewSet):
     def _warn_project_uuid_mismatch_if_present(
         self, request: Request, template_uuid: UUID, exc: ValidationError
     ) -> None:
-        """Emit the FR-008a ``project_uuid_mismatch`` audit-log line on mismatch.
+        """Emit a ``project_uuid_mismatch`` WARNING when applicable.
 
-        Inspects the DRF ``ValidationError`` for the serializer-layer
-        ``project_uuid_mismatch`` code and, when present, emits a WARNING
-        line with the BOTH project UUIDs so dashboards can drill down on
-        cross-tenant misuse attempts (SC-008). The DRF default 400
-        response is re-raised by the caller in any case — this method
-        only handles the audit-log side effect.
+        Anchor: FR-008a / SC-008.
         """
         if not self._validation_error_has_project_uuid_mismatch(exc):
             return

--- a/retail/webhooks/templates/tests/usecases/test_direct_send_category.py
+++ b/retail/webhooks/templates/tests/usecases/test_direct_send_category.py
@@ -217,19 +217,7 @@ class _VersionSaveSpy:
 
 
 class FlaggingPathTest(_UseCaseTestBase):
-    """FR-006 single-field flag rule (Clarifications session 2026-05-25 Q3).
-
-    ``template_correct_category != "UTILITY"`` is the only flag clause;
-    ``template_category`` is captured for audit visibility but never
-    participates in the rule. The single-field parametrization below
-    sweeps four representative ``(template_category,
-    template_correct_category)`` pairs that all share the same outcome
-    (flag fires with the single reason ``correct_category_not_utility``);
-    the inverted-category cell ``("UTILITY", "MARKETING")`` is the
-    diagnostic-only pin (C1) — ``template_category="UTILITY"`` does NOT
-    rescue the row from flagging when ``template_correct_category``
-    says otherwise.
-    """
+    """Single-field flag rule. Anchor: FR-006 / FR-006a."""
 
     FLAGGING_PAYLOADS = [
         ("MARKETING", "MARKETING"),
@@ -295,11 +283,7 @@ class FlaggingPathTest(_UseCaseTestBase):
                     )
 
     def test_correct_category_utility_skips_save_for_every_template_category(self):
-        """FR-006 no-fire (US1 AS3): when ``template_correct_category ==
-        "UTILITY"`` no flag fires regardless of ``template_category``.
-        The ``MARKETING/UTILITY`` cell is the AS3 pin — ``template_category``
-        carrying a non-UTILITY value does NOT trigger a flag because the
-        eligibility gate is the single field ``template_correct_category``."""
+        """``template_correct_category == "UTILITY"`` skips save. Anchor: FR-006."""
         for template_category in ("UTILITY", "MARKETING"):
             with self.subTest(template_category=template_category):
                 Version.objects.filter(pk=self.version.pk).update(status="APPROVED")
@@ -330,10 +314,7 @@ class FlaggingPathTest(_UseCaseTestBase):
                 )
 
     def test_lowercase_utility_in_correct_category_is_case_sensitive_and_flags(self):
-        """FR-006a (C4): the flag rule is strict string equality against
-        the literal ``"UTILITY"``. A lowercase ``"utility"`` is NOT equal
-        to ``"UTILITY"`` and therefore fires the flag branch with the
-        single reason ``correct_category_not_utility``."""
+        """Strict case-sensitive equality. Anchor: FR-006a."""
         with _VersionSaveSpy() as save_spy:
             dto = self._build_dto(
                 template_category="UTILITY",
@@ -560,10 +541,7 @@ class IdempotentReplayWithFlaggingPayloadTest(_AlreadyFlaggedTestBase):
 
 
 class AutoDemoteOnCorrectedCategoryTest(_AlreadyFlaggedTestBase):
-    """FR-006c / FR-007c clause (b) / FR-007d: when the Version is
-    already ``FLAGGED`` AND the FR-006 flagging condition is false
-    (the corrected-category signal — ``UTILITY/UTILITY``), the webhook
-    writes ``status="APPROVED"`` and emits ``auto_demoted``."""
+    """FLAGGED + UTILITY/UTILITY -> APPROVED. Anchor: FR-006c / FR-007d."""
 
     def test_corrected_category_payload_demotes_flagged_version_to_approved(self):
         with _VersionSaveSpy() as save_spy:
@@ -615,9 +593,7 @@ class AutoDemoteOnCorrectedCategoryTest(_AlreadyFlaggedTestBase):
 
 
 class AutoDemoteSettlesIntoNoActionRequiredTest(_AlreadyFlaggedTestBase):
-    """FR-008 last clause: after a corrected-category payload demotes a
-    ``FLAGGED`` Version to ``APPROVED``, re-firing the same payload
-    settles into ``no_action_required`` instead of writing again."""
+    """Re-fire after auto-demote settles in no_action_required. Anchor: FR-008."""
 
     def test_consecutive_corrected_category_calls_converge_to_no_action_required(self):
         dto = self._build_dto(
@@ -718,11 +694,7 @@ class ReplayWithChangedCorrectCategoryTest(_UseCaseTestBase):
 
 
 class NoMatchingIntegratedAgentTest(_UseCaseTestBase):
-    """FR-004b — when the lookup returns zero IntegratedAgents, the
-    response is HTTP 200 with zero counters and the audit log records
-    a single WARNING-level ``no_matching_integrated_agent`` line that
-    carries only the five payload values (no IA / Template / Version
-    identifiers because none were resolved)."""
+    """Zero IntegratedAgents -> 200 + WARNING log. Anchor: FR-004b."""
 
     def test_no_match_emits_warning_and_returns_zero_counters(self):
         unrelated_app_uuid = uuid4()
@@ -761,10 +733,7 @@ class NoMatchingIntegratedAgentTest(_UseCaseTestBase):
 
 
 class TemplateNotFoundTest(_UseCaseTestBase):
-    """FR-005 — when a matched IntegratedAgent has no Template with the
-    requested name, the use case emits a WARNING-level
-    ``template_not_found`` line, skips the write, and reports
-    ``"Template not found."``."""
+    """No matching Template -> WARNING + skip save. Anchor: FR-005."""
 
     def test_template_not_found_emits_warning_and_skips_save(self):
         unknown_template_name = "weni_unknown_template"
@@ -801,11 +770,7 @@ class TemplateNotFoundTest(_UseCaseTestBase):
 
 
 class TemplateHasNoCurrentVersionTest(_UseCaseTestBase):
-    """FR-005a — when a matched Template has ``current_version=None``
-    (an inconsistent local state — defensively guarded), the use case
-    emits a WARNING-level ``template_has_no_current_version`` line,
-    skips the write, and the response ``detail`` collapses to
-    ``"Template not found."`` per data-model §5.2 footnote *."""
+    """Null ``current_version`` -> WARNING + skip save. Anchor: FR-005a."""
 
     def test_null_current_version_emits_warning_and_skips_save(self):
         self.template.current_version = None
@@ -904,13 +869,7 @@ class CategoryDeterminationOscillatesBetweenFlagAndDemoteTest(_UseCaseTestBase):
 
 
 class HeterogeneousFanOutUnderCorrectedCategoryPayloadTest(_UseCaseTestBase):
-    """spec.md Edge Case "Heterogeneous-status fan-out under a
-    corrected-category payload": when the fan-out matches IntegratedAgents
-    whose Versions are in different starting states and the payload is a
-    corrected-category signal, each IA is processed independently — the
-    ``APPROVED`` row stays as ``no_action_required`` while the ``FLAGGED``
-    row is auto-demoted. ``templates_updated`` counts only the demote
-    write per FR-010's direction-agnostic counter rule."""
+    """Heterogeneous-status fan-out under corrected-category. Anchor: FR-010."""
 
     def setUp(self):
         super().setUp()

--- a/retail/webhooks/templates/tests/views/test_direct_send_category.py
+++ b/retail/webhooks/templates/tests/views/test_direct_send_category.py
@@ -190,13 +190,7 @@ class DirectSendCategoryWebhookViewTest(BaseTestMixin, APITestCase):
 
 @with_test_settings
 class DirectSendCategoryWebhookReplayTest(BaseTestMixin, APITestCase):
-    """Pins the bidirectional FR-008 idempotency contract via the HTTP
-    boundary: (a) firing the same flagging payload twice converges on
-    ``FLAGGED`` with exactly one underlying write and an
-    ``"Already flagged."`` response on the replay (SC-004);
-    (b) firing a corrected-category payload against an already
-    ``FLAGGED`` Version auto-demotes to ``APPROVED`` per FR-006c /
-    FR-007d."""
+    """Bidirectional idempotency via HTTP. Anchor: FR-008 / FR-006c / FR-007d."""
 
     URL_NAME = "direct-send-category-webhook"
     TEMPLATE_NAME = "weni_order_invoiced"
@@ -339,10 +333,7 @@ class DirectSendCategoryWebhookDispatchIntegrationTest(BaseTestMixin, TestCase):
 
 @with_test_settings
 class DirectSendCategoryWebhookFailClosedTest(BaseTestMixin, APITestCase):
-    """Pins FR-004b / FR-005 / FR-005a — the three negative scenarios
-    enumerated in ``quickstart.md`` §7. Every well-formed payload
-    returns HTTP 200 (so the upstream courier does not retry) and no
-    Version row is mutated when the lookup misses."""
+    """Negative scenarios fail closed with HTTP 200. Anchor: FR-004b / FR-005 / FR-005a."""
 
     URL_NAME = "direct-send-category-webhook"
     TEMPLATE_NAME = "weni_order_invoiced"

--- a/retail/webhooks/templates/usecases/direct_send_category.py
+++ b/retail/webhooks/templates/usecases/direct_send_category.py
@@ -15,9 +15,7 @@ LOG_TAG = "[DirectSendCategoryWebhook]"
 class DirectSendCategoryDTO:
     """Validated, immutable payload passed from the view to the use case.
 
-    Built by the view from the serializer's ``validated_data``;
-    consumed by ``DirectSendCategoryWebhookUseCase.execute(...)``.
-    Carries the five required fields pinned by FR-003.
+    Anchor: FR-003 (see ``specs/003-template-category-webhook/spec.md``).
     """
 
     project_uuid: UUID
@@ -29,11 +27,9 @@ class DirectSendCategoryDTO:
 
 @dataclass(frozen=True)
 class DirectSendCategoryResult:
-    """Use-case return value shaped for the HTTP 200 response body.
+    """HTTP 200 response body shape; counters must match audit ``completed`` line.
 
-    The view shapes the HTTP body as ``Response(result.to_dict(), 200)``.
-    The two counters MUST equal the same values emitted on the
-    FR-009c ``completed`` audit-log line (FR-010 last sentence).
+    Anchor: FR-009c / FR-010.
     """
 
     templates_updated: int
@@ -49,25 +45,18 @@ class DirectSendCategoryResult:
 
 
 class FlaggingReason(str, Enum):
-    """Closed enumeration for the ``reason=`` k=v on ``flagged`` audit-log lines.
+    """Closed enumeration for ``flagged`` audit lines.
 
-    Pinned by FR-006b / FR-009a (Clarifications session 2026-05-25 Q3 —
-    single-field eligibility model). Under the single-clause flag rule
-    (``template_correct_category != "UTILITY"``) there is only one
-    reason that can fire. Additive-only: future flag clauses MAY add
-    new reason values but MUST NOT rename or remove
-    ``correct_category_not_utility``.
+    Additive-only; existing values MUST NOT be renamed or removed.
+    Anchor: FR-006b / FR-009a (see
+    ``specs/003-template-category-webhook/spec.md``).
     """
 
     CORRECT_CATEGORY_NOT_UTILITY = "correct_category_not_utility"
 
 
 class EventName(str, Enum):
-    """Closed enumeration for the ``event_name`` discriminator immediately
-    after the ``[DirectSendCategoryWebhook]`` tag in every audit-log line.
-
-    Pinned by FR-009a. Additive-only.
-    """
+    """Closed audit-log ``event_name`` discriminator. Anchor: FR-009a (additive-only)."""
 
     RECEIVED = "received"
     FLAGGED = "flagged"
@@ -82,19 +71,13 @@ class EventName(str, Enum):
 
 
 class DirectSendCategoryWebhookUseCase:
-    """Handles incorrect-category notifications from Integrations.
+    """Handle incorrect-category notifications from Integrations.
 
-    Fans out across every IntegratedAgent linked to ``(project_uuid, app_uuid)``
-    and flips the matched Template's ``current_version.status`` to
-    ``"FLAGGED"`` when the FR-006 single-field flagging condition fires
-    (``template_correct_category != "UTILITY"``). The symmetric inverse
-    (``template_correct_category == "UTILITY"`` against an already-
-    ``FLAGGED`` Version) auto-demotes the Version back to ``"APPROVED"``
-    per FR-006c / FR-007d. ``template_category`` is captured verbatim
-    on every audit-log ``k=v`` payload for diagnostic visibility but
-    does NOT participate in the flag-or-demote decision. Framework-
-    agnostic: no rest_framework imports, no Response/Request handling,
-    no permission checks.
+    Fans out across every IntegratedAgent linked to ``(project_uuid,
+    app_uuid)``, flagging or auto-demoting the matched Template's
+    ``current_version.status``. Framework-agnostic. Anchor: FR-006 /
+    FR-006c / FR-007d (see
+    ``specs/003-template-category-webhook/spec.md``).
     """
 
     _UTILITY_CATEGORY = "UTILITY"
@@ -193,14 +176,10 @@ class DirectSendCategoryWebhookUseCase:
         )
 
     def _evaluate_flagging_condition(self, dto: DirectSendCategoryDTO) -> bool:
-        """FR-006 single-field flag rule (Clarifications session 2026-05-25 Q3).
+        """Single-field flag rule on ``template_correct_category``.
 
-        ``template_correct_category`` is the sole source of truth for
-        Direct-Send eligibility — Meta's content-determined "this
-        template should be UTILITY" determination. ``template_category``
-        is captured for audit visibility but never participates in the
-        rule. Strict string equality, case-sensitive, no normalization
-        (FR-006a).
+        Strict string equality, case-sensitive, no normalization.
+        Anchor: FR-006 / FR-006a.
         """
         return dto.template_correct_category != self._UTILITY_CATEGORY
 
@@ -223,17 +202,11 @@ class DirectSendCategoryWebhookUseCase:
         integrated_agent: IntegratedAgent,
         dto: DirectSendCategoryDTO,
     ) -> None:
-        """Write the corrected-category recovery transition.
+        """Write the corrected-category recovery (FLAGGED -> APPROVED).
 
-        FR-006c / FR-007c clause (b) / FR-007d: when the matched
-        Version is already ``"FLAGGED"`` AND the FR-006 flagging
-        condition is false (the corrected-category signal —
-        ``template_correct_category == "UTILITY"``, regardless of
-        ``template_category``), the webhook writes ``status =
-        "APPROVED"`` and emits ``auto_demoted``. The Template's
-        ``current_version`` pointer is NOT changed (FR-007a applies
-        symmetrically to the demote branch — only the status string
-        is updated).
+        Only ``Version.status`` is updated; the Template's
+        ``current_version`` pointer is unchanged. Anchor: FR-006c /
+        FR-007a / FR-007c / FR-007d.
         """
         previous_status = version.status
         version.status = self._APPROVED_STATUS
@@ -249,19 +222,11 @@ class DirectSendCategoryWebhookUseCase:
         return "Mixed outcomes."
 
     def _emit(self, event: EventName, level: int, **kv) -> None:
-        """Single emission point that knows the FR-009 log-line shape.
+        """Single emission point that knows the audit log-line shape.
 
-        Every audit-log entry for this webhook MUST route through this
-        method — the ``[DirectSendCategoryWebhook]`` tag, the
-        ``event_name: k=v ...`` shape, and the log-level discipline are
-        enforced structurally here so callers cannot drift from FR-009.
-
-        The fully-formatted message is built up front so the rendered log
-        line carries the FR-009 ``k=v`` pairs verbatim. The same payload
-        is also forwarded as a dict via the logging stdlib's ``args``
-        slot so operator dashboards (and FR-009e tests) can inspect the
-        structured payload via ``record.args.keys()`` without re-parsing
-        the rendered string.
+        Anchor: FR-009 / FR-009e — the dict is forwarded via the
+        logging stdlib's ``args`` slot so dashboards can inspect the
+        structured payload without re-parsing the rendered string.
         """
         payload = " ".join(f"{key}={value}" for key, value in kv.items())
         message = f"{LOG_TAG} {event.value}: {payload}".replace("%", "%%")

--- a/retail/webhooks/templates/views/direct_send_category.py
+++ b/retail/webhooks/templates/views/direct_send_category.py
@@ -13,14 +13,10 @@ from retail.webhooks.templates.usecases.direct_send_category import (
 
 
 class DirectSendCategoryWebhook(APIView):
-    """Inbound webhook called by Integrations when Meta-side
-    category-detection determines a Direct Send template's category is
-    wrong (FR-001 / FR-002).
+    """Inbound Integrations webhook for incorrect-category notifications.
 
-    The view is thin: payload validation lives in the serializer, every
-    business rule (lookup, fan-out, flagging, audit log) lives in the
-    use case, authorization is expressed exclusively via
-    ``permission_classes``.
+    Anchor: FR-001 / FR-002 (see
+    ``specs/003-template-category-webhook/spec.md``).
     """
 
     permission_classes = [CanCommunicateInternally]


### PR DESCRIPTION
## What
- Updated exception messages in `exceptions.py` for clarity and conciseness, including references to relevant specs.
- Simplified docstrings in `serializers.py` to enhance readability while retaining essential information about the Direct Send flag.
- Refined comments and docstrings in `assign.py`, `broadcast.py`, and other service files to clarify logic and maintain consistency with spec references.
- Removed redundant comments and improved the overall structure of the code for better maintainability.

## Why

Docstrings created by #487, #488, #489 were too verbose and containing information that would be enough being only in the spec and with a referece