### PR TITLE
feat: Skip Fulfillment order events and add vtex_account to lambda logs

### DIFF
--- a/retail/agents/domains/agent_webhook/services/active_agent.py
+++ b/retail/agents/domains/agent_webhook/services/active_agent.py
@@ -88,6 +88,7 @@ class ActiveAgent:
         """Validate lambda response for errors based on status codes."""
         status_code = data.get("status")
         error = data.get("error")
+        vtex_account = integrated_agent.project.vtex_account
 
         if status_code is not None:
             match status_code:
@@ -95,42 +96,52 @@ class ActiveAgent:
                     return True
                 case ActiveAgentResponseStatus.RULE_NOT_MATCHED:
                     logger.info(
-                        f"Rule not matched for integrated agent {integrated_agent.uuid}: {error}"
+                        f"Rule not matched for integrated agent {integrated_agent.uuid}: "
+                        f"vtex_account={vtex_account} error={error}"
                     )
                     return False
                 case ActiveAgentResponseStatus.PRE_PROCESSING_FAILED:
                     logger.info(
-                        f"Pre-processing failed for integrated agent {integrated_agent.uuid}: {error}"
+                        f"Pre-processing failed for integrated agent {integrated_agent.uuid}: "
+                        f"vtex_account={vtex_account} error={error}"
                     )
                     return False
                 case ActiveAgentResponseStatus.CUSTOM_RULE_FAILED:
                     logger.info(
-                        f"Custom rule failed for integrated agent {integrated_agent.uuid}: {error}"
+                        f"Custom rule failed for integrated agent {integrated_agent.uuid}: "
+                        f"vtex_account={vtex_account} error={error}"
                     )
                     return False
                 case ActiveAgentResponseStatus.OFFICIAL_RULE_FAILED:
                     logger.info(
-                        f"Official rule failed for integrated agent {integrated_agent.uuid}: {error}"
+                        f"Official rule failed for integrated agent {integrated_agent.uuid}: "
+                        f"vtex_account={vtex_account} error={error}"
                     )
                     return False
                 case ActiveAgentResponseStatus.GLOBAL_RULE_FAILED:
                     logger.info(
-                        f"Global rule failed for integrated agent {integrated_agent.uuid}: {error}"
+                        f"Global rule failed for integrated agent {integrated_agent.uuid}: "
+                        f"vtex_account={vtex_account} error={error}"
                     )
                     return False
                 case ActiveAgentResponseStatus.GLOBAL_RULE_NOT_MATCHED:
                     logger.info(
-                        f"Global rule not matched for integrated agent {integrated_agent.uuid}: {error}"
+                        f"Global rule not matched for integrated agent {integrated_agent.uuid}: "
+                        f"vtex_account={vtex_account} error={error}"
                     )
                     return False
                 case _:
                     logger.warning(
-                        f"Unknown status code for integrated agent {integrated_agent.uuid}: {status_code}"
+                        f"Unknown status code for integrated agent {integrated_agent.uuid}: "
+                        f"vtex_account={vtex_account} status_code={status_code}"
                     )
                     return False
 
         if isinstance(data, dict) and "errorMessage" in data:
-            logger.error(f"Lambda execution error: {data.get('errorMessage')}")
+            logger.error(
+                f"Lambda execution error: vtex_account={vtex_account} "
+                f"errorMessage={data.get('errorMessage')}"
+            )
             return False
 
         return False

--- a/retail/agents/domains/agent_webhook/usecases/order_status.py
+++ b/retail/agents/domains/agent_webhook/usecases/order_status.py
@@ -22,6 +22,10 @@ from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 
 logger = logging.getLogger(__name__)
 
+# Dropped before dedup so it does not register the key and discard the
+# equivalent "Marketplace" event the agent actually needs.
+FULFILLMENT_DOMAIN = "Fulfillment"
+
 
 def adapt_order_status_to_webhook_payload(
     order_status_dto: OrderStatusDTO,
@@ -178,6 +182,21 @@ class AgentOrderStatusUpdateUsecase:
             )
             return None
 
