### PR TITLE
feat: Add minimum order value rule to PIX recovery automation

### DIFF
--- a/retail/agents/domains/agent_integration/serializers.py
+++ b/retail/agents/domains/agent_integration/serializers.py
@@ -4,6 +4,9 @@ from django.conf import settings
 
 from retail.templates.serializers import ReadTemplateSerializer
 from retail.agents.domains.agent_management.usecases.push import PushAgentUseCase
+from retail.agents.domains.agent_integration.usecases.payment_recovery import (
+    DEFAULT_DELAY_MINUTES,
+)
 
 
 class DeliveredOrderTrackingEnableSerializer(serializers.Serializer):
@@ -81,6 +84,10 @@ class PaymentRecoveryConfigSerializer(PartialUpdateSerializer):
         required=False,
         allow_null=True,
         min_value=0,
+    )
+    delay_minutes = serializers.IntegerField(
+        required=False,
+        min_value=1,
     )
 
 
@@ -189,6 +196,9 @@ class ReadIntegratedAgentSerializer(serializers.Serializer):
 
         return {
             "minimum_order_value": payment_recovery_config.get("minimum_order_value"),
+            "delay_minutes": payment_recovery_config.get(
+                "delay_minutes", DEFAULT_DELAY_MINUTES
+            ),
         }
 
 

--- a/retail/agents/domains/agent_integration/serializers.py
+++ b/retail/agents/domains/agent_integration/serializers.py
@@ -19,12 +19,31 @@ class RetrieveIntegratedAgentQueryParamsSerializer(serializers.Serializer):
     end = serializers.DateField(required=False, default=None)
 
 
-class AbandonedCartConfigSerializer(serializers.Serializer):
-    """
-    Serializer for abandoned cart configuration.
+class PartialUpdateSerializer(serializers.Serializer):
+    """Base serializer that only validates fields present in the payload.
 
-    Supports partial updates - only fields that are explicitly sent will be updated.
-    Fields not included in the request will not be modified.
+    Enables true partial updates: fields omitted from the request are left
+    untouched instead of being reset to their defaults.
+    """
+
+    def to_internal_value(self, data):
+        validated_data = {}
+
+        for field_name, field in self.fields.items():
+            if field_name in data:
+                try:
+                    validated_data[field_name] = field.run_validation(data[field_name])
+                except serializers.ValidationError as exc:
+                    raise serializers.ValidationError({field_name: exc.detail})
+
+        return validated_data
+
+
+class AbandonedCartConfigSerializer(PartialUpdateSerializer):
+    """Serializer for abandoned cart configuration.
+
+    Supports partial updates: only fields that are explicitly sent are
+    updated; fields omitted from the request are not modified.
     """
 
     header_image_type = serializers.ChoiceField(
@@ -49,50 +68,32 @@ class AbandonedCartConfigSerializer(serializers.Serializer):
         max_value=168,  # Max 7 days
     )
 
-    def to_internal_value(self, data):
-        """
-        Override to only include fields that were actually sent in the request.
-        This enables true partial updates where only specified fields are modified.
-        """
-        # Get the validated data for fields that were actually provided
-        validated_data = {}
 
-        for field_name, field in self.fields.items():
-            if field_name in data:
-                try:
-                    validated_data[field_name] = field.run_validation(data[field_name])
-                except serializers.ValidationError as exc:
-                    raise serializers.ValidationError({field_name: exc.detail})
+class PaymentRecoveryConfigSerializer(PartialUpdateSerializer):
+    """Serializer for payment recovery (PIX) configuration.
 
