### PR TITLE
feat: set 100% rollout for order status agent on assignment

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -266,17 +266,17 @@ class AssignAgentUseCase:
         """
         Return the contact_percentage override for specific agent types.
 
-        Payment recovery must reach 100% of eligible contacts from day one;
-        other agents keep the model default (10%).
+        Payment recovery and order status must reach 100% of eligible
+        contacts from day one; other agents keep the model default (10%).
         """
-        payment_recovery_agent_uuid = getattr(
-            settings, "PAYMENT_RECOVERY_AGENT_UUID", ""
+        full_rollout_setting_names = (
+            "PAYMENT_RECOVERY_AGENT_UUID",
+            "ORDER_STATUS_AGENT_UUID",
         )
-        if (
-            payment_recovery_agent_uuid
-            and str(agent.uuid) == payment_recovery_agent_uuid
-        ):
-            return 100
+        for setting_name in full_rollout_setting_names:
+            agent_uuid = getattr(settings, setting_name, "")
+            if agent_uuid and str(agent.uuid) == agent_uuid:
+                return 100
         return None
 
     def _validate_credentials(self, agent: Agent, credentials: dict):

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -16,6 +16,7 @@ from retail.projects.models import Project
 
 PAYMENT_RECOVERY_UUID = str(uuid.uuid4())
 ABANDONED_CART_UUID = str(uuid.uuid4())
+ORDER_STATUS_UUID = str(uuid.uuid4())
 
 
 class ResolveContactPercentageTest(TestCase):
@@ -56,6 +57,30 @@ class ResolveContactPercentageTest(TestCase):
         agent = Agent.objects.create(
             uuid=PAYMENT_RECOVERY_UUID,
             name="Payment Recovery",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        result = self.use_case._resolve_contact_percentage(agent)
+        self.assertIsNone(result)
+
+    @override_settings(ORDER_STATUS_AGENT_UUID=ORDER_STATUS_UUID)
+    def test_returns_100_for_order_status_agent(self):
+        agent = Agent.objects.create(
+            uuid=ORDER_STATUS_UUID,
+            name="Order Status",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        result = self.use_case._resolve_contact_percentage(agent)
+        self.assertEqual(result, 100)
+
+    @override_settings(ORDER_STATUS_AGENT_UUID="")
+    def test_returns_none_when_order_status_setting_is_empty(self):
+        agent = Agent.objects.create(
+            uuid=ORDER_STATUS_UUID,
+            name="Order Status",
             lambda_arn="arn:aws:lambda:fake",
             project=self.project,
             credentials={},


### PR DESCRIPTION
## What

Extend `AssignAgentUseCase._resolve_contact_percentage` so the Order
Status agent is created with `contact_percentage=100`, matching the
existing behavior of the Payment Recovery agent. The single-agent
check was refactored into an iteration over a tuple of setting names
(`PAYMENT_RECOVERY_AGENT_UUID`, `ORDER_STATUS_AGENT_UUID`), keeping the
logic DRY and making future full-rollout agents a one-line addition.
Any other agent keeps the model default (10%).

Files:
- `retail/agents/domains/agent_integration/usecases/assign.py`
- `retail/agents/tests/usecases/test_assign_payment_recovery.py`

## Why

The Order Status agent must reach 100% of eligible contacts from day
one, consistent with the other active agents already rolled out at full
coverage. Leaving it at the 10% default would silently throttle the
feature in production.
