### PR TITLE
refactor: Decouple crawl and Nexus upload from onboarding wizard

### DIFF
--- a/retail/projects/tasks.py
+++ b/retail/projects/tasks.py
@@ -8,7 +8,10 @@ from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_orchestrator import OnboardingOrchestrator
 from retail.projects.usecases.pre_crawl_channel import PreCrawlChannelUseCase
-from retail.projects.usecases.start_crawl import CrawlerStartError
+from retail.projects.usecases.save_background_failure import (
+    SaveBackgroundFailureUseCase,
+)
+from retail.projects.usecases.upload_nexus_contents import UploadNexusContentsUseCase
 from retail.services.vtex_io.service import VtexIOService
 
 logger = logging.getLogger(__name__)
@@ -45,12 +48,21 @@ def release_task_lock(task_name: str, vtex_account: str) -> None:
 
 def _run_setup_channel_and_start_crawl(task, vtex_account: str, crawl_url: str) -> None:
     """
-    Shared implementation for the pre-crawl pipeline.
+    Shared implementation for the pre-crawl + post-crawl pipeline.
 
     Both ``task_setup_channel_and_start_crawl`` (new name) and the
     legacy alias ``task_wait_and_start_crawl`` delegate here so the
     same retry/cleanup logic runs regardless of how the task was
     enqueued.
+
+    Pipeline order (single Celery task, sequential):
+      1. Wait until the project is linked (retries up to ~10 minutes).
+      2. Pre-crawl channel setup (WWC or WPP Cloud).
+      3. Kick off the crawl (fire-and-forget; soft-fails internally).
+      4. Run the post-crawl orchestrator inline (manager + payment +
+         agents -- no content upload). The wizard completes here; the
+         content upload happens in background later when the crawler
+         webhook arrives.
 
     Args:
         task: The bound Celery task instance (provides ``retry`` /
@@ -99,11 +111,9 @@ def _run_setup_channel_and_start_crawl(task, vtex_account: str, crawl_url: str) 
         mark_onboarding_failed(vtex_account, f"Channel creation failed: {exc}")
         raise
 
-    try:
-        InitiateCrawlUseCase().execute(onboarding.project, vtex_account, crawl_url)
-    except CrawlerStartError as e:
-        logger.error(f"Crawl start failed for vtex_account={vtex_account}: {e}")
-        raise
+    InitiateCrawlUseCase().execute(onboarding.project, vtex_account, crawl_url)
+
+    OnboardingOrchestrator().execute(vtex_account)
 
 
 @shared_task(
@@ -113,16 +123,19 @@ def _run_setup_channel_and_start_crawl(task, vtex_account: str, crawl_url: str) 
 )
 def task_setup_channel_and_start_crawl(self, vtex_account: str, crawl_url: str) -> None:
     """
-    Pre-crawl orchestration: wait for project link, create channel, start crawl.
+    Pre-crawl + post-crawl orchestration: wait for project link, create
+    channel, kick off the crawl, then run the post-crawl orchestrator
+    inline so the wizard completes without waiting for the crawl.
 
     The Facebook ``auth_code`` from Embedded Signup is short-lived, so the
     channel must be created (and the code exchanged on the
     integrations-engine side) before the long-running crawl can expire it.
 
-    Retries while the project is not linked. Once linked, runs the channel
-    use case (resolves wwc or wpp-cloud) and then starts the crawl. If
-    channel creation fails, the onboarding is marked failed and the crawl
-    is not started — the user must redo Embedded Signup.
+    Retries while the project is not linked. Once linked, runs the
+    channel use case (resolves wwc or wpp-cloud), kicks off the crawl
+    (background), and runs the orchestrator. If channel creation fails,
+    the onboarding is marked failed and the orchestrator is not invoked
+    -- the user must redo Embedded Signup.
     """
     return _run_setup_channel_and_start_crawl(self, vtex_account, crawl_url)
 
@@ -157,14 +170,56 @@ def task_activate_agentic_cx_script(vtex_account: str) -> None:
     logger.info(f"Agentic CX script activated for vtex_account={vtex_account}")
 
 
+UPLOAD_NEXUS_LOCK_NAME = "upload_nexus_contents"
+
+
+def _run_upload_nexus_contents(vtex_account: str, contents: list) -> None:
+    """
+    Shared implementation for the background Nexus content upload.
+
+    Both ``task_upload_nexus_contents`` (new canonical name) and the
+    deprecated alias ``task_configure_nexus`` delegate here so the same
+    soft-failure + lock-release semantics run regardless of which task
+    name was used to enqueue the job.
+
+    Soft-fails on any exception: the post-crawl orchestrator (manager +
+    payment + agents) has already run inline as part of
+    ``task_setup_channel_and_start_crawl`` and the wizard may already
+    be complete from the user's perspective -- so a failure here lands
+    in ``config["background_error"]`` and does NOT flip
+    ``onboarding.failed``.
+    """
+    try:
+        UploadNexusContentsUseCase().execute(vtex_account, contents)
+    except Exception as exc:
+        logger.exception(
+            f"Background nexus upload failed for vtex_account={vtex_account}"
+        )
+        SaveBackgroundFailureUseCase.execute(vtex_account, "nexus_upload", str(exc))
+    finally:
+        release_task_lock(UPLOAD_NEXUS_LOCK_NAME, vtex_account)
+
+
+@shared_task(name="task_upload_nexus_contents")
+def task_upload_nexus_contents(vtex_account: str, contents: list) -> None:
+    """
+    Background-only: uploads crawled contents to Nexus.
+
+    Dispatched by ``UpdateOnboardingProgressUseCase`` when the
+    ``crawl.completed`` webhook arrives.
+    """
+    return _run_upload_nexus_contents(vtex_account, contents)
+
+
 @shared_task(name="task_configure_nexus")
 def task_configure_nexus(vtex_account: str, contents: list) -> None:
     """
-    Thin wrapper that delegates post-crawl configuration to the orchestrator.
+    Deprecated alias for ``task_upload_nexus_contents``.
 