-        return validated_data
-
-
-class UpdateIntegratedAgentSerializer(serializers.Serializer):
+    Supports partial updates: only fields that are explicitly sent are
+    updated. A null ``minimum_order_value`` means no threshold: every
+    recovery request is dispatched regardless of the order value.
     """
-    Serializer for updating integrated agent.
 
-    Supports partial updates - only fields that are explicitly sent will be updated.
+    minimum_order_value = serializers.FloatField(
+        required=False,
+        allow_null=True,
+        min_value=0,
+    )
+
+
+class UpdateIntegratedAgentSerializer(PartialUpdateSerializer):
+    """Serializer for updating an integrated agent.
+
+    Supports partial updates: only fields that are explicitly sent are updated.
     """
 
     contact_percentage = serializers.IntegerField(required=False)
     global_rule = serializers.CharField(required=False, allow_null=True)
     abandoned_cart_config = AbandonedCartConfigSerializer(required=False)
-
-    def to_internal_value(self, data):
-        """
-        Override to only include fields that were actually sent in the request.
-        This enables true partial updates where only specified fields are modified.
-        """
-        validated_data = {}
-
-        for field_name, field in self.fields.items():
-            if field_name in data:
-                try:
-                    validated_data[field_name] = field.run_validation(data[field_name])
-                except serializers.ValidationError as exc:
-                    raise serializers.ValidationError({field_name: exc.detail})
-
-        return validated_data
+    payment_recovery_config = PaymentRecoveryConfigSerializer(required=False)
 
 
 class ReadIntegratedAgentSerializer(serializers.Serializer):
@@ -114,6 +115,9 @@ class ReadIntegratedAgentSerializer(serializers.Serializer):
     )
     abandoned_cart_config = serializers.SerializerMethodField(
         "get_abandoned_cart_config"
+    )
+    payment_recovery_config = serializers.SerializerMethodField(
+        "get_payment_recovery_config"
     )
     direct_send = serializers.SerializerMethodField("get_direct_send")
 
@@ -173,6 +177,18 @@ class ReadIntegratedAgentSerializer(serializers.Serializer):
             "notification_cooldown_hours": abandoned_cart_config.get(
                 "notification_cooldown_hours"
             ),
+        }
+
+    def get_payment_recovery_config(self, obj):
+        """Get payment recovery (PIX) configuration from agent config."""
+        payment_recovery_config = obj.config.get("payment_recovery", {})
+
+        # Only return if there's actual configuration
+        if not payment_recovery_config:
+            return None
+
+        return {
+            "minimum_order_value": payment_recovery_config.get("minimum_order_value"),
         }
 
 

--- a/retail/agents/domains/agent_integration/usecases/payment_recovery.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Dict, Any
+from decimal import Decimal
+from typing import Dict, Any, Optional
 from uuid import UUID
 
 from rest_framework.exceptions import NotFound, ValidationError
@@ -8,6 +9,7 @@ from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_webhook.usecases.order_status import (
     AgentOrderStatusUpdateUsecase,
 )
+from retail.services.vtex_io.service import VtexIOService
 from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 
 logger = logging.getLogger(__name__)
@@ -19,9 +21,17 @@ DEFAULT_DELAY_MINUTES = 5
 class PaymentRecoveryWebhookUseCase:
     """Use case for processing payment recovery webhook notifications from VTEX."""
 
-    def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
+    def __init__(self, vtex_io_service: Optional[VtexIOService] = None):
+        """Initialize the use case with its VTEX IO dependency.
+
+        Args:
+            vtex_io_service: Service used to fetch order details from VTEX.
+                Defaults to a concrete ``VtexIOService`` instance.
         """
-        Retrieve an integrated agent by UUID.
+        self.vtex_io_service = vtex_io_service or VtexIOService()
+
+    def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
+        """Retrieve an integrated agent by UUID.
 
         Args:
             integrated_agent_uuid: UUID of the integrated agent.
@@ -38,11 +48,17 @@ class PaymentRecoveryWebhookUseCase:
             raise NotFound(f"Integrated agent not found: {integrated_agent_uuid}")
 
     def get_delay_seconds(self, integrated_agent_uuid: UUID) -> int:
-        """
-        Get the configured delay in seconds for scheduling the processing task.
+        """Get the configured delay in seconds for scheduling the processing task.
 
