### PR TITLE
feat: enhance AssignAgentUseCase to drop non-interactive headers footers

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -396,8 +396,11 @@ class AssignAgentUseCase:
                 integrated_agent=integrated_agent,
             )
 
+            content_metadata = dict(content["metadata"])
+            self._drop_non_interactive_header_footer(content_metadata)
+
             template.metadata = {
-                **content["metadata"],
+                **content_metadata,
                 "direct_send": {
                     "fetched_from_meta_library": True,
                     "fetched_at": datetime.now(timezone.utc).isoformat(),
@@ -476,6 +479,22 @@ class AssignAgentUseCase:
             )
 
         return content, actual_language
+
+    def _drop_non_interactive_header_footer(self, metadata: Dict[str, Any]) -> None:
+        """Strip components Meta can't render without an interactive type.
+
+        Meta only accepts header/footer when the message carries a URL CTA
+        or quick replies. A button-less template would dispatch as a plain
+        text message, which Meta rejects if it has a text header/footer, so
+        we never persist those. Image headers survive (they travel as a
+        media attachment).
+        """
+        if metadata.get("buttons"):
+            return
+        metadata.pop("footer", None)
+        header = metadata.get("header")
+        if header and header.get("header_type") == "TEXT":
+            metadata.pop("header", None)
 
     def _safely_fetch_direct_send_metadata(
         self, template_name: str, language: str

--- a/retail/agents/tests/usecases/test_assign_direct_send.py
+++ b/retail/agents/tests/usecases/test_assign_direct_send.py
@@ -585,3 +585,117 @@ class AssignDirectSendReassignmentTest(AssignDirectSendBaseTest):
             self.assertIsNotNone(ds_meta)
             self.assertEqual(ds_meta["actual_language"], "es_MX")
             self.assertEqual(ds_meta["requested_language"], "es_MX")
+
+
+class AssignDirectSendDropsHeaderFooterWhenNonInteractiveTest(AssignDirectSendBaseTest):
+    """Templates without interactive buttons must not persist header/footer.
+
+    Meta rejects a plain text message that carries a text header/footer,
+    so the assignment path drops them before persistence.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.integrations_service.get_channel_app.return_value = {
+            "config": {"direct_send": True}
+        }
+        self.meta_service.fetch_library_template_by_name_and_language.side_effect = (
+            lambda name, language: {
+                "name": name,
+                "language": language,
+                "category": "UTILITY",
+                "body": "Olá {{1}}, seu pedido {{2}}.",
+                "body_params": ["customer_name", "order_id"],
+                "footer": "Equipe Loja",
+                "header": "Pedido enviado",
+                "buttons": [],
+            }
+        )
+
+    def test_persists_templates_without_header_and_footer(self):
+        with override_settings(
+            ORDER_STATUS_AGENT_UUID=str(self.order_status_agent_uuid)
+        ):
+            integrated_agent = self.use_case.execute(
+                agent=self.order_status_agent,
+                project_uuid=self.project.uuid,
+                app_uuid=uuid4(),
+                channel_uuid=uuid4(),
+                credentials={},
+                include_templates=[
+                    str(self.template_a.uuid),
+                    str(self.template_b.uuid),
+                ],
+            )
+
+        templates = Template.objects.filter(integrated_agent=integrated_agent)
+        self.assertEqual(templates.count(), 2)
+        for template in templates:
+            self.assertNotIn("header", template.metadata)
+            self.assertNotIn("footer", template.metadata)
+            self.assertIn("body", template.metadata)
+
+
+class AssignDirectSendPreservesHeaderFooterWhenInteractiveTest(
+    AssignDirectSendBaseTest
+):
+    """Templates with interactive buttons keep header and footer."""
+
+    def setUp(self):
+        super().setUp()
+        self.integrations_service.get_channel_app.return_value = {
+            "config": {"direct_send": True}
+        }
+
+    def test_quick_reply_keeps_header_and_footer(self):
+        with override_settings(
+            ORDER_STATUS_AGENT_UUID=str(self.order_status_agent_uuid)
+        ):
+            integrated_agent = self.use_case.execute(
+                agent=self.order_status_agent,
+                project_uuid=self.project.uuid,
+                app_uuid=uuid4(),
+                channel_uuid=uuid4(),
+                credentials={},
+                include_templates=[
+                    str(self.template_a.uuid),
+                    str(self.template_b.uuid),
+                ],
+            )
+
+        templates = Template.objects.filter(integrated_agent=integrated_agent)
+        self.assertEqual(templates.count(), 2)
+        for template in templates:
+            self.assertEqual(
+                template.metadata["header"],
+                {"header_type": "TEXT", "text": "Pedido enviado"},
+            )
+            self.assertEqual(template.metadata["footer"], "Equipe Loja")
+
+
+class DropNonInteractiveHeaderFooterHelperTest(AssignDirectSendBaseTest):
+    """Direct unit coverage for `_drop_non_interactive_header_footer`."""
+
+    def test_keeps_image_header_when_non_interactive(self):
+        metadata = {
+            "header": {"header_type": "IMAGE", "text": "s3-key"},
+            "footer": "Equipe Loja",
+            "buttons": [],
+        }
+        self.use_case._drop_non_interactive_header_footer(metadata)
+
+        self.assertEqual(metadata["header"], {"header_type": "IMAGE", "text": "s3-key"})
+        self.assertNotIn("footer", metadata)
+
+    def test_preserves_components_when_buttons_present(self):
+        metadata = {
+            "header": {"header_type": "TEXT", "text": "Pedido enviado"},
+            "footer": "Equipe Loja",
+            "buttons": [{"type": "QUICK_REPLY", "text": "Sim"}],
+        }
+        self.use_case._drop_non_interactive_header_footer(metadata)
+
+        self.assertEqual(
+            metadata["header"], {"header_type": "TEXT", "text": "Pedido enviado"}
+        )
+        self.assertEqual(metadata["footer"], "Equipe Loja")


### PR DESCRIPTION
## What
When materializing Direct Send library templates during agent assignment
(`AssignAgentUseCase._create_direct_send_library_templates`), strip the
text header and footer from a template's metadata when it has no
interactive buttons. The fetched metadata is shallow-copied first, so the
original adapter response is left untouched, and the new
`_drop_non_interactive_header_footer` helper only removes a `TEXT` header —
image headers are preserved since they travel as a media attachment.
Touched files:
- `retail/agents/domains/agent_integration/usecases/assign.py`
- `retail/agents/tests/usecases/test_assign_direct_send.py`

## Why
Meta only renders a header/footer when the message carries an interactive
type (URL CTA or quick replies). A button-less template dispatches as a
plain text message; if it still carries a text header/footer, Meta rejects
the send. Dropping these components at persistence time keeps the stored
metadata dispatchable.