### PR TITLE
chore: Improve vtex_host_store propagation logging and add vtex_account

### DIFF
--- a/retail/projects/consumers/project_update_consumer.py
+++ b/retail/projects/consumers/project_update_consumer.py
@@ -43,7 +43,16 @@ class ProjectUpdateConsumer(EDAConsumer):  # pragma: no cover
         project.config.update(config)
         project.save(update_fields=["config"])
 
+        if "vtex_host_store" in config:
+            logger.info(
+                f"[ProjectUpdateConsumer] - vtex_host_store echoed back from "
+                f"Connect and persisted for project {project_uuid} "
+                f"vtex_account={project.vtex_account}: "
+                f"host={config['vtex_host_store']!r}"
+            )
+
         logger.info(
-            f"[ProjectUpdateConsumer] - Config updated for project {project_uuid}"
+            f"[ProjectUpdateConsumer] - Config updated for project {project_uuid} "
+            f"vtex_account={project.vtex_account} (keys={list(config.keys())})"
         )
         self.ack()

--- a/retail/projects/usecases/initiate_crawl.py
+++ b/retail/projects/usecases/initiate_crawl.py
@@ -33,6 +33,19 @@ class InitiateCrawlUseCase:
         self.detect_storefront_usecase.execute(project, crawl_url)
 
     def _send_vtex_host_store(self, project: Project, crawl_url: str) -> None:
+        """Propagates the store host to Connect.
+
+        The host value is the ``crawl_url`` received from the storefront at
+        start-setup; it is NOT fetched from VTEX here. The local
+        ``Project.config["vtex_host_store"]`` is only persisted once Connect
+        echoes it back via EDA, so this log trail is the source of truth for
+        whether the outbound propagation happened.
+        """
+        logger.info(
+            f"[vtex_host_store] Resolved store host for project={project.uuid} "
+            f"vtex_account={project.vtex_account}: host={crawl_url!r}. "
+            f"Sending to Connect."
+        )
         try:
             self.connect_service.update_project_config(
                 project_uuid=str(project.uuid),
@@ -40,6 +53,14 @@ class InitiateCrawlUseCase:
             )
         except Exception:
             logger.exception(
-                f"Failed to send vtex_host_store to Connect "
-                f"for project={project.uuid}"
+                f"[vtex_host_store] Failed to send to Connect for "
+                f"project={project.uuid} vtex_account={project.vtex_account} "
+                f"host={crawl_url!r}"
             )
+            return
+
+        logger.info(
+            f"[vtex_host_store] Sent to Connect for project={project.uuid} "
+            f"vtex_account={project.vtex_account} host={crawl_url!r}. "
+            f"Awaiting EDA echo to persist locally."
+        )

--- a/retail/projects/usecases/update_onboarding_progress.py
+++ b/retail/projects/usecases/update_onboarding_progress.py
@@ -132,10 +132,17 @@ class UpdateOnboardingProgressUseCase:
         resolved_url = dto.data.get("resolved_url")
         original_url = dto.data.get("original_url")
 
+        logger.info(
+            f"[url_redirected] Crawler reported a store host redirect for "
+            f"onboarding={onboarding.uuid} vtex_account={onboarding.vtex_account}: "
+            f"original={original_url!r} -> resolved={resolved_url!r}"
+        )
+
         if not resolved_url:
             logger.warning(
                 f"[url_redirected] Missing resolved_url in webhook payload for "
-                f"onboarding={onboarding.uuid}. Skipping update."
+                f"onboarding={onboarding.uuid} vtex_account={onboarding.vtex_account}. "
+                f"Skipping update."
             )
             return onboarding
 
@@ -145,7 +152,8 @@ class UpdateOnboardingProgressUseCase:
         onboarding.save(update_fields=["config"])
 
         logger.info(
-            f"[url_redirected] Updated store URL for onboarding={onboarding.uuid}: "
+            f"[url_redirected] Updated store URL for onboarding={onboarding.uuid} "
+            f"vtex_account={onboarding.vtex_account}: "
             f"original={original_url} -> resolved={resolved_url}"
         )
 
@@ -158,11 +166,17 @@ class UpdateOnboardingProgressUseCase:
         """Propagates the resolved store URL to Connect. Non-blocking by design."""
         if onboarding.project is None:
             logger.warning(
-                f"[url_redirected] Onboarding={onboarding.uuid} has no linked project. "
+                f"[url_redirected] Onboarding={onboarding.uuid} "
+                f"vtex_account={onboarding.vtex_account} has no linked project. "
                 f"Skipping Connect update."
             )
             return
 
+        logger.info(
+            f"[url_redirected] Sending resolved store host to Connect for "
+            f"project={onboarding.project.uuid} "
+            f"vtex_account={onboarding.vtex_account}: host={resolved_url!r}"
+        )
         try:
             self.connect_service.update_project_config(
                 project_uuid=str(onboarding.project.uuid),
@@ -171,8 +185,17 @@ class UpdateOnboardingProgressUseCase:
         except Exception:
             logger.exception(
                 f"[url_redirected] Failed to propagate vtex_host_store to Connect "
-                f"for project={onboarding.project.uuid}"
+                f"for project={onboarding.project.uuid} "
+                f"vtex_account={onboarding.vtex_account} host={resolved_url!r}"
             )
+            return
+
+        logger.info(
+            f"[url_redirected] Sent vtex_host_store to Connect for "
+            f"project={onboarding.project.uuid} "
+            f"vtex_account={onboarding.vtex_account} host={resolved_url!r}. "
+            f"Awaiting EDA echo to persist locally."
+        )
 
     @staticmethod
     def _handle_progress(


### PR DESCRIPTION
## What

Adds explicit, end-to-end logging for the `vtex_host_store` lifecycle so its
propagation can be traced in the pods without relying on failure-only logs.

- `InitiateCrawlUseCase._send_vtex_host_store` now logs before sending the
  store host to Connect, on success ("awaiting EDA echo"), and on failure,
  all prefixed with `[vtex_host_store]`. A docstring clarifies the host
  comes from the start-setup `crawl_url` (not fetched from VTEX) and that the
  local value is only persisted once Connect echoes it back via EDA.
- `UpdateOnboardingProgressUseCase` (the `crawl.url_redirected` path) logs the
  crawler-reported redirect (`original -> resolved`), the outbound send to
  Connect, and success/failure.
- `ProjectUpdateConsumer` logs when `vtex_host_store` is echoed back from
  Connect and persisted, plus the config keys received.
- Adds `vtex_account` to every log line where the value is available.

No behavior change: outbound calls, config writes, and the crawl pipeline are
untouched. Logging only.

## Why

In production several projects had an empty `Project.config["vtex_host_store"]`
and the existing code only logged on failure, making it impossible to tell
whether the value was sent to Connect, echoed back, or never propagated. These
logs make each step observable end-to-end.