-        Reads delay_minutes from integrated_agent.config["payment_recovery"].
-        Falls back to DEFAULT_DELAY_MINUTES if agent or config is not found.
+        Reads ``delay_minutes`` from ``integrated_agent.config["payment_recovery"]``
+        and falls back to ``DEFAULT_DELAY_MINUTES`` when the agent or config
+        is not found.
+
+        Args:
+            integrated_agent_uuid: UUID of the integrated agent.
+
+        Returns:
+            int: The delay in seconds before processing the webhook.
         """
         try:
             integrated_agent = IntegratedAgent.objects.get(
@@ -57,8 +73,7 @@ class PaymentRecoveryWebhookUseCase:
     def validate_payment_recovery_enabled(
         self, integrated_agent: IntegratedAgent
     ) -> None:
-        """
-        Validate that payment recovery is enabled for the integrated agent.
+        """Validate that payment recovery is enabled for the integrated agent.
 
         Args:
             integrated_agent: The integrated agent to validate.
@@ -73,8 +88,7 @@ class PaymentRecoveryWebhookUseCase:
     def process_webhook_notification(
         self, integrated_agent: IntegratedAgent, webhook_data: Dict[str, Any]
     ) -> Dict[str, str]:
-        """
-        Process a VTEX payment recovery webhook notification.
+        """Process a VTEX payment recovery webhook notification.
 
         Validates that payment recovery is enabled, builds an OrderStatusDTO
         and delegates to AgentOrderStatusUpdateUsecase — same pattern as
@@ -98,26 +112,20 @@ class PaymentRecoveryWebhookUseCase:
             f"data={webhook_data}"
         )
 
-        self._process_payment_recovery_notification(
+        return self._process_payment_recovery_notification(
             integrated_agent, webhook_data, vtex_account
         )
-
-        return {
-            "status": "success",
-            "message": "Payment recovery notification processed",
-        }
 
     def _process_payment_recovery_notification(
         self,
         integrated_agent: IntegratedAgent,
         webhook_data: Dict[str, Any],
         vtex_account: str,
-    ) -> None:
-        """
-        Build an OrderStatusDTO with ``currentState="payment-pending"``
-        and delegate to AgentOrderStatusUpdateUsecase.
+    ) -> Dict[str, str]:
+        """Build an OrderStatusDTO and delegate to AgentOrderStatusUpdateUsecase.
 
-        The raw VTEX state (often ``"unknow"``) is stored as ``lastState``
+        The DTO is built with ``currentState="payment-pending"``. The raw
+        VTEX state (often ``"unknow"``) is stored as ``lastState``
         while ``currentState`` is hardcoded because the payment recovery
         hook only fires for orders awaiting payment.
 
@@ -125,9 +133,19 @@ class PaymentRecoveryWebhookUseCase:
             integrated_agent: The integrated agent that owns the webhook.
             webhook_data: Raw data received from the VTEX webhook.
             vtex_account: The VTEX account identifier for the project.
+
+        Returns:
+            Dict[str, str]: ``status``/``message`` describing whether the
+            notification was dispatched or skipped below the minimum value.
         """
         agent_uuid = integrated_agent.uuid
         order_id = webhook_data.get("OrderId")
+
+        if self._is_below_minimum_order_value(integrated_agent, order_id, vtex_account):
+            return {
+                "status": "skipped",
+                "message": "Order value below configured minimum",
+            }
 
         logger.info(
             f"[PAYMENT_RECOVERY] converting_state: "
@@ -154,3 +172,106 @@ class PaymentRecoveryWebhookUseCase:
             f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
             f"current_state=payment-pending order_id={order_id}"
         )
