### PR TITLE
feat: Add position attribute to WWC webchat onboarding config

### DIFF
--- a/retail/projects/tests/test_configure_wwc.py
+++ b/retail/projects/tests/test_configure_wwc.py
@@ -141,6 +141,22 @@ class TestConfigureWWCUseCase(TestCase):
         self.assertEqual(configure_call[0][0], "wwc")
         self.assertEqual(configure_call[0][1], app_uuid)
 
+    def test_configure_uses_default_bottom_right_position(self):
+        """The widget defaults to bottom-right, matching how it renders today."""
+        app_uuid = str(uuid4())
+        self.mock_integrations_service.create_channel_app.return_value = {
+            "uuid": app_uuid,
+        }
+        self.mock_integrations_service.configure_channel_app.return_value = {
+            "uuid": app_uuid,
+        }
+
+        self.usecase.execute("mystore")
+
+        configure_call = self.mock_integrations_service.configure_channel_app.call_args
+        channel_config = configure_call[0][2]
+        self.assertEqual(channel_config["position"], "bottom-right")
+
     def test_progress_milestones_within_project_config(self):
         """Progress walks the PROJECT_CONFIG start/create/configure/persist milestones."""
         app_uuid = str(uuid4())

--- a/retail/projects/usecases/configure_wwc.py
+++ b/retail/projects/usecases/configure_wwc.py
@@ -19,6 +19,8 @@ WWC_CHANNEL_BASE_CONFIG = {
     "selector": "#wwc",
     "embedded": False,
     "mainColor": "#0366DD",
+    # Anchor corner of the widget; "bottom-left" is the only other value.
+    "position": "bottom-right",
     "contactTimeout": 0,
     "startFullScreen": False,
     "showCameraButton": False,


### PR DESCRIPTION
## What

Adds a `position` attribute to the WWC (Weni Web Chat) channel
configuration sent to the Integrations API during onboarding. The value
defaults to `bottom-right`, which matches how the widget already renders
today; `bottom-left` is the only other accepted value. The attribute is
part of `WWC_CHANNEL_BASE_CONFIG`, so it propagates to both the initial
onboarding flow (`ConfigureWWCUseCase`) and the additional-channel
install flow (`WWCChannelInstaller`) via `build_wwc_channel_config`.

A unit test pins the default `bottom-right` value in the configure
payload.

## Why

The product needs the webchat anchor corner to be configurable. This is
the backend step that ships the attribute with a safe default; the
Integrations service will consume `position` to render the widget on the
chosen corner.

