### PR TITLE
fix: Enrich lambda parse-error logs and lazy-load log traces storage

### DIFF
--- a/retail/agents/domains/agent_execution/usecases/get_agent_log_json.py
+++ b/retail/agents/domains/agent_execution/usecases/get_agent_log_json.py
@@ -49,7 +49,20 @@ class GetAgentLogJsonUseCase:
     def __init__(
         self, traces_storage: Optional[ExecutionTracesStorageService] = None
     ):
-        self._traces_storage = traces_storage or ExecutionTracesStorageService()
+        self._traces_storage = traces_storage
+
+    @property
+    def traces_storage(self) -> ExecutionTracesStorageService:
+        """Build the S3-backed storage lazily.
+
+        Constructing it resolves the trace bucket from settings, which
+        fails loudly when storage is unconfigured. Deferring it keeps
+        the not-found paths (missing row / empty key) from depending on
+        S3 configuration, so they return 404 without ever touching S3.
+        """
+        if self._traces_storage is None:
+            self._traces_storage = ExecutionTracesStorageService()
+        return self._traces_storage
 
     def execute(self, dto: GetAgentLogJsonDTO) -> Any:
         execution = self._get_execution(dto)
@@ -75,7 +88,7 @@ class GetAgentLogJsonUseCase:
 
     def _read_payload(self, s3_key: str, log_uuid: UUID) -> Optional[bytes]:
         try:
-            return self._traces_storage.read_traces_payload(s3_key)
+            return self.traces_storage.read_traces_payload(s3_key)
         except (BotoCoreError, ClientError) as exc:
             logger.error(
                 f"[AGENT_LOGS] Failed to read payload for log {log_uuid}: {exc}"

--- a/retail/agents/domains/agent_webhook/usecases/webhook.py
+++ b/retail/agents/domains/agent_webhook/usecases/webhook.py
@@ -325,7 +325,11 @@ class AgentWebhookUseCase:
             )
 
             if not parsed_response:
-                logger.info("Error in parsing lambda response.")
+                logger.info(
+                    f"Error in parsing lambda response. "
+                    f"vtex_account={integrated_agent.project.vtex_account} "
+                    f"agent={integrated_agent.uuid}"
+                )
                 exec_logger.log_execution_error(
                     error_message="Error parsing lambda response",
                 )


### PR DESCRIPTION
### What

- Enrich the "Error in parsing lambda response" log in `AgentWebhookUseCase.execute` with `vtex_account` and the integrated `agent` UUID, so an unparseable Lambda response can be traced back to the originating account and agent.
- Make the S3-backed traces storage in `GetAgentLogJsonUseCase` lazy: `ExecutionTracesStorageService` is now built on first read (via a `traces_storage` property) instead of in `__init__`, so the not-found paths (missing log row / empty `traces_s3_key`) return `404` without ever resolving the trace bucket.

### Why

- The previous log line was a bare `"Error in parsing lambda response."` with no context, making it impossible to correlate a parse failure with a specific tenant or agent when triaging in production.
- Building `ExecutionTracesStorageService` eagerly resolved `EXECUTION_TRACES_BUCKET` / `AWS_STORAGE_BUCKET_NAME` at construction time, raising `ImproperlyConfigured` (HTTP 500) before the use case could return a legitimate `404`. This broke CI (`test_unknown_log_returns_404`, which doesn't configure a bucket) and coupled the 404 / permission paths to S3 being set up. Deferring construction keeps those paths independent of storage configuration, while the injection point used by the mocked tests still works.