+
+        return {
+            "status": "success",
+            "message": "Payment recovery notification processed",
+        }
+
+    def _is_below_minimum_order_value(
+        self,
+        integrated_agent: IntegratedAgent,
+        order_id: Optional[str],
+        vtex_account: str,
+    ) -> bool:
+        """Decide whether the recovery dispatch must be skipped by minimum value.
+
+        No threshold (``minimum_order_value`` is ``None`` or absent) means
+        every recovery request is dispatched. When a threshold is set but the
+        order value cannot be resolved from VTEX, the dispatch proceeds to
+        avoid dropping a legitimate recovery on a transient lookup failure.
+
+        Args:
+            integrated_agent: The integrated agent that owns the webhook.
+            order_id: VTEX order identifier from the webhook payload.
+            vtex_account: The VTEX account identifier for the project.
+
+        Returns:
+            bool: ``True`` when the dispatch must be skipped because the order
+            value is below the configured minimum, ``False`` otherwise.
+        """
+        payment_config = integrated_agent.config.get("payment_recovery", {})
+        minimum_value = payment_config.get("minimum_order_value")
+
+        if minimum_value is None:
+            return False
+
+        order_value = self._get_order_value(order_id, vtex_account)
+        if order_value is None:
+            logger.warning(
+                f"[PAYMENT_RECOVERY] minimum_value_unresolved: "
+                f"vtex_account={vtex_account} agent_uuid={integrated_agent.uuid} "
+                f"order_id={order_id} minimum_order_value={minimum_value} "
+                f"action=dispatch reason=order_value_unavailable"
+            )
+            return False
+
+        if order_value < Decimal(str(minimum_value)):
+            logger.info(
+                f"[PAYMENT_RECOVERY] skipped_below_minimum_value: "
+                f"vtex_account={vtex_account} agent_uuid={integrated_agent.uuid} "
+                f"order_id={order_id} order_value={order_value} "
+                f"minimum_order_value={minimum_value}"
+            )
+            return True
+
+        return False
+
+    def _get_order_value(
+        self, order_id: Optional[str], vtex_account: str
+    ) -> Optional[Decimal]:
+        """Resolve the order total (in major units) from the VTEX order details.
+
+        VTEX returns ``order.value`` in minor units (cents), so the value is
+        divided by 100 and rounded to two decimal places.
+
+        Args:
+            order_id: VTEX order identifier from the webhook payload.
+            vtex_account: The VTEX account identifier for the project.
+
+        Returns:
+            Optional[Decimal]: The order total in major units, or ``None`` when
+            the order id is missing, the lookup fails or the value is absent.
+
+        Example:
+            A VTEX ``value`` of ``2047`` (cents) resolves to
+            ``Decimal("20.47")`` (R$ 20.47).
+        """
+        if not order_id:
+            return None
+
+        account_domain = f"{vtex_account}.myvtex.com"
+        try:
+            order_details = self.vtex_io_service.get_order_details_by_id(
+                account_domain=account_domain,
+                vtex_account=vtex_account,
+                order_id=order_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                f"[PAYMENT_RECOVERY] order_lookup_failed: "
+                f"vtex_account={vtex_account} order_id={order_id} error={exc}"
+            )
+            return None
+
+        if not order_details:
+            return None
+
+        raw_value = order_details.get("value")
+        if raw_value in (None, ""):
+            return None
+
+        try:
+            return (Decimal(raw_value) / Decimal(100)).quantize(Decimal("0.01"))
+        except (TypeError, ValueError, ArithmeticError):
+            return None

--- a/retail/agents/domains/agent_integration/usecases/update.py
+++ b/retail/agents/domains/agent_integration/usecases/update.py
@@ -22,22 +22,48 @@ class AbandonedCartConfigData(TypedDict, total=False):
     notification_cooldown_hours: Optional[int]
 
 
+class PaymentRecoveryConfigData(TypedDict, total=False):
+    minimum_order_value: Optional[float]
+
+
 class UpdateIntegratedAgentData(TypedDict, total=False):
     contact_percentage: Optional[int]
     global_rule: Optional[str]
     abandoned_cart_config: Optional[AbandonedCartConfigData]
+    payment_recovery_config: Optional[PaymentRecoveryConfigData]
 
 
 class UpdateIntegratedAgentUseCase:
+    """Apply partial updates to an integrated agent and invalidate its cache."""
+
     def __init__(
         self,
         global_rule: Optional[GlobalRule] = None,
         cache_handler: Optional[IntegratedAgentCacheHandler] = None,
     ):