+    def _is_fulfillment_domain(self, order_status_dto: OrderStatusDTO) -> bool:
+        """Check whether the event belongs to the VTEX ``Fulfillment`` domain.
+
+        The ``Fulfillment`` event mirrors the ``Marketplace`` one the agent
+        already handles, so it must neither be processed nor counted for
+        deduplication.
+
+        Args:
+            order_status_dto (OrderStatusDTO): The order status event payload.
+
+        Returns:
+            bool: True when the event domain is ``Fulfillment``, otherwise False.
+        """
+        return order_status_dto.domain == FULFILLMENT_DOMAIN
+
     def _is_duplicate_event(
         self,
         integrated_agent: IntegratedAgent,
@@ -217,6 +236,14 @@ class AgentOrderStatusUpdateUsecase:
         current_state = order_status_dto.currentState
         order_id = order_status_dto.orderId
         agent_uuid = integrated_agent.uuid
+
+        if self._is_fulfillment_domain(order_status_dto):
+            logger.info(
+                f"[ORDER_STATUS] fulfillment_domain_skipped: "
+                f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+                f"current_state={current_state} order_id={order_id}"
+            )
+            return
 
         if self._is_duplicate_event(integrated_agent, order_status_dto):
             logger.info(

--- a/retail/agents/domains/agent_webhook/usecases/webhook.py
+++ b/retail/agents/domains/agent_webhook/usecases/webhook.py
@@ -113,10 +113,14 @@ class AgentWebhookUseCase:
         dispatch_context: Optional[BroadcastDispatchContext] = None,
     ) -> Optional[Dict[str, Any]]:
         """Process lambda response and build broadcast message."""
+        vtex_account = integrated_agent.project.vtex_account
         data = self.active_agent.parse_response(response)
 
         if not data:
-            logger.info("Error in parsing lambda response.")
+            logger.info(
+                f"Error in parsing lambda response. "
+                f"vtex_account={vtex_account} agent={integrated_agent.uuid}"
+            )
             return None
 
         response["payload"] = data
@@ -125,14 +129,19 @@ class AgentWebhookUseCase:
             return None
 
         if not self.broadcast_handler.can_send_to_contact(integrated_agent, data):
-            logger.info("Contact is not allowed to receive the broadcast.")
+            logger.info(
+                f"Contact is not allowed to receive the broadcast. "
+                f"vtex_account={vtex_account} agent={integrated_agent.uuid}"
+            )
             return None
 
         try:
             message = self.broadcast_handler.build_message(integrated_agent, data)
             if not message:
                 logger.info(
-                    f"Failed to build broadcast message from payload data: {data}"
+                    f"Failed to build broadcast message from payload data: "
+                    f"vtex_account={vtex_account} agent={integrated_agent.uuid} "
+                    f"data={data}"
                 )
                 return None
 

--- a/retail/agents/tests/services/test_active_agent.py
+++ b/retail/agents/tests/services/test_active_agent.py
@@ -197,12 +197,60 @@ class ActiveAgentTest(TestCase):
 
         self.assertFalse(result)
 
+    def test_validate_response_rejection_log_includes_vtex_account(self):
+        data = {
+            "status": ActiveAgentResponseStatus.RULE_NOT_MATCHED,
+            "error": "No rule matched",
+        }
+
+        with self.assertLogs(
+            "retail.agents.domains.agent_webhook.services.active_agent",
+            level="INFO",
+        ) as captured:
+            self.handler.validate_response(data, self.mock_agent)
+
+        self.assertTrue(
+            any(
+                "Rule not matched" in line and "vtex_account=test_account" in line
+                for line in captured.output
+            ),
+            captured.output,
+        )
+
+    def test_validate_response_unknown_status_log_includes_vtex_account(self):
+        data = {"status": 999, "error": "Unknown error"}
+
+        with self.assertLogs(
+            "retail.agents.domains.agent_webhook.services.active_agent",
+            level="WARNING",
+        ) as captured:
+            self.handler.validate_response(data, self.mock_agent)
+
+        self.assertTrue(
+            any("vtex_account=test_account" in line for line in captured.output),
+            captured.output,
+        )
+
     def test_validate_response_error_message(self):
         data = {"errorMessage": "Some error"}
 
         result = self.handler.validate_response(data, self.mock_agent)
 
         self.assertFalse(result)
+
+    def test_validate_response_error_message_log_includes_vtex_account(self):
+        data = {"errorMessage": "Some error"}
+
+        with self.assertLogs(
+            "retail.agents.domains.agent_webhook.services.active_agent",
+            level="ERROR",
+        ) as captured:
+            self.handler.validate_response(data, self.mock_agent)
+
+        self.assertTrue(
+            any("vtex_account=test_account" in line for line in captured.output),
+            captured.output,
+        )
 
     def test_validate_response_no_status_no_error_message(self):
         data = {"template": "order_update", "contact_urn": "whatsapp:123"}

--- a/retail/agents/tests/usecases/test_agent_webhook.py
+++ b/retail/agents/tests/usecases/test_agent_webhook.py
@@ -143,6 +143,27 @@ class AgentWebhookUseCaseTest(TestCase):
         result = self.usecase.execute(self.mock_agent, MagicMock())
         self.assertIsNone(result)
 
+    def test_execute_parse_response_failure_logs_vtex_account(self):
+        self.mock_lambda_handler.invoke.return_value = {"Payload": MagicMock()}
+        self.mock_lambda_handler.parse_response.return_value = None
+
+        with self.assertLogs(
+            "retail.agents.domains.agent_webhook.usecases.webhook",
+            level="INFO",
+        ) as captured:
+            result = self.usecase.execute(self.mock_agent, MagicMock())
+
+        self.assertIsNone(result)
+        self.mock_broadcast_handler.build_message.assert_not_called()
+        self.assertTrue(
+            any(
+                "Error in parsing lambda response" in line
+                and "vtex_account=test_account" in line
+                for line in captured.output
+            ),
+            captured.output,
+        )
+
     def test_execute_missing_template_error(self):
         mock_response = {"Payload": MagicMock()}
         self.mock_lambda_handler.invoke.return_value = mock_response

--- a/retail/agents/tests/usecases/test_order_status_update.py
+++ b/retail/agents/tests/usecases/test_order_status_update.py
@@ -303,6 +303,7 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
         mock_order_status_dto = MagicMock(spec=OrderStatusDTO)
         mock_order_status_dto.orderId = "order-id"
         mock_order_status_dto.currentState = "invoiced"
+        mock_order_status_dto.domain = "Marketplace"
         mock_order_status_dto.vtexAccount = "test-account"
 
         mock_agent_webhook_use_case = MagicMock()
@@ -312,6 +313,24 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
 
         mock_agent_webhook_use_case_cls.assert_not_called()
         mock_agent_webhook_use_case.execute.assert_not_called()
+
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    def test_execute_skips_fulfillment_domain_before_dedup(
+        self, mock_agent_webhook_use_case_cls, mock_cache
+    ):
+        mock_order_status_dto = MagicMock(spec=OrderStatusDTO)
+        mock_order_status_dto.orderId = "order-id"
+        mock_order_status_dto.currentState = "invoiced"
+        mock_order_status_dto.domain = "Fulfillment"
+        mock_order_status_dto.vtexAccount = "test-account"
+
+        self.usecase.execute(self.mock_integrated_agent, mock_order_status_dto)
+
+        mock_cache.add.assert_not_called()
+        mock_agent_webhook_use_case_cls.assert_not_called()
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")


### PR DESCRIPTION
## What

Two adjustments to the order-status agent flow:

1. **`Fulfillment` domain filter**: VTEX emits the same event under both the
   `Marketplace` and `Fulfillment` domains with the same `orderId`/`currentState`.
   Since the dedup key does not include the domain, the `Fulfillment` event was
   registering the key first and discarding the `Marketplace` one (the event the
   agent actually needs). `AgentOrderStatusUpdateUsecase.execute` now drops
   `Fulfillment` events before the deduplication check.
2. **Tenant context in logs**: the Lambda response rejection logs
   (`validate_response` in `active_agent.py`) and the response processing logs
   (`_process_lambda_response` in `webhook.py`) now include `vtex_account`, which
   previously showed only the integrated agent uuid.

Files: `active_agent.py`, `order_status.py`, `webhook.py` (plus tests).

## Why

When the `Fulfillment` event arrived first, the agent invoked the Lambda with an
event lacking the marketplace context, breaking the flow. Additionally, the
absence of `vtex_account` in the Lambda response logs made per-account analysis
in production difficult.