-    Ensures the task lock is released in all code paths.
+    Kept registered under the original Celery task name so any jobs
+    queued before the rename keep executing the new upload pipeline.
+    All new dispatches MUST use ``task_upload_nexus_contents`` directly;
+    this alias can be removed once no more in-flight ``task_configure_nexus``
+    messages exist in the broker.
     """
-    try:
-        OnboardingOrchestrator().execute(vtex_account, contents)
-    finally:
-        release_task_lock("configure_nexus", vtex_account)
+    return _run_upload_nexus_contents(vtex_account, contents)

--- a/retail/projects/tests/test_agent_builder_helpers.py
+++ b/retail/projects/tests/test_agent_builder_helpers.py
@@ -1,0 +1,95 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.agent_builder_helpers import (
+    ProjectNotLinkedError,
+    ensure_agent_manager_configured,
+    load_onboarding_with_linked_project,
+)
+from retail.projects.usecases.manager_defaults import MANAGER_DEFAULTS
+
+
+class TestLoadOnboardingWithLinkedProject(TestCase):
+    """Shared module-level helper used by both inline and background paths."""
+
+    def test_returns_onboarding_when_project_linked(self):
+        project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+        ProjectOnboarding.objects.create(vtex_account="mystore", project=project)
+
+        result = load_onboarding_with_linked_project("mystore")
+
+        self.assertEqual(result.project, project)
+
+    def test_raises_when_project_not_linked(self):
+        ProjectOnboarding.objects.create(vtex_account="noproject")
+
+        with self.assertRaises(ProjectNotLinkedError):
+            load_onboarding_with_linked_project("noproject")
+
+    def test_raises_does_not_exist_for_unknown_vtex_account(self):
+        with self.assertRaises(ProjectOnboarding.DoesNotExist):
+            load_onboarding_with_linked_project("unknown")
+
+
+class TestEnsureAgentManagerConfigured(TestCase):
+    """
+    Shared idempotent helper. The upload background path calls this
+    defensively in case the inline manager step has not yet completed.
+    """
+
+    def setUp(self):
+        self.project_uuid = str(uuid4())
+        self.mock_nexus_service = MagicMock()
+
+    def test_skips_configure_when_agent_already_exists(self):
+        self.mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": True}
+        }
+
+        ensure_agent_manager_configured(
+            self.project_uuid, "mystore", "pt-br", self.mock_nexus_service
+        )
+
+        self.mock_nexus_service.configure_agent_attributes.assert_not_called()
+
+    def test_configures_when_agent_missing(self):
+        self.mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": False}
+        }
+        self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
+
+        ensure_agent_manager_configured(
+            self.project_uuid, "mystore", "pt-br", self.mock_nexus_service
+        )
+
+        self.mock_nexus_service.configure_agent_attributes.assert_called_once()
+        payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
+        self.assertEqual(payload["agent"]["name"], "Mystore Manager")
+        self.assertEqual(payload["agent"]["goal"], MANAGER_DEFAULTS["pt"]["goal"])
+
+    def test_configures_when_check_returns_none(self):
+        self.mock_nexus_service.check_agent_builder_exists.return_value = None
+        self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
+
+        ensure_agent_manager_configured(
+            self.project_uuid, "mystore", "en-us", self.mock_nexus_service
+        )
+
+        self.mock_nexus_service.configure_agent_attributes.assert_called_once()
+
+    def test_logs_failure_when_configure_returns_none(self):
+        self.mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": False}
+        }
+        self.mock_nexus_service.configure_agent_attributes.return_value = None
+
+        ensure_agent_manager_configured(
+            self.project_uuid, "mystore", "pt-br", self.mock_nexus_service
+        )
+
+        self.mock_nexus_service.configure_agent_attributes.assert_called_once()

--- a/retail/projects/tests/test_configure_agent_builder.py
+++ b/retail/projects/tests/test_configure_agent_builder.py
@@ -1,24 +1,23 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 from django.test import TestCase
 
 from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.agent_builder_helpers import ProjectNotLinkedError
+from retail.projects.usecases.configure_agent_builder import (
+    ConfigureAgentBuilderUseCase,
+    MANAGER_DONE_PROGRESS,
+)
 from retail.projects.usecases.manager_defaults import (
     MANAGER_DEFAULTS,
     MANAGER_PERSONALITY,
 )
-from retail.projects.usecases.configure_agent_builder import (
-    ConfigureAgentBuilderUseCase,
-    FileProcessingError,
-    FileUploadError,
-    ProjectNotLinkedError,
-    MAX_UPLOAD_PROGRESS,
-    _sanitize_filename,
-)
 
 
 class TestConfigureAgentBuilderUseCase(TestCase):
+    """Inline path invoked by ``OnboardingOrchestrator``."""
+
     def setUp(self):
         self.project = Project.objects.create(
             name="Test Project",
@@ -29,226 +28,44 @@ class TestConfigureAgentBuilderUseCase(TestCase):
         self.onboarding = ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
-        )
-        self.mock_nexus_service = MagicMock()
-        self.usecase = ConfigureAgentBuilderUseCase(
-            nexus_client=MagicMock(),
-        )
-        self.usecase.nexus_service = self.mock_nexus_service
-
-    def test_raises_error_when_project_not_linked(self):
-        ProjectOnboarding.objects.create(
-            vtex_account="noproject",
-        )
-
-        with self.assertRaises(ProjectNotLinkedError):
-            self.usecase.execute("noproject", [])
-
-    def test_sets_progress_to_max_upload_when_contents_empty(self):
-        self.usecase.execute("mystore", [])
-
-        self.onboarding.refresh_from_db()
-        self.assertEqual(self.onboarding.progress, MAX_UPLOAD_PROGRESS)
-        self.mock_nexus_service.upload_content_base_file.assert_not_called()
-
-    @patch("retail.projects.usecases.configure_agent_builder.time.sleep")
-    def test_uploads_files_for_each_content(self, mock_sleep):
-        upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "success",
-        }
-
-        contents = [
-            {
-                "link": "https://www.mystore.com.br/",
-                "title": "Home Page",
-                "content": "Welcome to our store.",
-            },
-            {
-                "link": "https://www.mystore.com.br/about",
-                "title": "About Us",
-                "content": "We sell great products.",
-            },
-        ]
-
-        self.usecase.execute("mystore", contents)
-
-        self.assertEqual(self.mock_nexus_service.upload_content_base_file.call_count, 2)
-        self.assertEqual(
-            self.mock_nexus_service.get_content_base_file_status.call_count, 2
-        )
-
-    @patch("retail.projects.usecases.configure_agent_builder.time.sleep")
-    def test_file_contains_only_content(self, mock_sleep):
-        upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "success",
-        }
-
-        contents = [
-            {
-                "link": "https://example.com/page",
-                "title": "Test Page",
-                "content": "Some content here.",
-            }
-        ]
-
-        self.usecase.execute("mystore", contents)
-
-        call_args = self.mock_nexus_service.upload_content_base_file.call_args
-        _, file_tuple = call_args[1]["project_uuid"], call_args[1]["file"]
-        filename, file_bytes, content_type = file_tuple
-
-        text = file_bytes.decode("utf-8")
-        self.assertEqual(text, "Some content here.")
-        self.assertNotIn("Title:", text)
-        self.assertNotIn("Source:", text)
-
-    @patch("retail.projects.usecases.configure_agent_builder.time.sleep")
-    def test_progress_updates_proportionally(self, mock_sleep):
-        upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "success",
-        }
-
-        contents = [
-            {"link": "https://a.com", "title": "A", "content": "a"},
-            {"link": "https://b.com", "title": "B", "content": "b"},
-            {"link": "https://c.com", "title": "C", "content": "c"},
-            {"link": "https://d.com", "title": "D", "content": "d"},
-        ]
-
-        self.usecase.execute("mystore", contents)
-
-        self.onboarding.refresh_from_db()
-        self.assertEqual(self.onboarding.progress, MAX_UPLOAD_PROGRESS)
-
-    def test_stops_on_upload_failure(self):
-        self.mock_nexus_service.upload_content_base_file.side_effect = [
-            None,
-            {"uuid": str(uuid4()), "extension_file": "txt"},
-        ]
-
-        contents = [
-            {"link": "https://a.com", "title": "A", "content": "a"},
-            {"link": "https://b.com", "title": "B", "content": "b"},
-        ]
-
-        with self.assertRaises(FileUploadError):
-            self.usecase.execute("mystore", contents)
-
-        self.assertEqual(self.mock_nexus_service.upload_content_base_file.call_count, 1)
-
-    @patch("retail.projects.usecases.configure_agent_builder.time.sleep")
-    def test_passes_project_uuid_to_nexus(self, mock_sleep):
-        upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "success",
-        }
-
-        contents = [
-            {"link": "https://a.com", "title": "A", "content": "a"},
-        ]
-
-        self.usecase.execute("mystore", contents)
-
-        call_kwargs = self.mock_nexus_service.upload_content_base_file.call_args[1]
-        self.assertEqual(call_kwargs["project_uuid"], str(self.project.uuid))
-
-    @patch("retail.projects.usecases.configure_agent_builder.time.sleep")
-    def test_waits_for_processing_before_next_upload(self, mock_sleep):
-        """Ensures polling occurs between consecutive uploads."""
-        uuid_1, uuid_2 = str(uuid4()), str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.side_effect = [
-            {"uuid": uuid_1, "extension_file": "txt"},
-            {"uuid": uuid_2, "extension_file": "txt"},
-        ]
-        self.mock_nexus_service.get_content_base_file_status.side_effect = [
-            {"uuid": uuid_1, "status": "Processing"},
-            {"uuid": uuid_1, "status": "success"},
-            {"uuid": uuid_2, "status": "success"},
-        ]
-
-        contents = [
-            {"link": "https://a.com", "title": "A", "content": "a"},
-            {"link": "https://b.com", "title": "B", "content": "b"},
-        ]
-
-        self.usecase.execute("mystore", contents)
-
-        self.assertEqual(
-            self.mock_nexus_service.get_content_base_file_status.call_count, 3
-        )
-
-    @patch("retail.projects.usecases.configure_agent_builder.time.sleep")
-    def test_raises_on_processing_failure(self, mock_sleep):
-        upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "failed",
-        }
-
-        contents = [
-            {"link": "https://a.com", "title": "A", "content": "a"},
-        ]
-
-        with self.assertRaises(FileProcessingError):
-            self.usecase.execute("mystore", contents)
-
-
-class TestAgentConfiguration(TestCase):
-    """Tests for the check/configure agent manager flow."""
-
-    def setUp(self):
-        self.project = Project.objects.create(
-            name="Test Project",
-            uuid=uuid4(),
-            vtex_account="flowstore",
-            language="pt-br",
-        )
-        self.onboarding = ProjectOnboarding.objects.create(
-            vtex_account="flowstore",
-            project=self.project,
+            current_step="NEXUS_CONFIG",
+            progress=10,
         )
         self.mock_nexus_service = MagicMock()
         self.usecase = ConfigureAgentBuilderUseCase(nexus_client=MagicMock())
         self.usecase.nexus_service = self.mock_nexus_service
 
+    def test_raises_error_when_project_not_linked(self):
+        ProjectOnboarding.objects.create(vtex_account="noproject")
+
+        with self.assertRaises(ProjectNotLinkedError):
+            self.usecase.execute("noproject")
+
+    def test_bumps_progress_to_manager_done(self):
+        self.mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": False}
+        }
+        self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
+
+        self.usecase.execute("mystore")
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(self.onboarding.progress, MANAGER_DONE_PROGRESS)
+
     def test_skips_configure_when_agent_already_exists(self):
         self.mock_nexus_service.check_agent_builder_exists.return_value = {
-            "data": {"has_agent": True, "name": "Flowstore Manager"}
+            "data": {"has_agent": True, "name": "Mystore Manager"}
         }
 
-        self.usecase.execute("flowstore", [])
+        self.usecase.execute("mystore")
 
         self.mock_nexus_service.check_agent_builder_exists.assert_called_once_with(
             str(self.project.uuid)
         )
         self.mock_nexus_service.configure_agent_attributes.assert_not_called()
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(self.onboarding.progress, MANAGER_DONE_PROGRESS)
 
     def test_configures_agent_when_not_exists(self):
         self.mock_nexus_service.check_agent_builder_exists.return_value = {
@@ -256,11 +73,11 @@ class TestAgentConfiguration(TestCase):
         }
         self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
 
-        self.usecase.execute("flowstore", [])
+        self.usecase.execute("mystore")
 
         self.mock_nexus_service.configure_agent_attributes.assert_called_once()
         payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
-        self.assertEqual(payload["agent"]["name"], "Flowstore Manager")
+        self.assertEqual(payload["agent"]["name"], "Mystore Manager")
         self.assertEqual(payload["agent"]["personality"], MANAGER_PERSONALITY)
         self.assertEqual(payload["agent"]["role"], MANAGER_DEFAULTS["pt"]["role"])
         self.assertEqual(payload["agent"]["goal"], MANAGER_DEFAULTS["pt"]["goal"])
@@ -275,7 +92,7 @@ class TestAgentConfiguration(TestCase):
         }
         self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
 
-        self.usecase.execute("flowstore", [])
+        self.usecase.execute("mystore")
 
         payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
         self.assertEqual(payload["agent"]["role"], MANAGER_DEFAULTS["en"]["role"])
@@ -290,7 +107,7 @@ class TestAgentConfiguration(TestCase):
         }
         self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
 
-        self.usecase.execute("flowstore", [])
+        self.usecase.execute("mystore")
 
         payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
         self.assertEqual(payload["agent"]["role"], MANAGER_DEFAULTS["es"]["role"])
@@ -300,7 +117,7 @@ class TestAgentConfiguration(TestCase):
         self.mock_nexus_service.check_agent_builder_exists.return_value = None
         self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
 
-        self.usecase.execute("flowstore", [])
+        self.usecase.execute("mystore")
 
         self.mock_nexus_service.configure_agent_attributes.assert_called_once()
 
@@ -313,67 +130,17 @@ class TestAgentConfiguration(TestCase):
         }
         self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
 
-        self.usecase.execute("flowstore", [])
+        self.usecase.execute("mystore")
 
         payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
         self.assertEqual(payload["agent"]["role"], MANAGER_DEFAULTS["en"]["role"])
 
+    def test_does_not_upload_files(self):
+        """Inline path must never touch the Nexus upload endpoint."""
+        self.mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": True}
+        }
 
-class TestBuildFilesFromContents(TestCase):
-    def test_builds_files_with_correct_structure(self):
-        contents = [
-            {
-                "link": "https://example.com/page",
-                "title": "Test Page",
-                "content": "Some content here.",
-            }
-        ]
+        self.usecase.execute("mystore")
 
-        files = ConfigureAgentBuilderUseCase._build_files_from_contents(contents)
-
-        self.assertEqual(len(files), 1)
-        filename, file_bytes, content_type = files[0]
-        self.assertEqual(filename, "000_test-page.txt")
-        self.assertEqual(file_bytes, b"Some content here.")
-        self.assertEqual(content_type, "text/plain")
-
-    def test_uses_fallback_title_when_missing(self):
-        contents = [{"link": "https://a.com", "content": "content"}]
-        files = ConfigureAgentBuilderUseCase._build_files_from_contents(contents)
-        filename = files[0][0]
-        self.assertIn("page-0", filename)
-
-    def test_handles_empty_content(self):
-        contents = [{"link": "https://a.com", "title": "Page"}]
-        files = ConfigureAgentBuilderUseCase._build_files_from_contents(contents)
-        self.assertEqual(files[0][1], b"")
-
-
-class TestSanitizeFilename(TestCase):
-    def test_basic_title(self):
-        self.assertEqual(_sanitize_filename("About Us", 0), "000_about-us.txt")
-
-    def test_special_characters(self):
-        result = _sanitize_filename("C&A | Fornecedores!", 1)
-        self.assertEqual(result, "001_ca-fornecedores.txt")
-
-    def test_url_as_title(self):
-        result = _sanitize_filename("https://www.cea.com.br/", 0)
-        self.assertEqual(result, "000_httpswwwceacombr.txt")
-
-    def test_empty_title(self):
-        result = _sanitize_filename("", 5)
-        self.assertEqual(result, "005_page.txt")
-
-    def test_long_title_truncated(self):
-        long_title = "A" * 200
-        result = _sanitize_filename(long_title, 0)
-        self.assertTrue(len(result) <= 89)
-
-    def test_whitespace_collapsed(self):
-        result = _sanitize_filename("Hello   World   Page", 2)
-        self.assertEqual(result, "002_hello-world-page.txt")
-
-    def test_strips_accents(self):
-        result = _sanitize_filename("Promoção Ação Café", 0)
-        self.assertEqual(result, "000_promocao-acao-cafe.txt")
+        self.mock_nexus_service.upload_content_base_file.assert_not_called()

--- a/retail/projects/tests/test_initiate_crawl.py
+++ b/retail/projects/tests/test_initiate_crawl.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
-from retail.projects.usecases.start_crawl import CrawlerStartError
 
 
 class TestInitiateCrawlUseCase(TestCase):
@@ -63,12 +62,16 @@ class TestInitiateCrawlUseCase(TestCase):
         self.mock_start_crawl.execute.assert_called_once()
         self.mock_detect_storefront.execute.assert_called_once()
 
-    def test_storefront_detection_skipped_when_crawl_fails(self):
-        self.mock_start_crawl.execute.side_effect = CrawlerStartError(
-            "crawler down"
-        )
+    def test_storefront_detection_skipped_when_start_crawl_raises(self):
+        """
+        ``StartCrawlUseCase`` soft-fails on crawler-comms errors (does NOT
+        raise), but it can still raise on unexpected errors (e.g. DB
+        lookup failures). When it does raise, storefront detection must
+        be skipped so the failure surface stays narrow.
+        """
+        self.mock_start_crawl.execute.side_effect = RuntimeError("unexpected boom")
 
-        with self.assertRaises(CrawlerStartError):
+        with self.assertRaises(RuntimeError):
             self.usecase.execute(
                 self.project, "mystore", "https://www.mystore.com.br/"
             )

--- a/retail/projects/tests/test_onboarding_full_flow.py
+++ b/retail/projects/tests/test_onboarding_full_flow.py
@@ -13,6 +13,7 @@ from django.test import TestCase
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.configure_agent_builder import (
     ConfigureAgentBuilderUseCase,
+    MANAGER_DONE_PROGRESS,
 )
 from retail.projects.usecases.configure_wwc import (
     PROJECT_CONFIG_AFTER_PERSIST,
@@ -27,25 +28,39 @@ from retail.projects.usecases.onboarding_dto import (
     CrawlerWebhookDTO,
     StartSetupDTO,
 )
-from retail.projects.usecases.start_crawl import StartCrawlUseCase
+from retail.projects.usecases.onboarding_orchestrator import OnboardingOrchestrator
+from retail.projects.usecases.start_crawl import (
+    CRAWL_KICKOFF_PROGRESS,
+    StartCrawlUseCase,
+)
 from retail.projects.usecases.start_setup import StartSetupUseCase
 from retail.projects.usecases.update_onboarding_progress import (
     UpdateOnboardingProgressUseCase,
+)
+from retail.projects.usecases.upload_nexus_contents import (
+    UploadNexusContentsUseCase,
 )
 
 
 class TestFullOnboardingFlow(TestCase):
     """
-    Simulates the full onboarding flow end-to-end (post pre-crawl refactor):
+    Simulates the full onboarding flow end-to-end (post background-crawl
+    refactor):
 