+        """Initialize the use case with its collaborators.
+
+        Args:
+            global_rule: Service that generates and validates the global rule
+                code. Defaults to a concrete ``GlobalRule`` instance.
+            cache_handler: Handler used to invalidate cached agent data.
+                Defaults to a concrete ``IntegratedAgentCacheHandlerRedis``.
+        """
         self.global_rule = global_rule or GlobalRule()
         self.cache_handler = cache_handler or IntegratedAgentCacheHandlerRedis()
 
     def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
+        """Retrieve an active integrated agent by UUID.
+
+        Args:
+            integrated_agent_uuid: UUID of the integrated agent.
+
+        Returns:
+            IntegratedAgent: The matching active integrated agent instance.
+
+        Raises:
+            NotFound: If no active integrated agent exists with the given UUID.
+        """
         try:
             return IntegratedAgent.objects.get(
                 uuid=integrated_agent_uuid, is_active=True
@@ -51,6 +77,21 @@ class UpdateIntegratedAgentUseCase:
     def execute(
         self, integrated_agent: IntegratedAgent, data: UpdateIntegratedAgentData
     ) -> IntegratedAgent:
+        """Apply the provided partial update and invalidate the agent cache.
+
+        Only the keys present in ``data`` are updated; omitted keys are left
+        untouched.
+
+        Args:
+            integrated_agent: The integrated agent to update.
+            data: Partial update payload validated by the serializer.
+
+        Returns:
+            IntegratedAgent: The updated integrated agent instance.
+
+        Raises:
+            ValidationError: If ``contact_percentage`` is outside 0-100.
+        """
         if "contact_percentage" in data:
             contact_percentage = data.get("contact_percentage")
 
@@ -80,6 +121,12 @@ class UpdateIntegratedAgentUseCase:
             abandoned_cart_config = data.get("abandoned_cart_config")
             self._update_abandoned_cart_config(integrated_agent, abandoned_cart_config)
 
+        if "payment_recovery_config" in data:
+            payment_recovery_config = data.get("payment_recovery_config")
+            self._update_payment_recovery_config(
+                integrated_agent, payment_recovery_config
+            )
+
         integrated_agent.save()
 
         self.cache_handler.invalidate_all_for(integrated_agent)
@@ -91,10 +138,13 @@ class UpdateIntegratedAgentUseCase:
         integrated_agent: IntegratedAgent,
         config_data: Optional[AbandonedCartConfigData],
     ) -> None:
-        """
-        Update abandoned cart configuration in the integrated agent's config.
+        """Update abandoned cart configuration in the integrated agent's config.
 
-        Only updates the fields that are provided in config_data.
+        Only updates the fields provided in ``config_data``.
+
+        Args:
+            integrated_agent: The integrated agent whose config will be updated.
+            config_data: Partial abandoned cart config; ``None`` is a no-op.
         """
         if config_data is None:
             return
@@ -128,4 +178,37 @@ class UpdateIntegratedAgentUseCase:
         logger.info(
             f"Updated abandoned cart config for agent {integrated_agent.uuid}: "
             f"{abandoned_cart}"
+        )
+
+    def _update_payment_recovery_config(
+        self,
+        integrated_agent: IntegratedAgent,
+        config_data: Optional[PaymentRecoveryConfigData],
+    ) -> None:
+        """Update payment recovery (PIX) configuration in the integrated agent's config.
+
+        Only updates the fields provided in ``config_data``, preserving
+        infrastructure keys (e.g. ``hook_created``, ``delay_minutes``) set
+        during agent assignment.
+
+        Args:
+            integrated_agent: The integrated agent whose config will be updated.
+            config_data: Partial payment recovery config; ``None`` is a no-op.
+        """
+        if config_data is None:
+            return
+
+        if integrated_agent.config is None:
+            integrated_agent.config = {}
+
+        payment_recovery = integrated_agent.config.get("payment_recovery", {})
+
+        if "minimum_order_value" in config_data:
+            payment_recovery["minimum_order_value"] = config_data["minimum_order_value"]
+
+        integrated_agent.config["payment_recovery"] = payment_recovery
+
+        logger.info(
+            f"Updated payment recovery config for agent {integrated_agent.uuid}: "
+            f"{payment_recovery}"
         )

--- a/retail/agents/domains/agent_integration/usecases/update.py
+++ b/retail/agents/domains/agent_integration/usecases/update.py
@@ -24,6 +24,7 @@ class AbandonedCartConfigData(TypedDict, total=False):
 
 class PaymentRecoveryConfigData(TypedDict, total=False):
     minimum_order_value: Optional[float]
+    delay_minutes: int
 
 
 class UpdateIntegratedAgentData(TypedDict, total=False):
@@ -205,6 +206,9 @@ class UpdateIntegratedAgentUseCase:
 
         if "minimum_order_value" in config_data:
             payment_recovery["minimum_order_value"] = config_data["minimum_order_value"]
+
+        if "delay_minutes" in config_data:
+            payment_recovery["delay_minutes"] = config_data["delay_minutes"]
 
         integrated_agent.config["payment_recovery"] = payment_recovery
 

--- a/retail/agents/tests/usecases/test_payment_recovery_webhook.py
+++ b/retail/agents/tests/usecases/test_payment_recovery_webhook.py
@@ -87,6 +87,90 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
     @patch(
         "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
     )
+    def test_process_webhook_notification_without_minimum_skips_value_lookup(
+        self, mock_order_usecase_cls
+    ):
+        """No minimum configured: dispatch happens without querying VTEX."""
+        mock_vtex_io = MagicMock()
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        result = use_case.process_webhook_notification(
+            self.mock_integrated_agent, self.webhook_data
+        )
+
+        self.assertEqual(result["status"], "success")
+        mock_vtex_io.get_order_details_by_id.assert_not_called()
+        mock_order_usecase_cls.return_value.execute.assert_called_once()
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
+    )
+    def test_process_webhook_notification_skipped_below_minimum(
+        self, mock_order_usecase_cls
+    ):
+        """Order value below the configured minimum skips the dispatch."""
+        self.mock_integrated_agent.config["payment_recovery"][
+            "minimum_order_value"
+        ] = 100.0
+        mock_vtex_io = MagicMock()
+        # VTEX returns value in cents: 5000 = R$ 50,00 < R$ 100,00
+        mock_vtex_io.get_order_details_by_id.return_value = {"value": 5000}
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        result = use_case.process_webhook_notification(
+            self.mock_integrated_agent, self.webhook_data
+        )
+
+        self.assertEqual(result["status"], "skipped")
+        mock_order_usecase_cls.return_value.execute.assert_not_called()
+        mock_vtex_io.get_order_details_by_id.assert_called_once()
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
+    )
+    def test_process_webhook_notification_dispatches_when_value_meets_minimum(
+        self, mock_order_usecase_cls
+    ):
+        """Order value at/above the minimum dispatches the recovery."""
+        self.mock_integrated_agent.config["payment_recovery"][
+            "minimum_order_value"
+        ] = 100.0
+        mock_vtex_io = MagicMock()
+        # 15000 cents = R$ 150,00 >= R$ 100,00
+        mock_vtex_io.get_order_details_by_id.return_value = {"value": 15000}
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        result = use_case.process_webhook_notification(
+            self.mock_integrated_agent, self.webhook_data
+        )
+
+        self.assertEqual(result["status"], "success")
+        mock_order_usecase_cls.return_value.execute.assert_called_once()
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
+    )
+    def test_process_webhook_notification_dispatches_when_value_unresolved(
+        self, mock_order_usecase_cls
+    ):
+        """A VTEX lookup failure does not drop a legitimate recovery."""
+        self.mock_integrated_agent.config["payment_recovery"][
+            "minimum_order_value"
+        ] = 100.0
+        mock_vtex_io = MagicMock()
+        mock_vtex_io.get_order_details_by_id.side_effect = Exception("boom")
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        result = use_case.process_webhook_notification(
+            self.mock_integrated_agent, self.webhook_data
+        )
+
+        self.assertEqual(result["status"], "success")
+        mock_order_usecase_cls.return_value.execute.assert_called_once()
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
+    )
     def test_process_webhook_notification_disabled_raises(self, mock_order_usecase_cls):
         self.mock_integrated_agent.config = {}
 
@@ -129,3 +213,43 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
         result = self.use_case.get_delay_seconds(self.agent_uuid)
 
         self.assertEqual(result, DEFAULT_DELAY_MINUTES * 60)
+
+    def test_get_order_value_returns_none_when_order_id_missing(self):
+        mock_vtex_io = MagicMock()
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        self.assertIsNone(use_case._get_order_value(None, "testaccount"))
+        mock_vtex_io.get_order_details_by_id.assert_not_called()
+
+    def test_get_order_value_returns_none_when_order_details_empty(self):
+        mock_vtex_io = MagicMock()
+        mock_vtex_io.get_order_details_by_id.return_value = {}
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        self.assertIsNone(use_case._get_order_value("v1234567-01", "testaccount"))
+
+    def test_get_order_value_returns_none_when_value_absent(self):
+        mock_vtex_io = MagicMock()
+        mock_vtex_io.get_order_details_by_id.return_value = {"orderId": "v1234567-01"}
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        self.assertIsNone(use_case._get_order_value("v1234567-01", "testaccount"))
+
+    def test_get_order_value_returns_none_when_value_invalid(self):
+        mock_vtex_io = MagicMock()
+        mock_vtex_io.get_order_details_by_id.return_value = {"value": "abc"}
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        self.assertIsNone(use_case._get_order_value("v1234567-01", "testaccount"))
+
+    def test_get_order_value_converts_cents_to_major_units(self):
+        from decimal import Decimal
+
+        mock_vtex_io = MagicMock()
+        mock_vtex_io.get_order_details_by_id.return_value = {"value": 2047}
+        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+
+        self.assertEqual(
+            use_case._get_order_value("v1234567-01", "testaccount"),
+            Decimal("20.47"),
+        )

--- a/retail/agents/tests/usecases/test_update_integrated_agent.py
+++ b/retail/agents/tests/usecases/test_update_integrated_agent.py
@@ -262,6 +262,23 @@ class UpdateIntegratedAgentUseCaseTest(TestCase):
         )
         self.mock_integrated_agent.save.assert_called_once()
 
+    def test_execute_sets_payment_recovery_delay_minutes(self):
+        """Test setting PIX delay_minutes persists into config."""
+        self.mock_integrated_agent.config = {
+            "payment_recovery": {"hook_created": True, "delay_minutes": 5}
+        }
+        data = {"payment_recovery_config": {"delay_minutes": 15}}
+
+        self.usecase.execute(self.mock_integrated_agent, data)
+
+        self.assertEqual(
+            self.mock_integrated_agent.config["payment_recovery"]["delay_minutes"],
+            15,
+        )
+        self.assertTrue(
+            self.mock_integrated_agent.config["payment_recovery"]["hook_created"]
+        )
+
     def test_execute_clears_payment_recovery_minimum_order_value(self):
         """Test that sending null removes the minimum (any value fires)."""
         self.mock_integrated_agent.config = {

--- a/retail/agents/tests/usecases/test_update_integrated_agent.py
+++ b/retail/agents/tests/usecases/test_update_integrated_agent.py
@@ -243,6 +243,79 @@ class UpdateIntegratedAgentUseCaseTest(TestCase):
             str(self.mock_integrated_agent.uuid), self.mock_cache_handler.cache
         )
 
+    def test_execute_sets_payment_recovery_minimum_order_value(self):
+        """Test setting the PIX minimum order value persists into config."""
+        self.mock_integrated_agent.config = {"payment_recovery": {"hook_created": True}}
+        data = {"payment_recovery_config": {"minimum_order_value": 100.0}}
+
+        self.usecase.execute(self.mock_integrated_agent, data)
+
+        self.assertEqual(
+            self.mock_integrated_agent.config["payment_recovery"][
+                "minimum_order_value"
+            ],
+            100.0,
+        )
+        # Infrastructure keys must be preserved.
+        self.assertTrue(
+            self.mock_integrated_agent.config["payment_recovery"]["hook_created"]
+        )
+        self.mock_integrated_agent.save.assert_called_once()
+
+    def test_execute_clears_payment_recovery_minimum_order_value(self):
+        """Test that sending null removes the minimum (any value fires)."""
+        self.mock_integrated_agent.config = {
+            "payment_recovery": {"hook_created": True, "minimum_order_value": 100.0}
+        }
+        data = {"payment_recovery_config": {"minimum_order_value": None}}
+
+        self.usecase.execute(self.mock_integrated_agent, data)
+
+        self.assertIsNone(
+            self.mock_integrated_agent.config["payment_recovery"]["minimum_order_value"]
+        )
+
+    def test_execute_initializes_payment_recovery_config_when_absent(self):
+        """Test that the payment_recovery namespace is created when missing."""
+        self.mock_integrated_agent.config = {}
+        data = {"payment_recovery_config": {"minimum_order_value": 50.0}}
+
+        self.usecase.execute(self.mock_integrated_agent, data)
+
+        self.assertEqual(
+            self.mock_integrated_agent.config["payment_recovery"][
+                "minimum_order_value"
+            ],
+            50.0,
+        )
+
+    def test_execute_initializes_config_dict_when_config_is_none(self):
+        """Test that a null config is initialized before writing PIX config."""
+        self.mock_integrated_agent.config = None
+        data = {"payment_recovery_config": {"minimum_order_value": 50.0}}
+
+        self.usecase.execute(self.mock_integrated_agent, data)
+
+        self.assertEqual(
+            self.mock_integrated_agent.config["payment_recovery"][
+                "minimum_order_value"
+            ],
+            50.0,
+        )
+
+    def test_execute_payment_recovery_config_none_is_noop(self):
+        """Test that a null payment_recovery_config leaves config untouched."""
+        self.mock_integrated_agent.config = {"payment_recovery": {"hook_created": True}}
+        data = {"payment_recovery_config": None}
+
+        self.usecase.execute(self.mock_integrated_agent, data)
+
+        self.assertNotIn(
+            "minimum_order_value",
+            self.mock_integrated_agent.config["payment_recovery"],
+        )
+        self.mock_integrated_agent.save.assert_called_once()
+
     def test_cache_handler_default_initialization(self):
         """Test that cache handler is properly initialized with default if not provided"""
         usecase_without_cache = UpdateIntegratedAgentUseCase(


### PR DESCRIPTION
## What

Adds a configurable minimum order value to the PIX (payment recovery)
automation, mirroring the existing abandoned-cart behavior. By default the
PIX agent has no threshold, so every recovery request is dispatched. Users
can set or edit `minimum_order_value` via
`PATCH /api/v3/agents/assigneds/{uuid}/` under `payment_recovery_config`,
and clear it by sending `null`.

At dispatch time, when a threshold is configured, the order total is fetched
from VTEX (`get_order_details_by_id`, cents converted to major units) and the
notification is skipped when the order is below the minimum. If the order
value cannot be resolved (transient VTEX failure), the dispatch proceeds so a
legitimate recovery is never silently dropped.

Touched files: `serializers.py` (new `PaymentRecoveryConfigSerializer` plus a
shared `PartialUpdateSerializer` base and a read field), `usecases/update.py`
(`_update_payment_recovery_config`) and `usecases/payment_recovery.py`
(minimum-value gate + `_get_order_value`), with their tests.

## Why

Lets merchants avoid triggering PIX recovery for low-value orders, cutting
messaging cost without losing relevant recoveries — feature parity with the
threshold already available for abandoned cart.