-    1. Front-end calls start-setup (project not linked yet) -> PROJECT_CONFIG 0%
-    2. EDA links the project                                -> PROJECT_CONFIG 30%
-    3. Pre-crawl channel setup runs                         -> PROJECT_CONFIG 100%
-    4. Crawl starts                                         -> CRAWL 10%
-    5. Crawler sends progress events
-    6. Crawler sends crawl.completed                        -> CRAWL 100%
-    7. NEXUS_CONFIG: agent builder + content upload         -> 10% -> 75%
-    8. NEXUS_CONFIG: agent integration                      -> 100%
+    Main (inline) path -- single Celery task:
+      1. Front-end calls start-setup (project not linked yet) -> PROJECT_CONFIG 0%
+      2. EDA links the project                                -> PROJECT_CONFIG 30%
+      3. Pre-crawl channel setup runs                         -> PROJECT_CONFIG 100%
+      4. Crawl kicked off (fire-and-forget)                   -> CRAWL 100%
+      5. Orchestrator: agent manager configured               -> NEXUS_CONFIG 10 -> 75
+      6. Orchestrator: agent integration                      -> NEXUS_CONFIG 100
+
+    Background path (decoupled from the wizard):
+      7. Crawler sends progress events                        -> NO main progress change
+      8. Crawler sends crawl.completed                        -> crawler_result=SUCCESS,
+                                                                 task_upload_nexus_contents
+                                                                 dispatched
+      9. task_upload_nexus_contents uploads contents to Nexus -> NO main progress change
     """
 
     def setUp(self):
@@ -107,7 +122,7 @@ class TestFullOnboardingFlow(TestCase):
             self.channel_app_uuid,
         )
 
-        # -- Step 4: Pre-crawl task transitions into CRAWL --
+        # -- Step 4: Crawl kicked off (background, CRAWL 100%) --
         mock_crawler_service = MagicMock()
         mock_crawler_service.start_crawling.return_value = {"status": "started"}
 
@@ -117,9 +132,48 @@ class TestFullOnboardingFlow(TestCase):
 
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.current_step, "CRAWL")
-        self.assertEqual(onboarding.progress, 10)
+        self.assertEqual(onboarding.progress, CRAWL_KICKOFF_PROGRESS)
 
-        # -- Step 5: Crawler sends progress update --
+        # -- Steps 5 + 6: Inline orchestrator runs the post-crawl steps --
+        mock_nexus_service = MagicMock()
+        mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": False}
+        }
+        mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
+
+        mock_nexus_service_agents = MagicMock()
+        mock_nexus_service_agents.integrate_agent.return_value = {"ok": True}
+
+        with patch(
+            "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
+        ) as mock_agent_cls, patch(
+            "retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase"
+        ) as mock_integrate_cls:
+            agent_usecase = ConfigureAgentBuilderUseCase(nexus_client=MagicMock())
+            agent_usecase.nexus_service = mock_nexus_service
+            mock_agent_cls.return_value = agent_usecase
+
+            integrate_usecase = IntegrateAgentsUseCase(nexus_client=MagicMock())
+            integrate_usecase.nexus_service = mock_nexus_service_agents
+            mock_integrate_cls.return_value = integrate_usecase
+
+            with patch(
+                "retail.projects.usecases.integrate_agents.get_channel_agents",
+                return_value=[],
+            ):
+                OnboardingOrchestrator().execute(self.vtex_account)
+
+        onboarding.refresh_from_db()
+        self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
+        self.assertEqual(onboarding.progress, 100)
+        mock_nexus_service.configure_agent_attributes.assert_called_once()
+        mock_nexus_service.upload_content_base_file.assert_not_called()
+
+        # The wizard is effectively done here; main onboarding is complete
+        # from the user's perspective. The background phase below MUST
+        # NOT regress current_step or progress.
+
+        # -- Step 7: Crawler sends progress (background, ignored by main) --
         progress_dto = CrawlerWebhookDTO(
             task_id="task-1",
             event="crawl.subpage.progress",
@@ -130,9 +184,10 @@ class TestFullOnboardingFlow(TestCase):
         result = UpdateOnboardingProgressUseCase().execute(
             str(onboarding.uuid), progress_dto
         )
-        self.assertEqual(result.progress, 50)
+        self.assertEqual(result.current_step, "NEXUS_CONFIG")
+        self.assertEqual(result.progress, 100)
 
-        # -- Step 6: Crawler sends crawl.completed --
+        # -- Step 8: Crawler sends crawl.completed (background) --
         crawled_contents = [
             {
                 "link": "https://www.flowstore.com.br/",
@@ -150,7 +205,7 @@ class TestFullOnboardingFlow(TestCase):
             "retail.projects.usecases.update_onboarding_progress.acquire_task_lock",
             return_value=True,
         ), patch(
-            "retail.projects.usecases.update_onboarding_progress.task_configure_nexus"
+            "retail.projects.usecases.update_onboarding_progress.task_upload_nexus_contents"
         ) as mock_nexus_task:
             completed_dto = CrawlerWebhookDTO(
                 task_id="task-1",
@@ -164,52 +219,40 @@ class TestFullOnboardingFlow(TestCase):
                 str(onboarding.uuid), completed_dto
             )
 
+        self.assertEqual(result.current_step, "NEXUS_CONFIG")
         self.assertEqual(result.progress, 100)
         self.assertEqual(result.crawler_result, ProjectOnboarding.SUCCESS)
         mock_nexus_task.delay.assert_called_once_with(
             self.vtex_account, crawled_contents
         )
 
-        # -- Step 7: Nexus agent config + content upload (10-75%) --
-        # The orchestrator marks NEXUS_CONFIG / 10 before agent builder runs.
-        onboarding.refresh_from_db()
-        onboarding.current_step = "NEXUS_CONFIG"
-        onboarding.progress = 10
-        onboarding.save(update_fields=["current_step", "progress"])
-
-        mock_nexus_service = MagicMock()
-        mock_nexus_service.check_agent_builder_exists.return_value = {
-            "data": {"has_agent": False}
+        # -- Step 9: Background upload runs -- NO main progress change --
+        background_nexus = MagicMock()
+        background_nexus.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": True}
         }
-        mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
-        mock_nexus_service.upload_content_base_file.return_value = {"status": "ok"}
+        background_nexus.upload_content_base_file.return_value = {
+            "uuid": str(uuid4()),
+            "extension_file": "txt",
+        }
+        background_nexus.get_content_base_file_status.return_value = {
+            "status": "success",
+        }
 
-        agent_usecase = ConfigureAgentBuilderUseCase(nexus_client=MagicMock())
-        agent_usecase.nexus_service = mock_nexus_service
-        agent_usecase.execute(self.vtex_account, crawled_contents)
+        background_usecase = UploadNexusContentsUseCase(nexus_client=MagicMock())
+        background_usecase.nexus_service = background_nexus
+
+        with patch("retail.projects.usecases.upload_nexus_contents.time.sleep"):
+            background_usecase.execute(self.vtex_account, crawled_contents)
 
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
-        self.assertEqual(onboarding.progress, 75)
-        self.assertEqual(mock_nexus_service.upload_content_base_file.call_count, 2)
-        mock_nexus_service.configure_agent_attributes.assert_called_once()
-
-        # -- Step 8: Agent integration (75-100%) --
-        mock_nexus_service_agents = MagicMock()
-        mock_nexus_service_agents.integrate_agent.return_value = {"ok": True}
-
-        integrate_usecase = IntegrateAgentsUseCase(nexus_client=MagicMock())
-        integrate_usecase.nexus_service = mock_nexus_service_agents
-
-        with patch(
-            "retail.projects.usecases.integrate_agents.get_channel_agents",
-            return_value=[],
-        ):
-            integrate_usecase.execute(self.vtex_account)
-
-        onboarding.refresh_from_db()
         self.assertEqual(onboarding.progress, 100)
+        self.assertEqual(background_nexus.upload_content_base_file.call_count, 2)
 
         # -- Final state check --
         self.assertFalse(onboarding.completed)
+        self.assertFalse(onboarding.failed)
         self.assertEqual(onboarding.crawler_result, ProjectOnboarding.SUCCESS)
+        # Sanity: the manager-done milestone fires inside the orchestrator
+        self.assertGreaterEqual(MANAGER_DONE_PROGRESS, 1)

--- a/retail/projects/tests/test_onboarding_orchestrator.py
+++ b/retail/projects/tests/test_onboarding_orchestrator.py
@@ -22,7 +22,6 @@ class TestOnboardingOrchestrator(TestCase):
             project=self.project,
             current_step="CRAWL",
             progress=100,
-            crawler_result=ProjectOnboarding.SUCCESS,
             config={
                 "channels": {
                     "wwc": {
@@ -44,10 +43,9 @@ class TestOnboardingOrchestrator(TestCase):
         mock_integrate = MagicMock()
         mock_integrate_cls.return_value = mock_integrate
 
-        contents = [{"link": "a", "title": "b", "content": "c"}]
-        OnboardingOrchestrator().execute("mystore", contents)
+        OnboardingOrchestrator().execute("mystore")
 
-        mock_agent_builder.execute.assert_called_once_with("mystore", contents)
+        mock_agent_builder.execute.assert_called_once_with("mystore")
         mock_integrate.execute.assert_called_once_with("mystore")
 
     @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
@@ -60,7 +58,7 @@ class TestOnboardingOrchestrator(TestCase):
         """The orchestrator must mark NEXUS_CONFIG so the UI advances."""
         progress_at_agent_time = {}
 
-        def capture(vtex_account, _contents):
+        def capture(vtex_account):
             onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
             progress_at_agent_time["step"] = onboarding.current_step
             progress_at_agent_time["progress"] = onboarding.progress
@@ -69,7 +67,7 @@ class TestOnboardingOrchestrator(TestCase):
         mock_agent_builder.execute.side_effect = capture
         mock_agent_builder_cls.return_value = mock_agent_builder
 
-        OnboardingOrchestrator().execute("mystore", [])
+        OnboardingOrchestrator().execute("mystore")
 
         self.assertEqual(progress_at_agent_time["step"], "NEXUS_CONFIG")
         self.assertEqual(
@@ -95,7 +93,7 @@ class TestOnboardingOrchestrator(TestCase):
         mock_integrate_cls.return_value = mock_integrate
 
         with self.assertRaises(RuntimeError):
-            OnboardingOrchestrator().execute("mystore", [])
+            OnboardingOrchestrator().execute("mystore")
 
         mock_mark_failed.assert_called_once()
         mock_integrate.execute.assert_not_called()
@@ -119,7 +117,7 @@ class TestOnboardingOrchestrator(TestCase):
         mock_integrate_cls.return_value = mock_integrate
 
         with self.assertRaises(RuntimeError):
-            OnboardingOrchestrator().execute("mystore", [])
+            OnboardingOrchestrator().execute("mystore")
 
         mock_mark_failed.assert_called_once()
 
@@ -135,6 +133,20 @@ class TestOnboardingOrchestrator(TestCase):
         source = inspect.getsource(onboarding_orchestrator)
         self.assertNotIn("ConfigureWPPCloudUseCase", source)
         self.assertNotIn("ConfigureWWCUseCase", source)
+
+    def test_does_not_invoke_upload_use_case(self):
+        """
+        Content upload now lives in ``UploadNexusContentsUseCase`` and
+        runs in background via ``task_upload_nexus_contents``. The inline
+        orchestrator must not reference the upload use case at all.
+        """
+        import inspect
+
+        from retail.projects.usecases import onboarding_orchestrator
+
+        source = inspect.getsource(onboarding_orchestrator)
+        self.assertNotIn("UploadNexusContentsUseCase", source)
+        self.assertNotIn("upload_contents", source)
 
 
 class TestOnboardingOrchestratorPaymentRouting(TestCase):
@@ -175,7 +187,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
     def test_runs_payment_step_for_wpp_cloud(self):
         self._make_onboarding("wpp-cloud")
 
-        OnboardingOrchestrator().execute("mystore", contents=[])
+        OnboardingOrchestrator().execute("mystore")
 
         self.mock_payment_cls.assert_called_once_with()
         self.mock_payment_cls.return_value.execute.assert_called_once_with("mystore")
@@ -183,7 +195,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
     def test_skips_payment_step_for_wwc(self):
         self._make_onboarding("wwc")
 
-        OnboardingOrchestrator().execute("mystore", contents=[])
+        OnboardingOrchestrator().execute("mystore")
 
         self.mock_payment_cls.assert_not_called()
 
@@ -199,7 +211,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
             lambda *_: call_order.append("integrate")
         )
 
-        OnboardingOrchestrator().execute("mystore", contents=[])
+        OnboardingOrchestrator().execute("mystore")
 
         self.assertEqual(call_order, ["ocp", "integrate"])
 
@@ -210,7 +222,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
         with patch(
             "retail.projects.usecases.onboarding_orchestrator.mark_onboarding_failed"
         ) as mock_mark_failed, self.assertRaises(RuntimeError):
-            OnboardingOrchestrator().execute("mystore", contents=[])
+            OnboardingOrchestrator().execute("mystore")
 
         mock_mark_failed.assert_called_once_with("mystore", "boom")
 
@@ -224,6 +236,6 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
         with patch(
             "retail.projects.usecases.onboarding_orchestrator.mark_onboarding_failed"
         ), self.assertRaises(ValueError) as ctx:
-            OnboardingOrchestrator().execute("mystore", contents=[])
+            OnboardingOrchestrator().execute("mystore")
 
         self.assertIn("No channel configured", str(ctx.exception))

--- a/retail/projects/tests/test_save_background_failure.py
+++ b/retail/projects/tests/test_save_background_failure.py
@@ -10,11 +10,12 @@ from retail.projects.usecases.save_background_failure import (
 
 class TestSaveBackgroundFailureUseCase(TestCase):
     def setUp(self):
-        self.onboarding = ProjectOnboarding.objects.create(
-            vtex_account="mystore",
-            completed=True,
-            config={"channels": {"wwc": {}}},
-        )
+        with patch("retail.projects.tasks.task_activate_agentic_cx_script"):
+            self.onboarding = ProjectOnboarding.objects.create(
+                vtex_account="mystore",
+                completed=True,
+                config={"channels": {"wwc": {}}},
+            )
 
     def test_writes_background_error_snapshot(self):
         SaveBackgroundFailureUseCase.execute(

--- a/retail/projects/tests/test_save_background_failure.py
+++ b/retail/projects/tests/test_save_background_failure.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.save_background_failure import (
+    SaveBackgroundFailureUseCase,
+)
+
+
+class TestSaveBackgroundFailureUseCase(TestCase):
+    def setUp(self):
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            completed=True,
+            config={"channels": {"wwc": {}}},
+        )
+
+    def test_writes_background_error_snapshot(self):
+        SaveBackgroundFailureUseCase.execute(
+            "mystore", "nexus_upload", "Nexus returned 500"
+        )
+
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["background_error"]
+        self.assertEqual(snapshot["stage"], "nexus_upload")
+        self.assertEqual(snapshot["error"], "Nexus returned 500")
+        self.assertIn("timestamp", snapshot)
+
+    def test_preserves_existing_config_keys(self):
+        SaveBackgroundFailureUseCase.execute("mystore", "crawl", "timeout")
+
+        self.onboarding.refresh_from_db()
+        self.assertIn("background_error", self.onboarding.config)
+        self.assertIn("channels", self.onboarding.config)
+
+    def test_overwrites_previous_background_error(self):
+        SaveBackgroundFailureUseCase.execute("mystore", "crawl", "first")
+        SaveBackgroundFailureUseCase.execute("mystore", "nexus_upload", "second")
+
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["background_error"]
+        self.assertEqual(snapshot["stage"], "nexus_upload")
+        self.assertEqual(snapshot["error"], "second")
+
+    def test_does_not_flip_onboarding_failed(self):
+        SaveBackgroundFailureUseCase.execute("mystore", "crawl", "timeout")
+
+        self.onboarding.refresh_from_db()
+        self.assertFalse(self.onboarding.failed)
+        self.assertTrue(self.onboarding.completed)
+
+    def test_swallows_when_onboarding_does_not_exist(self):
+        SaveBackgroundFailureUseCase.execute("unknown-store", "crawl", "timeout")
+
+    @patch("retail.projects.usecases.save_background_failure.ProjectOnboarding")
+    def test_swallows_unexpected_exception(self, mock_model):
+        mock_model.objects.get.side_effect = RuntimeError("db down")
+
+        SaveBackgroundFailureUseCase.execute("mystore", "crawl", "timeout")

--- a/retail/projects/tests/test_start_crawl.py
+++ b/retail/projects/tests/test_start_crawl.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.test import TestCase, override_settings
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.manager_defaults import MANAGER_DEFAULTS
 from retail.projects.usecases.start_crawl import (
-    CrawlerStartError,
+    CRAWL_KICKOFF_PROGRESS,
     StartCrawlUseCase,
 )
 
@@ -28,14 +28,21 @@ class TestStartCrawlUseCase(TestCase):
         self.usecase = StartCrawlUseCase(crawler_client=MagicMock())
         self.usecase.crawler_service = self.mock_crawler_service
 
-    def test_sets_step_to_crawl_and_initial_progress(self):
+    def test_sets_step_to_crawl_with_kickoff_progress(self):
+        """
+        Bumps progress to 100 to signal "crawl phase done from the
+        wizard's perspective" -- the actual long-running crawl runs in
+        background and its outcome lands in ``crawler_result``, NOT in
+        ``progress``.
+        """
         self.mock_crawler_service.start_crawling.return_value = {"status": "started"}
 
         self.usecase.execute("mystore", "https://www.mystore.com.br/")
 
         self.onboarding.refresh_from_db()
         self.assertEqual(self.onboarding.current_step, "CRAWL")
-        self.assertEqual(self.onboarding.progress, 10)
+        self.assertEqual(self.onboarding.progress, CRAWL_KICKOFF_PROGRESS)
+        self.assertEqual(self.onboarding.progress, 100)
 
     def test_calls_crawler_service_with_correct_args(self):
         self.mock_crawler_service.start_crawling.return_value = {"status": "started"}
@@ -48,14 +55,28 @@ class TestStartCrawlUseCase(TestCase):
         self.assertIn(str(self.onboarding.uuid), args[0][1])  # webhook_url
         self.assertEqual(args[0][2]["account_name"], "mystore")
 
-    def test_raises_error_when_crawler_fails(self):
+    @patch(
+        "retail.projects.usecases.start_crawl.SaveBackgroundFailureUseCase"
+    )
+    def test_soft_fails_when_crawler_unreachable(self, mock_save_background_cls):
+        """
+        On crawler-comms failure the use case must NOT raise (so the
+        inline post-crawl orchestrator can still complete the wizard)
+        but must record a soft failure under
+        ``config["background_error"]`` and set ``crawler_result=FAIL``.
+        """
         self.mock_crawler_service.start_crawling.return_value = None
 
-        with self.assertRaises(CrawlerStartError):
-            self.usecase.execute("mystore", "https://www.mystore.com.br/")
+        self.usecase.execute("mystore", "https://www.mystore.com.br/")
 
         self.onboarding.refresh_from_db()
         self.assertEqual(self.onboarding.crawler_result, ProjectOnboarding.FAIL)
+        self.assertFalse(self.onboarding.failed)
+
+        mock_save_background_cls.execute.assert_called_once()
+        called_args = mock_save_background_cls.execute.call_args[0]
+        self.assertEqual(called_args[0], "mystore")
+        self.assertEqual(called_args[1], "crawler_start")
 
     def test_build_webhook_url(self):
         onboarding_uuid = str(uuid4())

--- a/retail/projects/tests/test_start_onboarding.py
+++ b/retail/projects/tests/test_start_onboarding.py
@@ -66,6 +66,10 @@ class TestStartSetupUseCase(TestCase):
             config={
                 "last_failure": {"stage": "start_setup_validation"},
                 "reason_failed": "previous error",
+                "background_error": {
+                    "stage": "nexus_upload",
+                    "error": "previous background error",
+                },
             },
         )
 
@@ -79,6 +83,7 @@ class TestStartSetupUseCase(TestCase):
         self.assertFalse(onboarding.completed)
         self.assertNotIn("last_failure", onboarding.config)
         self.assertNotIn("reason_failed", onboarding.config)
+        self.assertNotIn("background_error", onboarding.config)
 
     @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
     def test_reset_clears_previous_channel_app_uuid(self, _mock_task):

--- a/retail/projects/tests/test_tasks.py
+++ b/retail/projects/tests/test_tasks.py
@@ -53,10 +53,11 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
             name="Test", uuid=uuid4(), vtex_account="mystore"
         )
 
+    @patch("retail.projects.tasks.OnboardingOrchestrator")
     @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
-    def test_runs_channel_then_crawl_when_project_linked(
-        self, mock_channel_cls, mock_initiate_cls
+    def test_runs_channel_crawl_and_orchestrator_when_project_linked(
+        self, mock_channel_cls, mock_initiate_cls, mock_orch_cls
     ):
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
@@ -68,6 +69,13 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         mock_channel_cls.return_value = mock_channel
         mock_initiate = MagicMock()
         mock_initiate_cls.return_value = mock_initiate
+        mock_orch = MagicMock()
+        mock_orch_cls.return_value = mock_orch
+
+        call_order = []
+        mock_channel.execute.side_effect = lambda *_: call_order.append("channel")
+        mock_initiate.execute.side_effect = lambda *_: call_order.append("crawl")
+        mock_orch.execute.side_effect = lambda *_: call_order.append("orchestrator")
 
         from retail.projects.tasks import task_setup_channel_and_start_crawl
 
@@ -77,17 +85,15 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         mock_initiate.execute.assert_called_once_with(
             self.project, "mystore", "https://mystore.com.br/"
         )
+        mock_orch.execute.assert_called_once_with("mystore")
 
-        # Channel must run before crawl initiation.
-        channel_call_order = mock_channel.execute.call_args
-        crawl_call_order = mock_initiate.execute.call_args
-        self.assertIsNotNone(channel_call_order)
-        self.assertIsNotNone(crawl_call_order)
+        self.assertEqual(call_order, ["channel", "crawl", "orchestrator"])
 
+    @patch("retail.projects.tasks.OnboardingOrchestrator")
     @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
     def test_sets_project_linked_progress_before_channel_setup(
-        self, mock_channel_cls, _mock_initiate
+        self, mock_channel_cls, _mock_initiate, _mock_orch
     ):
         """When start-setup linked the project inline, the task still bumps progress."""
         ProjectOnboarding.objects.create(
@@ -118,10 +124,11 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         self.assertEqual(progress_at_channel_time["value"], PROJECT_LINKED_PROGRESS)
         self.assertEqual(progress_at_channel_time["step"], "PROJECT_CONFIG")
 
+    @patch("retail.projects.tasks.OnboardingOrchestrator")
     @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
     def test_does_not_regress_progress_when_eda_linked_project(
-        self, mock_channel_cls, _mock_initiate
+        self, mock_channel_cls, _mock_initiate, _mock_orch
     ):
         """When EDA already set progress >= 30, the task must not regress it."""
         ProjectOnboarding.objects.create(
@@ -171,10 +178,15 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         )
 
     @patch("retail.projects.tasks.mark_onboarding_failed")
+    @patch("retail.projects.tasks.OnboardingOrchestrator")
     @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
     def test_marks_failed_and_skips_crawl_when_channel_fails(
-        self, mock_channel_cls, mock_initiate_cls, mock_mark_failed
+        self,
+        mock_channel_cls,
+        mock_initiate_cls,
+        mock_orch_cls,
+        mock_mark_failed,
     ):
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
@@ -189,6 +201,9 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         mock_initiate = MagicMock()
         mock_initiate_cls.return_value = mock_initiate
 
+        mock_orch = MagicMock()
+        mock_orch_cls.return_value = mock_orch
+
         from retail.projects.tasks import task_setup_channel_and_start_crawl
 
         with self.assertRaises(RuntimeError):
@@ -198,6 +213,7 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         called_with_reason = mock_mark_failed.call_args[0][1]
         self.assertIn("Channel creation failed", called_with_reason)
         mock_initiate.execute.assert_not_called()
+        mock_orch.execute.assert_not_called()
 
 
 class TestTaskWaitAndStartCrawlAlias(TestCase):
@@ -208,9 +224,12 @@ class TestTaskWaitAndStartCrawlAlias(TestCase):
             name="Test", uuid=uuid4(), vtex_account="mystore"
         )
 
+    @patch("retail.projects.tasks.OnboardingOrchestrator")
     @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
-    def test_alias_runs_channel_then_crawl(self, mock_channel_cls, mock_initiate_cls):
+    def test_alias_runs_channel_crawl_and_orchestrator(
+        self, mock_channel_cls, mock_initiate_cls, mock_orch_cls
+    ):
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
@@ -221,6 +240,8 @@ class TestTaskWaitAndStartCrawlAlias(TestCase):
         mock_channel_cls.return_value = mock_channel
         mock_initiate = MagicMock()
         mock_initiate_cls.return_value = mock_initiate
+        mock_orch = MagicMock()
+        mock_orch_cls.return_value = mock_orch
 
         from retail.projects.tasks import task_wait_and_start_crawl
 
@@ -230,9 +251,15 @@ class TestTaskWaitAndStartCrawlAlias(TestCase):
         mock_initiate.execute.assert_called_once_with(
             self.project, "mystore", "https://mystore.com.br/"
         )
+        mock_orch.execute.assert_called_once_with("mystore")
 
 
-class TestTaskConfigureNexus(TestCase):
+class TestTaskUploadNexusContents(TestCase):
+    """
+    Background-only upload task. Failures are soft -- the task swallows
+    the exception and records it via ``SaveBackgroundFailureUseCase``.
+    """
+
     def setUp(self):
         self.project = Project.objects.create(
             name="Test", uuid=uuid4(), vtex_account="mystore"
@@ -243,33 +270,81 @@ class TestTaskConfigureNexus(TestCase):
             config={"channels": {"wwc": {}}},
         )
 
-    @patch("retail.projects.tasks.OnboardingOrchestrator")
+    @patch("retail.projects.tasks.UploadNexusContentsUseCase")
     @patch("retail.projects.tasks.release_task_lock")
-    def test_delegates_to_orchestrator(self, mock_release, mock_orch_cls):
-        mock_orch = MagicMock()
-        mock_orch_cls.return_value = mock_orch
+    def test_delegates_to_upload_use_case(self, mock_release, mock_upload_cls):
+        mock_upload = MagicMock()
+        mock_upload_cls.return_value = mock_upload
+
+        from retail.projects.tasks import task_upload_nexus_contents
+
+        contents = [{"link": "a", "title": "b", "content": "c"}]
+        task_upload_nexus_contents("mystore", contents)
+
+        mock_upload.execute.assert_called_once_with("mystore", contents)
+        mock_release.assert_called_once_with("upload_nexus_contents", "mystore")
+
+    @patch("retail.projects.tasks.SaveBackgroundFailureUseCase")
+    @patch("retail.projects.tasks.UploadNexusContentsUseCase")
+    @patch("retail.projects.tasks.release_task_lock")
+    def test_soft_fails_and_records_background_failure(
+        self, mock_release, mock_upload_cls, mock_save_background_cls
+    ):
+        mock_upload = MagicMock()
+        mock_upload.execute.side_effect = RuntimeError("nexus down")
+        mock_upload_cls.return_value = mock_upload
+
+        from retail.projects.tasks import task_upload_nexus_contents
+
+        task_upload_nexus_contents("mystore", [])
+
+        mock_save_background_cls.execute.assert_called_once_with(
+            "mystore", "nexus_upload", "nexus down"
+        )
+        mock_release.assert_called_once_with("upload_nexus_contents", "mystore")
+
+    @patch("retail.projects.tasks.UploadNexusContentsUseCase")
+    @patch("retail.projects.tasks.release_task_lock")
+    def test_releases_lock_on_success(self, mock_release, _mock_upload_cls):
+        from retail.projects.tasks import task_upload_nexus_contents
+
+        task_upload_nexus_contents("mystore", [])
+
+        mock_release.assert_called_once_with("upload_nexus_contents", "mystore")
+
+
+class TestTaskConfigureNexusDeprecatedAlias(TestCase):
+    """
+    The legacy ``task_configure_nexus`` name must keep executing the new
+    upload pipeline so any jobs queued before the rename are still
+    processed correctly.
+    """
+
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            config={"channels": {"wwc": {}}},
+        )
+
+    @patch("retail.projects.tasks.UploadNexusContentsUseCase")
+    @patch("retail.projects.tasks.release_task_lock")
+    def test_alias_delegates_to_upload_use_case(
+        self, mock_release, mock_upload_cls
+    ):
+        mock_upload = MagicMock()
+        mock_upload_cls.return_value = mock_upload
 
         from retail.projects.tasks import task_configure_nexus
 
         contents = [{"link": "a", "title": "b", "content": "c"}]
         task_configure_nexus("mystore", contents)
 
-        mock_orch.execute.assert_called_once_with("mystore", contents)
-        mock_release.assert_called_once_with("configure_nexus", "mystore")
-
-    @patch("retail.projects.tasks.OnboardingOrchestrator")
-    @patch("retail.projects.tasks.release_task_lock")
-    def test_releases_lock_on_failure(self, mock_release, mock_orch_cls):
-        mock_orch = MagicMock()
-        mock_orch.execute.side_effect = Exception("orchestrator failed")
-        mock_orch_cls.return_value = mock_orch
-
-        from retail.projects.tasks import task_configure_nexus
-
-        with self.assertRaises(Exception):
-            task_configure_nexus("mystore", [])
-
-        mock_release.assert_called_once_with("configure_nexus", "mystore")
+        mock_upload.execute.assert_called_once_with("mystore", contents)
+        mock_release.assert_called_once_with("upload_nexus_contents", "mystore")
 
 
 class TestTaskActivateAgenticCxScript(TestCase):

--- a/retail/projects/tests/test_update_onboarding_progress.py
+++ b/retail/projects/tests/test_update_onboarding_progress.py
@@ -23,7 +23,8 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
         self.onboarding = ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
-            current_step="CRAWL",
+            current_step="NEXUS_CONFIG",
+            progress=75,
         )
         self.onboarding_uuid = str(self.onboarding.uuid)
         self.connect_service = MagicMock()
@@ -33,7 +34,13 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
 
     # ── Progress handling ──────────────────────────────────────────
 
-    def test_updates_progress_on_generic_event(self):
+    def test_does_not_touch_main_progress_on_generic_event(self):
+        """
+        Crawl webhook progress events run in background and must NOT
+        push the main wizard ``progress`` -- by the time these arrive
+        the inline orchestrator may already be advancing
+        ``NEXUS_CONFIG`` (or have completed).
+        """
         dto = CrawlerWebhookDTO(
             task_id="task-1",
             event="crawl.subpage.progress",
@@ -44,51 +51,38 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
 
         result = self.use_case.execute(self.onboarding_uuid, dto)
 
-        self.assertEqual(result.progress, 35)
+        self.assertEqual(result.progress, 75)
 
-    def test_does_not_decrease_progress(self):
-        """Multi-threaded crawler may send out-of-order events."""
-        self.onboarding.progress = 50
-        self.onboarding.save()
-
+    def test_does_not_overwrite_higher_main_progress(self):
         dto = CrawlerWebhookDTO(
             task_id="task-1",
             event="crawl.subpage.progress",
             timestamp="2026-01-01T00:00:00Z",
             url="https://mystore.com.br/",
-            progress=49,
+            progress=10,
         )
 
         result = self.use_case.execute(self.onboarding_uuid, dto)
 
-        self.assertEqual(result.progress, 50)
-
-    def test_increases_progress(self):
-        self.onboarding.progress = 30
-        self.onboarding.save()
-
-        dto = CrawlerWebhookDTO(
-            task_id="task-1",
-            event="crawl.subpage.progress",
-            timestamp="2026-01-01T00:00:00Z",
-            url="https://mystore.com.br/",
-            progress=60,
-        )
-
-        result = self.use_case.execute(self.onboarding_uuid, dto)
-
-        self.assertEqual(result.progress, 60)
+        self.assertEqual(result.progress, 75)
 
     # ── Completed event ────────────────────────────────────────────
 
-    @patch("retail.projects.usecases.update_onboarding_progress.task_configure_nexus")
+    @patch(
+        "retail.projects.usecases.update_onboarding_progress.task_upload_nexus_contents"
+    )
     @patch(
         "retail.projects.usecases.update_onboarding_progress.acquire_task_lock",
         return_value=True,
     )
-    def test_completed_sets_progress_100_and_dispatches_task(
+    def test_completed_records_success_and_dispatches_upload_task(
         self, mock_lock, mock_task
     ):
+        """
+        Completion must record ``crawler_result=SUCCESS`` and dispatch
+        the background nexus upload task -- WITHOUT touching the main
+        ``progress``.
+        """
         contents = [
             {"link": "https://mystore.com.br/", "title": "Home", "content": "Welcome"},
         ]
@@ -103,12 +97,14 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
 
         result = self.use_case.execute(self.onboarding_uuid, dto)
 
-        self.assertEqual(result.progress, 100)
+        self.assertEqual(result.progress, 75)
         self.assertEqual(result.crawler_result, ProjectOnboarding.SUCCESS)
-        mock_lock.assert_called_once_with("configure_nexus", "mystore")
+        mock_lock.assert_called_once_with("upload_nexus_contents", "mystore")
         mock_task.delay.assert_called_once_with("mystore", contents)
 
-    @patch("retail.projects.usecases.update_onboarding_progress.task_configure_nexus")
+    @patch(
+        "retail.projects.usecases.update_onboarding_progress.task_upload_nexus_contents"
+    )
     @patch(
         "retail.projects.usecases.update_onboarding_progress.acquire_task_lock",
         return_value=False,
@@ -125,13 +121,24 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
 
         result = self.use_case.execute(self.onboarding_uuid, dto)
 
-        self.assertEqual(result.progress, 100)
         self.assertEqual(result.crawler_result, ProjectOnboarding.SUCCESS)
         mock_task.delay.assert_not_called()
 
     # ── Failed event ───────────────────────────────────────────────
 
-    def test_handles_failed_event(self):
+    @patch(
+        "retail.projects.usecases.update_onboarding_progress."
+        "SaveBackgroundFailureUseCase"
+    )
+    def test_failed_records_soft_failure_without_flipping_failed(
+        self, mock_save_background_cls
+    ):
+        """
+        Background crawl failures are soft -- ``onboarding.failed``
+        must stay False (the main wizard is decoupled from the crawl
+        outcome) and the error lands in ``config["background_error"]``
+        via ``SaveBackgroundFailureUseCase``.
+        """
         dto = CrawlerWebhookDTO(
             task_id="task-1",
             event=FAILED_EVENT,
@@ -144,6 +151,10 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
         result = self.use_case.execute(self.onboarding_uuid, dto)
 
         self.assertEqual(result.crawler_result, ProjectOnboarding.FAIL)
+        self.assertFalse(result.failed)
+        mock_save_background_cls.execute.assert_called_once_with(
+            "mystore", "crawl", "Connection timeout"
+        )
 
     # ── URL redirected event ───────────────────────────────────────
 

--- a/retail/projects/tests/test_upload_nexus_contents.py
+++ b/retail/projects/tests/test_upload_nexus_contents.py
@@ -1,0 +1,347 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.agent_builder_helpers import ProjectNotLinkedError
+from retail.projects.usecases.upload_nexus_contents import (
+    FileProcessingError,
+    FileUploadError,
+    UploadNexusContentsUseCase,
+    _sanitize_filename,
+)
+
+
+class TestUploadNexusContentsUseCase(TestCase):
+    """Background path triggered by the crawl.completed webhook."""
+
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project",
+            uuid=uuid4(),
+            vtex_account="mystore",
+            language="pt-br",
+        )
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            project=self.project,
+            current_step="NEXUS_CONFIG",
+            progress=100,
+        )
+        self.mock_nexus_service = MagicMock()
+        self.mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": True}
+        }
+        self.usecase = UploadNexusContentsUseCase(nexus_client=MagicMock())
+        self.usecase.nexus_service = self.mock_nexus_service
+
+    def test_raises_error_when_project_not_linked(self):
+        ProjectOnboarding.objects.create(vtex_account="noproject")
+
+        with self.assertRaises(ProjectNotLinkedError):
+            self.usecase.execute("noproject", [])
+
+    def test_does_not_touch_progress_when_contents_empty(self):
+        self.usecase.execute("mystore", [])
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(self.onboarding.progress, 100)
+        self.mock_nexus_service.upload_content_base_file.assert_not_called()
+
+    def test_ensures_agent_configured_before_upload(self):
+        """
+        Background-only entrypoint: if the inline manager step has not
+        yet completed (e.g. webhook arrived early), the upload path must
+        configure the manager itself idempotently.
+        """
+        self.mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": False}
+        }
+        self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
+
+        self.usecase.execute("mystore", [])
+
+        self.mock_nexus_service.check_agent_builder_exists.assert_called_once_with(
+            str(self.project.uuid)
+        )
+        self.mock_nexus_service.configure_agent_attributes.assert_called_once()
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_uploads_files_for_each_content(self, _mock_sleep):
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_file.return_value = {
+            "uuid": upload_uuid,
+            "extension_file": "txt",
+        }
+        self.mock_nexus_service.get_content_base_file_status.return_value = {
+            "uuid": upload_uuid,
+            "status": "success",
+        }
+
+        contents = [
+            {
+                "link": "https://www.mystore.com.br/",
+                "title": "Home Page",
+                "content": "Welcome to our store.",
+            },
+            {
+                "link": "https://www.mystore.com.br/about",
+                "title": "About Us",
+                "content": "We sell great products.",
+            },
+        ]
+
+        self.usecase.execute("mystore", contents)
+
+        self.assertEqual(self.mock_nexus_service.upload_content_base_file.call_count, 2)
+        self.assertEqual(
+            self.mock_nexus_service.get_content_base_file_status.call_count, 2
+        )
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_file_contains_only_content(self, _mock_sleep):
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_file.return_value = {
+            "uuid": upload_uuid,
+            "extension_file": "txt",
+        }
+        self.mock_nexus_service.get_content_base_file_status.return_value = {
+            "uuid": upload_uuid,
+            "status": "success",
+        }
+
+        contents = [
+            {
+                "link": "https://example.com/page",
+                "title": "Test Page",
+                "content": "Some content here.",
+            }
+        ]
+
+        self.usecase.execute("mystore", contents)
+
+        call_kwargs = self.mock_nexus_service.upload_content_base_file.call_args[1]
+        _, file_bytes, _ = call_kwargs["file"]
+
+        text = file_bytes.decode("utf-8")
+        self.assertEqual(text, "Some content here.")
+        self.assertNotIn("Title:", text)
+        self.assertNotIn("Source:", text)
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_does_not_update_progress(self, _mock_sleep):
+        """Background path must never touch ``onboarding.progress``."""
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_file.return_value = {
+            "uuid": upload_uuid,
+            "extension_file": "txt",
+        }
+        self.mock_nexus_service.get_content_base_file_status.return_value = {
+            "uuid": upload_uuid,
+            "status": "success",
+        }
+
+        contents = [
+            {"link": "https://a.com", "title": "A", "content": "a"},
+            {"link": "https://b.com", "title": "B", "content": "b"},
+        ]
+
+        self.usecase.execute("mystore", contents)
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(self.onboarding.progress, 100)
+
+    def test_stops_on_upload_failure(self):
+        self.mock_nexus_service.upload_content_base_file.side_effect = [
+            None,
+            {"uuid": str(uuid4()), "extension_file": "txt"},
+        ]
+
+        contents = [
+            {"link": "https://a.com", "title": "A", "content": "a"},
+            {"link": "https://b.com", "title": "B", "content": "b"},
+        ]
+
+        with self.assertRaises(FileUploadError):
+            self.usecase.execute("mystore", contents)
+
+        self.assertEqual(self.mock_nexus_service.upload_content_base_file.call_count, 1)
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_passes_project_uuid_to_nexus(self, _mock_sleep):
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_file.return_value = {
+            "uuid": upload_uuid,
+            "extension_file": "txt",
+        }
+        self.mock_nexus_service.get_content_base_file_status.return_value = {
+            "uuid": upload_uuid,
+            "status": "success",
+        }
+
+        contents = [
+            {"link": "https://a.com", "title": "A", "content": "a"},
+        ]
+
+        self.usecase.execute("mystore", contents)
+
+        call_kwargs = self.mock_nexus_service.upload_content_base_file.call_args[1]
+        self.assertEqual(call_kwargs["project_uuid"], str(self.project.uuid))
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_waits_for_processing_before_next_upload(self, _mock_sleep):
+        """Ensures polling occurs between consecutive uploads."""
+        uuid_1, uuid_2 = str(uuid4()), str(uuid4())
+        self.mock_nexus_service.upload_content_base_file.side_effect = [
+            {"uuid": uuid_1, "extension_file": "txt"},
+            {"uuid": uuid_2, "extension_file": "txt"},
+        ]
+        self.mock_nexus_service.get_content_base_file_status.side_effect = [
+            {"uuid": uuid_1, "status": "Processing"},
+            {"uuid": uuid_1, "status": "success"},
+            {"uuid": uuid_2, "status": "success"},
+        ]
+
+        contents = [
+            {"link": "https://a.com", "title": "A", "content": "a"},
+            {"link": "https://b.com", "title": "B", "content": "b"},
+        ]
+
+        self.usecase.execute("mystore", contents)
+
+        self.assertEqual(
+            self.mock_nexus_service.get_content_base_file_status.call_count, 3
+        )
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_retries_status_poll_when_status_unavailable(self, _mock_sleep):
+        """A transient ``None`` status response must not abort polling."""
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_file.return_value = {
+            "uuid": upload_uuid,
+            "extension_file": "txt",
+        }
+        self.mock_nexus_service.get_content_base_file_status.side_effect = [
+            None,
+            {"uuid": upload_uuid, "status": "success"},
+        ]
+
+        contents = [{"link": "https://a.com", "title": "A", "content": "a"}]
+
+        self.usecase.execute("mystore", contents)
+
+        self.assertEqual(
+            self.mock_nexus_service.get_content_base_file_status.call_count, 2
+        )
+
+    @patch("retail.projects.usecases.upload_nexus_contents.FILE_STATUS_MAX_ATTEMPTS", 2)
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_gives_up_after_max_attempts_without_terminal_status(self, _mock_sleep):
+        """Polling stops (without raising) once the attempt budget runs out."""
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_file.return_value = {
+            "uuid": upload_uuid,
+            "extension_file": "txt",
+        }
+        self.mock_nexus_service.get_content_base_file_status.return_value = {
+            "uuid": upload_uuid,
+            "status": "processing",
+        }
+
+        contents = [{"link": "https://a.com", "title": "A", "content": "a"}]
+
+        self.usecase.execute("mystore", contents)
+
+        self.assertEqual(
+            self.mock_nexus_service.get_content_base_file_status.call_count, 2
+        )
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_raises_on_processing_failure(self, _mock_sleep):
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_file.return_value = {
+            "uuid": upload_uuid,
+            "extension_file": "txt",
+        }
+        self.mock_nexus_service.get_content_base_file_status.return_value = {
+            "uuid": upload_uuid,
+            "status": "failed",
+        }
+
+        contents = [
+            {"link": "https://a.com", "title": "A", "content": "a"},
+        ]
+
+        with self.assertRaises(FileProcessingError):
+            self.usecase.execute("mystore", contents)
+
+
+class TestBuildFilesFromContents(TestCase):
+    def test_builds_files_with_correct_structure(self):
+        contents = [
+            {
+                "link": "https://example.com/page",
+                "title": "Test Page",
+                "content": "Some content here.",
+            }
+        ]
+
+        files = UploadNexusContentsUseCase._build_files_from_contents(contents)
+
+        self.assertEqual(len(files), 1)
+        filename, file_bytes, content_type = files[0]
+        self.assertEqual(filename, "000_test-page.txt")
+        self.assertEqual(file_bytes, b"Some content here.")
+        self.assertEqual(content_type, "text/plain")
+
+    def test_uses_fallback_title_when_missing(self):
+        contents = [{"link": "https://a.com", "content": "content"}]
+        files = UploadNexusContentsUseCase._build_files_from_contents(contents)
+        filename = files[0][0]
+        self.assertIn("page-0", filename)
+
+    def test_handles_empty_content(self):
+        contents = [{"link": "https://a.com", "title": "Page"}]
+        files = UploadNexusContentsUseCase._build_files_from_contents(contents)
+        self.assertEqual(files[0][1], b"")
+
+    def test_handles_null_title_from_crawler(self):
+        contents = [{"link": "https://a.com", "title": None, "content": "body"}]
+        files = UploadNexusContentsUseCase._build_files_from_contents(contents)
+        self.assertEqual(files[0][0], "000_page-0.txt")
+
+    def test_handles_null_content_from_crawler(self):
+        contents = [{"link": "https://a.com", "title": "Page", "content": None}]
+        files = UploadNexusContentsUseCase._build_files_from_contents(contents)
+        self.assertEqual(files[0][1], b"")
+
+
+class TestSanitizeFilename(TestCase):
+    def test_basic_title(self):
+        self.assertEqual(_sanitize_filename("About Us", 0), "000_about-us.txt")
+
+    def test_special_characters(self):
+        result = _sanitize_filename("C&A | Fornecedores!", 1)
+        self.assertEqual(result, "001_ca-fornecedores.txt")
+
+    def test_url_as_title(self):
+        result = _sanitize_filename("https://www.cea.com.br/", 0)
+        self.assertEqual(result, "000_httpswwwceacombr.txt")
+
+    def test_empty_title(self):
+        result = _sanitize_filename("", 5)
+        self.assertEqual(result, "005_page.txt")
+
+    def test_long_title_truncated(self):
+        long_title = "A" * 200
+        result = _sanitize_filename(long_title, 0)
+        self.assertTrue(len(result) <= 89)
+
+    def test_whitespace_collapsed(self):
+        result = _sanitize_filename("Hello   World   Page", 2)
+        self.assertEqual(result, "002_hello-world-page.txt")
+
+    def test_strips_accents(self):
+        result = _sanitize_filename("Promoção Ação Café", 0)
+        self.assertEqual(result, "000_promocao-acao-cafe.txt")

--- a/retail/projects/tests/test_views.py
+++ b/retail/projects/tests/test_views.py
@@ -47,24 +47,6 @@ class TestStartSetupView(TestCase):
 
     @_auth_bypass(None)
     @patch("retail.projects.views.StartSetupUseCase")
-    def test_returns_502_when_crawler_fails(self, mock_usecase_cls, _mock_auth):
-        from retail.projects.usecases.start_crawl import CrawlerStartError
-
-        mock_instance = MagicMock()
-        mock_instance.execute.side_effect = CrawlerStartError("Crawler down")
-        mock_usecase_cls.return_value = mock_instance
-
-        response = self.client.post(
-            "/api/onboard/mystore/start-setup/",
-            {"crawl_url": "https://www.mystore.com.br/", "channel": "wwc"},
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, 502)
-        self.assertIn("Crawler down", response.json()["detail"])
-
-    @_auth_bypass(None)
-    @patch("retail.projects.views.StartSetupUseCase")
     def test_returns_201_with_wpp_cloud_channel_data(
         self, mock_usecase_cls, _mock_auth
     ):
@@ -140,8 +122,20 @@ class TestCrawlerWebhookView(TestCase):
         "retail.projects.usecases.update_onboarding_progress.acquire_task_lock",
         return_value=True,
     )
-    @patch("retail.projects.usecases.update_onboarding_progress.task_configure_nexus")
+    @patch(
+        "retail.projects.usecases.update_onboarding_progress.task_upload_nexus_contents"
+    )
     def test_returns_200_on_valid_webhook(self, mock_task, mock_lock):
+        """
+        Background crawl progress events do NOT touch the main
+        ``progress`` -- the response reflects the onboarding's current
+        main progress (set by the inline orchestrator path), not the
+        crawl-local percentage in the webhook payload.
+        """
+        self.onboarding.progress = 100
+        self.onboarding.current_step = "NEXUS_CONFIG"
+        self.onboarding.save(update_fields=["progress", "current_step"])
+
         response = self.client.post(
             f"/api/onboard/{self.onboarding.uuid}/webhook/",
             {
@@ -155,7 +149,7 @@ class TestCrawlerWebhookView(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["progress"], 50)
+        self.assertEqual(response.json()["progress"], 100)
 
     def test_returns_404_for_unknown_project(self):
         response = self.client.post(

--- a/retail/projects/usecases/agent_builder_helpers.py
+++ b/retail/projects/usecases/agent_builder_helpers.py
@@ -1,0 +1,89 @@
+"""
+Shared helpers used by the inline and background Agent Builder paths.
+
+The inline path (``ConfigureAgentBuilderUseCase``) and the background
+upload path (``UploadNexusContentsUseCase``) both need to:
+  1. Load the onboarding record and assert a project is linked.
+  2. Idempotently configure the Nexus agent manager.
+
+Extracting these into a single helpers module keeps the "must have a
+project" + "configure if missing" contracts in one place and avoids the
+two use cases duplicating the logic (or worse, drifting apart).
+"""
+
+import logging
+
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.manager_defaults import (
+    MANAGER_PERSONALITY,
+    get_manager_defaults,
+)
+from retail.services.nexus.service import NexusService
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectNotLinkedError(Exception):
+    """Raised when Agent Builder configuration is attempted without a linked project."""
+
+
+def load_onboarding_with_linked_project(vtex_account: str) -> ProjectOnboarding:
+    """
+    Fetches the onboarding record and asserts it has a linked project.
+
+    Raises:
+        ProjectNotLinkedError: If the onboarding has no project linked.
+    """
+    onboarding = ProjectOnboarding.objects.select_related("project").get(
+        vtex_account=vtex_account
+    )
+
+    if onboarding.project is None:
+        raise ProjectNotLinkedError(
+            f"Onboarding {onboarding.uuid} has no project linked yet."
+        )
+
+    return onboarding
+
+
+def ensure_agent_manager_configured(
+    project_uuid: str,
+    vtex_account: str,
+    language: str,
+    nexus_service: NexusService,
+) -> None:
+    """
+    Idempotent: configures the agent manager in Nexus if not yet configured.
+
+    Called by both use cases so the upload task can safely run even if
+    the inline manager step has not yet completed (e.g. the crawl
+    webhook arrived before the inline orchestrator's manager step).
+    """
+    response = nexus_service.check_agent_builder_exists(project_uuid)
+
+    if response and response.get("data", {}).get("has_agent"):
+        logger.info(f"Agent manager already configured for project={project_uuid}")
+        return
+
+    defaults = get_manager_defaults(language)
+
+    payload = {
+        "agent": {
+            "name": f"{vtex_account.title()} Manager",
+            "goal": defaults["goal"],
+            "role": defaults["role"],
+            "personality": MANAGER_PERSONALITY,
+        },
+        "links": [],
+    }
+
+    result = nexus_service.configure_agent_attributes(project_uuid, payload)
+
+    if result is not None:
+        logger.info(
+            f"Agent manager attributes set for project={project_uuid}: {result}"
+        )
+    else:
+        logger.error(
+            f"Failed to set agent manager attributes for project={project_uuid}"
+        )

--- a/retail/projects/usecases/configure_agent_builder.py
+++ b/retail/projects/usecases/configure_agent_builder.py
@@ -1,53 +1,32 @@
 import logging
-import re
-import time
-import unicodedata
-
-from typing import List, Tuple
 
 from retail.clients.nexus.client import NexusClient
 from retail.interfaces.clients.nexus.client import NexusClientInterface
-from retail.projects.models import ProjectOnboarding
-from retail.projects.usecases.manager_defaults import (
-    MANAGER_PERSONALITY,
-    get_manager_defaults,
+from retail.projects.usecases.agent_builder_helpers import (
+    ensure_agent_manager_configured,
+    load_onboarding_with_linked_project,
 )
 from retail.services.nexus.service import NexusService
 
 logger = logging.getLogger(__name__)
 
 
-class ProjectNotLinkedError(Exception):
-    """Raised when Agent Builder configuration is attempted without a linked project."""
-
-
-class FileProcessingError(Exception):
-    """Raised when Nexus reports a file processing failure."""
-
-
-class FileUploadError(Exception):
-    """Raised when a file upload to Nexus fails."""
-
-
-CHANNEL_PROGRESS_OFFSET = 20
-MAX_UPLOAD_PROGRESS = 75
-
-FILE_STATUS_POLL_INTERVAL = 3  # seconds between status checks
-FILE_STATUS_MAX_ATTEMPTS = 60  # ~3 minutes max wait per file
+MANAGER_DONE_PROGRESS = 75
 
 
 class ConfigureAgentBuilderUseCase:
     """
-    Configures the Nexus Agent Builder for a project.
+    Inline (main-flow) configuration of the Nexus Agent Builder manager
+    attributes.
 
-    Steps executed in order:
-      1. Check if the agent manager attributes are already set.
-      2. If not, set them (name, goal, role, personality) using the
-         project language for translation.
-      3. Upload crawled content files to the Nexus content base.
+    Invoked by ``OnboardingOrchestrator`` right after the crawler is
+    kicked off. Configures the agent manager (name, goal, role,
+    personality) using the project language for translation and bumps
+    the onboarding progress to ``MANAGER_DONE_PROGRESS`` (75%).
 
-    Progress is tracked from 20% (after channel) to 75%.
-    Agent integration (75-100%) follows as a separate step.
+    Does NOT upload any content -- the crawled content is uploaded
+    asynchronously by ``UploadNexusContentsUseCase`` when the crawler's
+    ``crawl.completed`` webhook arrives.
     """
 
     def __init__(
@@ -56,212 +35,21 @@ class ConfigureAgentBuilderUseCase:
     ):
         self.nexus_service = NexusService(nexus_client=nexus_client or NexusClient())
 
-    def execute(self, vtex_account: str, contents: list) -> None:
+    def execute(self, vtex_account: str) -> None:
         """
-        Full Nexus configuration flow: set agent attributes then upload files.
-
         Args:
             vtex_account: The VTEX account identifier for the onboarding.
-            contents: List of dicts with 'link', 'title', and 'content' keys.
 
         Raises:
             ProjectNotLinkedError: If the onboarding has no project linked.
         """
-        onboarding = ProjectOnboarding.objects.select_related("project").get(
-            vtex_account=vtex_account
-        )
-
-        if onboarding.project is None:
-            raise ProjectNotLinkedError(
-                f"Onboarding {onboarding.uuid} has no project linked yet."
-            )
-
+        onboarding = load_onboarding_with_linked_project(vtex_account)
         project_uuid = str(onboarding.project.uuid)
         language = onboarding.project.language or ""
 
-        self._ensure_agent_configured(project_uuid, vtex_account, language)
-        self._upload_contents(onboarding, project_uuid, contents)
-
-    def _ensure_agent_configured(
-        self, project_uuid: str, vtex_account: str, language: str
-    ) -> None:
-        """
-        Checks whether the agent manager is already configured; if not,
-        sends the translated attributes to Nexus.
-        """
-        response = self.nexus_service.check_agent_builder_exists(project_uuid)
-
-        if response and response.get("data", {}).get("has_agent"):
-            logger.info(f"Agent manager already configured for project={project_uuid}")
-            return
-
-        defaults = get_manager_defaults(language)
-
-        payload = {
-            "agent": {
-                "name": f"{vtex_account.title()} Manager",
-                "goal": defaults["goal"],
-                "role": defaults["role"],
-                "personality": MANAGER_PERSONALITY,
-            },
-            "links": [],
-        }
-
-        result = self.nexus_service.configure_agent_attributes(project_uuid, payload)
-
-        if result is not None:
-            logger.info(
-                f"Agent manager attributes set for project={project_uuid}: {result}"
-            )
-        else:
-            logger.error(
-                f"Failed to set agent manager attributes for project={project_uuid}"
-            )
-
-    def _upload_contents(
-        self,
-        onboarding: ProjectOnboarding,
-        project_uuid: str,
-        contents: list,
-    ) -> None:
-        """
-        Converts crawled content to .txt files and uploads them to Nexus.
-        Updates progress proportionally from CHANNEL_PROGRESS_OFFSET to MAX_UPLOAD_PROGRESS.
-        """
-        if not contents:
-            logger.warning(
-                f"No contents found in crawl result for onboarding={onboarding.uuid}"
-            )
-            onboarding.progress = MAX_UPLOAD_PROGRESS
-            onboarding.save(update_fields=["progress"])
-            return
-
-        files = self._build_files_from_contents(contents)
-        total = len(files)
-
-        logger.info(
-            f"Uploading {total} content files to Nexus for project={project_uuid}"
+        ensure_agent_manager_configured(
+            project_uuid, vtex_account, language, self.nexus_service
         )
 
-        for index, (filename, file_bytes, content_type) in enumerate(files):
-            response = self.nexus_service.upload_content_base_file(
-                project_uuid=project_uuid,
-                file=(filename, file_bytes, content_type),
-            )
-
-            if response is None:
-                raise FileUploadError(
-                    f"Failed to upload {filename} to Nexus for project={project_uuid}"
-                )
-
-            file_uuid = response.get("uuid")
-            logger.info(
-                f"Uploaded {filename} to Nexus for project={project_uuid}: "
-                f"file_uuid={file_uuid}, response={response}"
-            )
-
-            if file_uuid:
-                self._wait_for_processing(project_uuid, file_uuid, filename)
-
-            upload_range = MAX_UPLOAD_PROGRESS - CHANNEL_PROGRESS_OFFSET
-            onboarding.progress = CHANNEL_PROGRESS_OFFSET + int(
-                ((index + 1) / total) * upload_range
-            )
-            onboarding.save(update_fields=["progress"])
-
-        logger.info(
-            f"Content base upload completed for project={project_uuid} "
-            f"({total} files uploaded, progress={onboarding.progress}%)"
-        )
-
-    def _wait_for_processing(
-        self, project_uuid: str, file_uuid: str, filename: str
-    ) -> None:
-        """
-        Polls Nexus until the uploaded file reaches a terminal status
-        (``success`` or ``failed``) before allowing the next upload.
-        """
-        for attempt in range(1, FILE_STATUS_MAX_ATTEMPTS + 1):
-            time.sleep(FILE_STATUS_POLL_INTERVAL)
-
-            status_response = self.nexus_service.get_content_base_file_status(
-                project_uuid, file_uuid
-            )
-
-            if status_response is None:
-                logger.warning(
-                    f"Could not fetch status for file_uuid={file_uuid} "
-                    f"(attempt {attempt}/{FILE_STATUS_MAX_ATTEMPTS})"
-                )
-                continue
-
-            status = status_response.get("status", "").lower()
-
-            logger.info(
-                f"File {filename} (uuid={file_uuid}) status={status} "
-                f"(attempt {attempt}/{FILE_STATUS_MAX_ATTEMPTS})"
-            )
-
-            if status == "success":
-                return
-
-            if status == "failed":
-                raise FileProcessingError(
-                    f"Nexus reported processing failure for "
-                    f"file_uuid={file_uuid} ({filename})"
-                )
-
-        logger.error(
-            f"Timed out waiting for file_uuid={file_uuid} ({filename}) "
-            f"after {FILE_STATUS_MAX_ATTEMPTS} attempts"
-        )
-
-    @staticmethod
-    def _build_files_from_contents(
-        contents: list,
-    ) -> List[Tuple[str, bytes, str]]:
-        """
-        Converts a list of crawled page contents into in-memory .txt files.
-
-        Each file contains the scraped content for a single page.
-
-        Args:
-            contents: List of dicts with 'link', 'title', and 'content' keys.
-
-        Returns:
-            List of tuples (filename, file_bytes, content_type).
-        """
-        files = []
-
-        for index, item in enumerate(contents):
-            title = item.get("title", f"page_{index}")
-            content = item.get("content", "")
-
-            file_bytes = content.encode("utf-8")
-
-            filename = _sanitize_filename(title, index)
-            files.append((filename, file_bytes, "text/plain"))
-
-        return files
-
-
-def _sanitize_filename(title: str, index: int) -> str:
-    """
-    Generates a safe filename from a page title.
-
-    Strips accents via NFKD normalization, removes special characters,
-    limits length, and appends the index to guarantee uniqueness.
-
-    Args:
-        title: The page title to convert into a filename.
-        index: Numeric index for uniqueness.
-
-    Returns:
-        A sanitized .txt filename.
-    """
-    normalized = unicodedata.normalize("NFKD", title)
-    ascii_title = normalized.encode("ascii", "ignore").decode("ascii")
-    name = re.sub(r"[^\w\s-]", "", ascii_title).strip().lower()
-    name = re.sub(r"[\s_]+", "-", name)
-    name = name[:80] if name else "page"
-    return f"{index:03d}_{name}.txt"
+        onboarding.progress = MANAGER_DONE_PROGRESS
+        onboarding.save(update_fields=["progress"])

--- a/retail/projects/usecases/onboarding_orchestrator.py
+++ b/retail/projects/usecases/onboarding_orchestrator.py
@@ -23,30 +23,46 @@ CHANNELS_WITH_ONE_CLICK_PAYMENT = {"wpp-cloud"}
 
 class OnboardingOrchestrator:
     """
-    Orchestrates post-crawl configuration:
-      1. Nexus manager + upload (20-75%) -- configures agent and uploads content
-      2. One-Click Payment (wpp-cloud)   -- registers keys + creates + publishes Meta Flow
-                                            (runs BEFORE agent integration so the
-                                            One-Click Payment agent can consume the
-                                            published flow_id as a credential)
-      3. Agent integration (75-100%)     -- integrates Nexus agents for the channel
+    Orchestrates post-crawl configuration that runs INLINE in the main
+    onboarding flow (right after the crawler is kicked off):
+
+      1. Nexus manager configuration (10-75%) -- configures the agent
+                                                  manager attributes ONLY.
+                                                  Content upload happens
+                                                  in background later, when
+                                                  the crawl webhook arrives.
+      2. One-Click Payment (wpp-cloud)        -- registers keys + creates
+                                                  + publishes Meta Flow
+                                                  (runs BEFORE agent
+                                                  integration so the
+                                                  One-Click Payment agent
+                                                  can consume the published
+                                                  flow_id as a credential)
+      3. Agent integration (75-100%)          -- integrates Nexus agents
+                                                  for the channel
 
     Channel creation runs before the crawl (see ``PreCrawlChannelUseCase``)
     so the short-lived Facebook ``auth_code`` is not exposed to the
     crawl's runtime. Both channels' ``app_uuid`` / ``flow_object_uuid``
     are already persisted by the time this orchestrator runs.
 
+    Crawl + Nexus content upload run in the background and do NOT affect
+    the main onboarding progress: the user-visible wizard completes once
+    this orchestrator returns. The content upload to Nexus is dispatched
+    by ``UpdateOnboardingProgressUseCase`` when the ``crawl.completed``
+    webhook arrives.
+
     Each step is sequential. If any step fails, progress freezes
     at the last saved value and the error propagates.
     """
 
-    def execute(self, vtex_account: str, contents: list) -> None:
+    def execute(self, vtex_account: str) -> None:
         logger.info(f"Starting post-crawl config for vtex_account={vtex_account}")
 
         try:
             self._mark_nexus_config_started(vtex_account)
 
-            ConfigureAgentBuilderUseCase().execute(vtex_account, contents)
+            ConfigureAgentBuilderUseCase().execute(vtex_account)
 
             channel_code = self._resolve_channel_code(vtex_account)
             if channel_code in CHANNELS_WITH_ONE_CLICK_PAYMENT:

--- a/retail/projects/usecases/save_background_failure.py
+++ b/retail/projects/usecases/save_background_failure.py
@@ -1,0 +1,56 @@
+import logging
+
+from django.utils import timezone
+
+from retail.projects.models import ProjectOnboarding
+
+logger = logging.getLogger(__name__)
+
+
+class SaveBackgroundFailureUseCase:
+    """
+    Stores a snapshot of a background-phase failure (crawl + Nexus
+    content upload) in ProjectOnboarding.config.
+
+    Writes the snapshot under config["background_error"] WITHOUT
+    flipping onboarding.failed -- the main onboarding may already be
+    completed from the user's perspective by the time the background
+    phase fails, and we don't want to retroactively flip a wizard that
+    the user has already finished.
+
+    The payload is overwritten on each new failure. It is cleared when
+    a new attempt is made via StartSetupUseCase (see _reset_onboarding).
+
+    Fail-safe: exceptions are logged and never propagated, so the
+    caller's flow is not affected by persistence issues.
+    """
+
+    @staticmethod
+    def execute(vtex_account: str, stage: str, error: str) -> None:
+        """
+        Args:
+            vtex_account: VTEX account identifier.
+            stage: Short code identifying where the failure happened
+                (e.g. "crawler_start", "crawl", "nexus_upload").
+            error: Human-readable error message.
+        """
+        try:
+            onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
+            config = onboarding.config or {}
+            config["background_error"] = {
+                "timestamp": timezone.now().isoformat(),
+                "stage": stage,
+                "error": error,
+            }
+            onboarding.config = config
+            onboarding.save(update_fields=["config"])
+
+            logger.info(
+                f"[BackgroundFailure] recorded "
+                f"vtex_account={vtex_account} stage={stage}"
+            )
+        except Exception as exc:
+            logger.error(
+                f"[BackgroundFailure] persist failed for "
+                f"vtex_account={vtex_account}: {exc}"
+            )

--- a/retail/projects/usecases/start_crawl.py
+++ b/retail/projects/usecases/start_crawl.py
@@ -6,23 +6,35 @@ from retail.clients.crawler.client import CrawlerClient
 from retail.interfaces.clients.crawler.client import CrawlerClientInterface
 from retail.projects.models import ProjectOnboarding
 from retail.projects.usecases.manager_defaults import get_manager_defaults
-from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_defaults import get_instructions
+from retail.projects.usecases.save_background_failure import (
+    SaveBackgroundFailureUseCase,
+)
 from retail.services.crawler.service import CrawlerService
 
 logger = logging.getLogger(__name__)
 
 
-class CrawlerStartError(Exception):
-    """Raised when the Crawler MS fails to start."""
+CRAWL_KICKOFF_PROGRESS = 100
 
 
 class StartCrawlUseCase:
     """
-    Starts the crawl by calling the Crawler MS.
+    Kicks off the crawl by calling the Crawler MS.
 
-    Sets current_step to CRAWL, resets progress, builds the webhook URL
-    using the onboarding UUID, and forwards the request to the crawler.
+    Sets ``current_step`` to ``CRAWL`` with ``progress=100`` to signal
+    that the crawl phase is done from the wizard's perspective the
+    moment the crawler is kicked off. The actual long-running crawl
+    runs in background and its real outcome lands in
+    ``crawler_result`` (``SUCCESS`` / ``FAIL``), NOT in ``progress``.
+
+    The orchestrator that runs immediately after this use case will
+    overwrite ``current_step`` with ``NEXUS_CONFIG`` in the same Celery
+    task, so the ``CRAWL`` step is visible only transiently.
+
+    Soft-fails on crawler-comms errors: the main onboarding must still
+    be able to complete even when the crawler cannot be reached -- the
+    crawl is no longer mandatory for the wizard to finish.
     """
 
     def __init__(
@@ -40,16 +52,13 @@ class StartCrawlUseCase:
         Args:
             vtex_account: The VTEX account identifier.
             crawl_url: The store URL to crawl.
-
-        Raises:
-            CrawlerStartError: If the crawler fails to start.
         """
         onboarding = ProjectOnboarding.objects.select_related("project").get(
             vtex_account=vtex_account,
         )
 
         onboarding.current_step = "CRAWL"
-        onboarding.progress = 10
+        onboarding.progress = CRAWL_KICKOFF_PROGRESS
         onboarding.save(update_fields=["current_step", "progress"])
 
         onboarding_uuid = str(onboarding.uuid)
@@ -72,8 +81,13 @@ class StartCrawlUseCase:
             onboarding.save(update_fields=["crawler_result"])
 
             error_msg = "Failed to communicate with the Crawler service."
-            mark_onboarding_failed(vtex_account, error_msg)
-            raise CrawlerStartError(error_msg)
+            SaveBackgroundFailureUseCase.execute(
+                vtex_account, "crawler_start", error_msg
+            )
+            logger.error(
+                f"Crawler start failed for vtex_account={vtex_account}: {error_msg}"
+            )
+            return
 
         logger.info(
             f"Crawl started for vtex_account={vtex_account} crawl_url={crawl_url}"

--- a/retail/projects/usecases/start_setup.py
+++ b/retail/projects/usecases/start_setup.py
@@ -89,6 +89,7 @@ class StartSetupUseCase:
         config = onboarding.config or {}
         config.pop("last_failure", None)
         config.pop("reason_failed", None)
+        config.pop("background_error", None)
 
         channels = config.get("channels", {})
         for channel_config in channels.values():

--- a/retail/projects/usecases/update_onboarding_progress.py
+++ b/retail/projects/usecases/update_onboarding_progress.py
@@ -2,9 +2,15 @@ import logging
 from typing import Optional
 
 from retail.projects.models import ProjectOnboarding
-from retail.projects.tasks import acquire_task_lock, task_configure_nexus
-from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
+from retail.projects.tasks import (
+    UPLOAD_NEXUS_LOCK_NAME,
+    acquire_task_lock,
+    task_upload_nexus_contents,
+)
 from retail.projects.usecases.onboarding_dto import CrawlerWebhookDTO
+from retail.projects.usecases.save_background_failure import (
+    SaveBackgroundFailureUseCase,
+)
 from retail.services.connect.service import ConnectService
 
 logger = logging.getLogger(__name__)
@@ -60,24 +66,31 @@ class UpdateOnboardingProgressUseCase:
     def _handle_completed(
         onboarding: ProjectOnboarding, dto: CrawlerWebhookDTO
     ) -> ProjectOnboarding:
-        """Marks crawl as successful and dispatches the NEXUS_CONFIG task."""
-        onboarding.progress = 100
+        """
+        Records the crawl as successful and dispatches the background
+        Nexus content upload.
+
+        Does NOT touch ``onboarding.progress`` -- by the time this
+        webhook arrives the main wizard may already be at
+        ``NEXUS_CONFIG`` 100%, and pushing the bar back to 100 (or any
+        value) would conflict with the inline orchestrator's writes.
+        """
         onboarding.crawler_result = ProjectOnboarding.SUCCESS
-        onboarding.save(update_fields=["progress", "crawler_result"])
+        onboarding.save(update_fields=["crawler_result"])
 
         contents = dto.data.get("contents", [])
         vtex_account = onboarding.vtex_account
 
         logger.info(
             f"Crawler completed for onboarding={onboarding.uuid}. "
-            f"Dispatching NEXUS_CONFIG with {len(contents)} content items."
+            f"Dispatching background nexus upload with {len(contents)} content items."
         )
 
-        if acquire_task_lock("configure_nexus", vtex_account):
-            task_configure_nexus.delay(vtex_account, contents)
+        if acquire_task_lock(UPLOAD_NEXUS_LOCK_NAME, vtex_account):
+            task_upload_nexus_contents.delay(vtex_account, contents)
         else:
             logger.warning(
-                f"Nexus config task already running for vtex_account={vtex_account}, "
+                f"Nexus upload task already running for vtex_account={vtex_account}, "
                 f"skipping dispatch."
             )
 
@@ -87,12 +100,24 @@ class UpdateOnboardingProgressUseCase:
     def _handle_failed(
         onboarding: ProjectOnboarding, dto: CrawlerWebhookDTO
     ) -> ProjectOnboarding:
-        """Records the crawl failure and marks the onboarding as failed."""
+        """
+        Records a soft crawl failure.
+
+        Does NOT flip ``onboarding.failed`` -- the main onboarding is
+        decoupled from the background crawl outcome. The failure is
+        persisted under ``config["background_error"]`` for ops
+        visibility, and ``crawler_result`` is set to ``FAIL``.
+        """
         onboarding.crawler_result = ProjectOnboarding.FAIL
         onboarding.save(update_fields=["crawler_result"])
 
         error_msg = dto.data.get("error", "Unknown error")
-        mark_onboarding_failed(onboarding.vtex_account, f"Crawler failed: {error_msg}")
+        SaveBackgroundFailureUseCase.execute(
+            onboarding.vtex_account, "crawl", error_msg
+        )
+        logger.warning(
+            f"Background crawl failed for onboarding={onboarding.uuid}: {error_msg}"
+        )
         return onboarding
 
     def _handle_url_redirected(
@@ -153,13 +178,17 @@ class UpdateOnboardingProgressUseCase:
     def _handle_progress(
         onboarding: ProjectOnboarding, dto: CrawlerWebhookDTO
     ) -> ProjectOnboarding:
-        """Updates crawl progress when it has advanced."""
-        if dto.progress > onboarding.progress:
-            onboarding.progress = dto.progress
-            onboarding.save(update_fields=["progress"])
+        """
+        Logs a background-crawl progress event.
 
+        Does NOT touch ``onboarding.progress`` -- the main wizard
+        progress is owned by the inline orchestrator path (which has
+        already moved on to ``NEXUS_CONFIG`` by the time these events
+        arrive). The crawl phase reports its outcome via
+        ``crawler_result``, not via ``progress``.
+        """
         logger.info(
-            f"Crawl progress for onboarding={onboarding.uuid}: "
-            f"event={dto.event} progress={onboarding.progress}%"
+            f"Crawl background progress for onboarding={onboarding.uuid}: "
+            f"event={dto.event} crawl_progress={dto.progress}%"
         )
         return onboarding

--- a/retail/projects/usecases/upload_nexus_contents.py
+++ b/retail/projects/usecases/upload_nexus_contents.py
@@ -1,0 +1,211 @@
+import logging
+import re
+import time
+import unicodedata
+
+from typing import List, Tuple
+
+from retail.clients.nexus.client import NexusClient
+from retail.interfaces.clients.nexus.client import NexusClientInterface
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.agent_builder_helpers import (
+    ensure_agent_manager_configured,
+    load_onboarding_with_linked_project,
+)
+from retail.services.nexus.service import NexusService
+
+logger = logging.getLogger(__name__)
+
+
+class FileProcessingError(Exception):
+    """Raised when Nexus reports a file processing failure."""
+
+
+class FileUploadError(Exception):
+    """Raised when a file upload to Nexus fails."""
+
+
+FILE_STATUS_POLL_INTERVAL = 3  # seconds between status checks
+FILE_STATUS_MAX_ATTEMPTS = 60  # ~3 minutes max wait per file
+
+
+class UploadNexusContentsUseCase:
+    """
+    Background-only upload of crawled content files to the Nexus
+    content base.
+
+    Invoked by ``task_upload_nexus_contents`` when the crawl webhook
+    arrives with ``crawl.completed``. Calls ``ensure_agent_manager_configured``
+    first so the upload is safe to run even if the inline manager step
+    (``ConfigureAgentBuilderUseCase``) has not yet completed -- e.g.
+    the webhook arrived early.
+
+    Background path: does NOT touch ``onboarding.progress`` -- the main
+    wizard is decoupled from the crawl outcome.
+    """
+
+    def __init__(
+        self,
+        nexus_client: NexusClientInterface = None,
+    ):
+        self.nexus_service = NexusService(nexus_client=nexus_client or NexusClient())
+
+    def execute(self, vtex_account: str, contents: list) -> None:
+        """
+        Args:
+            vtex_account: The VTEX account identifier for the onboarding.
+            contents: List of dicts with 'link', 'title', and 'content' keys.
+
+        Raises:
+            ProjectNotLinkedError: If the onboarding has no project linked.
+        """
+        onboarding = load_onboarding_with_linked_project(vtex_account)
+        project_uuid = str(onboarding.project.uuid)
+        language = onboarding.project.language or ""
+
+        ensure_agent_manager_configured(
+            project_uuid, vtex_account, language, self.nexus_service
+        )
+        self._upload_contents(onboarding, project_uuid, contents)
+
+    def _upload_contents(
+        self,
+        onboarding: ProjectOnboarding,
+        project_uuid: str,
+        contents: list,
+    ) -> None:
+        """
+        Converts crawled content to .txt files and uploads them to Nexus.
+
+        Background-only: does NOT update ``onboarding.progress``. The
+        ``onboarding`` argument is kept for log context.
+        """
+        if not contents:
+            logger.warning(
+                f"No contents found in crawl result for onboarding={onboarding.uuid}"
+            )
+            return
+
+        files = self._build_files_from_contents(contents)
+        total = len(files)
+
+        logger.info(
+            f"Uploading {total} content files to Nexus for project={project_uuid}"
+        )
+
+        for filename, file_bytes, content_type in files:
+            response = self.nexus_service.upload_content_base_file(
+                project_uuid=project_uuid,
+                file=(filename, file_bytes, content_type),
+            )
+
+            if response is None:
+                raise FileUploadError(
+                    f"Failed to upload {filename} to Nexus for project={project_uuid}"
+                )
+
+            file_uuid = response.get("uuid")
+            logger.info(
+                f"Uploaded {filename} to Nexus for project={project_uuid}: "
+                f"file_uuid={file_uuid}, response={response}"
+            )
+
+            if file_uuid:
+                self._wait_for_processing(project_uuid, file_uuid, filename)
+
+        logger.info(
+            f"Content base upload completed for project={project_uuid} "
+            f"({total} files uploaded)"
+        )
+
+    def _wait_for_processing(
+        self, project_uuid: str, file_uuid: str, filename: str
+    ) -> None:
+        """
+        Polls Nexus until the uploaded file reaches a terminal status
+        (``success`` or ``failed``) before allowing the next upload.
+        """
+        for attempt in range(1, FILE_STATUS_MAX_ATTEMPTS + 1):
+            time.sleep(FILE_STATUS_POLL_INTERVAL)
+
+            status_response = self.nexus_service.get_content_base_file_status(
+                project_uuid, file_uuid
+            )
+
+            if status_response is None:
+                logger.warning(
+                    f"Could not fetch status for file_uuid={file_uuid} "
+                    f"(attempt {attempt}/{FILE_STATUS_MAX_ATTEMPTS})"
+                )
+                continue
+
+            status = status_response.get("status", "").lower()
+
+            logger.info(
+                f"File {filename} (uuid={file_uuid}) status={status} "
+                f"(attempt {attempt}/{FILE_STATUS_MAX_ATTEMPTS})"
+            )
+
+            if status == "success":
+                return
+
+            if status == "failed":
+                raise FileProcessingError(
+                    f"Nexus reported processing failure for "
+                    f"file_uuid={file_uuid} ({filename})"
+                )
+
+        logger.error(
+            f"Timed out waiting for file_uuid={file_uuid} ({filename}) "
+            f"after {FILE_STATUS_MAX_ATTEMPTS} attempts"
+        )
+
+    @staticmethod
+    def _build_files_from_contents(
+        contents: list,
+    ) -> List[Tuple[str, bytes, str]]:
+        """
+        Converts a list of crawled page contents into in-memory .txt files.
+
+        Each file contains the scraped content for a single page.
+
+        Args:
+            contents: List of dicts with 'link', 'title', and 'content' keys.
+
+        Returns:
+            List of tuples (filename, file_bytes, content_type).
+        """
+        files = []
+
+        for index, item in enumerate(contents):
+            title = item.get("title") or f"page_{index}"
+            content = item.get("content") or ""
+
+            file_bytes = content.encode("utf-8")
+
+            filename = _sanitize_filename(title, index)
+            files.append((filename, file_bytes, "text/plain"))
+
+        return files
+
+
+def _sanitize_filename(title: str, index: int) -> str:
+    """
+    Generates a safe filename from a page title.
+
+    Strips accents via NFKD normalization, removes special characters,
+    limits length, and appends the index to guarantee uniqueness.
+
+    Args:
+        title: The page title to convert into a filename.
+        index: Numeric index for uniqueness.
+
+    Returns:
+        A sanitized .txt filename.
+    """
+    normalized = unicodedata.normalize("NFKD", title)
+    ascii_title = normalized.encode("ascii", "ignore").decode("ascii")
+    name = re.sub(r"[^\w\s-]", "", ascii_title).strip().lower()
+    name = re.sub(r"[\s_]+", "-", name)
+    name = name[:80] if name else "page"
+    return f"{index:03d}_{name}.txt"

--- a/retail/projects/views.py
+++ b/retail/projects/views.py
@@ -42,7 +42,6 @@ from retail.projects.usecases.request_onboarding_support import (
 from retail.projects.usecases.save_onboarding_failure import (
     SaveOnboardingFailureUseCase,
 )
-from retail.projects.usecases.start_crawl import CrawlerStartError
 from retail.projects.usecases.start_setup import StartSetupUseCase
 from retail.projects.usecases.update_onboarding_progress import (
     UpdateOnboardingProgressUseCase,
@@ -151,13 +150,7 @@ class StartSetupView(KeycloakAPIView):
             channel_data=channel_data,
         )
 
-        try:
-            StartSetupUseCase().execute(dto)
-        except CrawlerStartError as e:
-            return Response(
-                {"detail": str(e)},
-                status=status.HTTP_502_BAD_GATEWAY,
-            )
+        StartSetupUseCase().execute(dto)
 
         return Response({"status": "started"}, status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
## What
Splits the onboarding flow so the user-visible wizard completes inline and
the long-running crawl + Nexus content upload run in the background.
- `ConfigureAgentBuilderUseCase` now only configures the agent manager and
  bumps progress to 75%; content upload moved to a new background-only
  `UploadNexusContentsUseCase` (dispatched on `crawl.completed`).
- New `agent_builder_helpers` centralizes "load onboarding + linked project"
  and the idempotent "ensure manager configured" contract shared by both paths.
- New `SaveBackgroundFailureUseCase` records crawl/upload failures under
  `config["background_error"]` WITHOUT flipping `onboarding.failed`.
- `StartCrawlUseCase` soft-fails on crawler-comms errors; the wizard no
  longer 502s (removed `CrawlerStartError` path from the view).
- `task_upload_nexus_contents` added; `task_configure_nexus` /
  `task_wait_and_start_crawl` kept as deprecated aliases for in-flight jobs.
## Why
The crawl is slow and no longer mandatory for the wizard to finish. Coupling
it to the progress bar blocked completion and surfaced background failures as
hard wizard failures. Decoupling lets the user finish onboarding immediately
while content ingestion completes asynchronously.