### PR TITLE
feat: Add endpoint to link a project to a VTEX account

### DIFF
--- a/retail/clients/connect/client.py
+++ b/retail/clients/connect/client.py
@@ -63,6 +63,20 @@ class ConnectClient(RequestClient, ConnectClientInterface):
         )
         return response.json()
 
+    def link_vtex_account(self, project_uuid: str, vtex_account: str) -> Dict:
+        url = (
+            f"{self.base_url}/v2/commerce/projects/"
+            f"{project_uuid}/link-vtex-account/"
+        )
+
+        response = self.make_request(
+            url=url,
+            method="POST",
+            json={"vtex_account": vtex_account},
+            headers=self.internal_authentication.headers,
+        )
+        return response.json()
+
     def send_data_export_email(
         self,
         user_email: str,

--- a/retail/clients/connect/tests/test_connect_client.py
+++ b/retail/clients/connect/tests/test_connect_client.py
@@ -46,3 +46,31 @@ class ConnectClientSendDataExportEmailTests(TestCase):
             },
             headers={"Authorization": "Bearer token"},
         )
+
+
+@override_settings(CONNECT_REST_ENDPOINT="https://connect.example.com")
+class ConnectClientLinkVtexAccountTests(TestCase):
+    @patch("retail.clients.connect.client.InternalAuthentication")
+    def test_posts_expected_url_and_payload(self, mock_auth_cls):
+        mock_auth_cls.return_value.headers = {"Authorization": "Bearer token"}
+
+        client = ConnectClient()
+        response = MagicMock()
+        response.json.return_value = {"success": True}
+        client.make_request = MagicMock(return_value=response)
+
+        result = client.link_vtex_account(
+            project_uuid="project-uuid",
+            vtex_account="mystore",
+        )
+
+        self.assertEqual(result, {"success": True})
+        client.make_request.assert_called_once_with(
+            url=(
+                "https://connect.example.com/v2/commerce/projects/"
+                "project-uuid/link-vtex-account/"
+            ),
+            method="POST",
+            json={"vtex_account": "mystore"},
+            headers={"Authorization": "Bearer token"},
+        )

--- a/retail/interfaces/clients/connect/interface.py
+++ b/retail/interfaces/clients/connect/interface.py
@@ -17,6 +17,9 @@ class ConnectClientInterface(Protocol):
     ) -> Dict:
         ...
 
+    def link_vtex_account(self, project_uuid: str, vtex_account: str) -> Dict:
+        ...
+
     def send_data_export_email(
         self,
         user_email: str,

--- a/retail/interfaces/services/connect.py
+++ b/retail/interfaces/services/connect.py
@@ -17,6 +17,9 @@ class ConnectServiceInterface(Protocol):
     ) -> Dict:
         ...
 
+    def link_vtex_account(self, project_uuid: str, vtex_account: str) -> Dict:
+        ...
+
     def send_data_export_email(
         self,
         user_email: str,

--- a/retail/services/connect/service.py
+++ b/retail/services/connect/service.py
@@ -37,6 +37,12 @@ class ConnectService(ConnectServiceInterface):
             project_name=project_name,
         )
 
+    def link_vtex_account(self, project_uuid: str, vtex_account: str) -> Dict:
+        return self.connect_client.link_vtex_account(
+            project_uuid=project_uuid,
+            vtex_account=vtex_account,
+        )
+
     def send_data_export_email(
         self,
         user_email: str,
@@ -56,9 +62,7 @@ class ConnectService(ConnectServiceInterface):
                 status=status,
             )
         except Exception as exc:
-            logger.error(
-                f"Failed to send data export email to {user_email}: {exc}"
-            )
+            logger.error(f"Failed to send data export email to {user_email}: {exc}")
             return None
 
     def update_project_config(

--- a/retail/services/tests/test_connect.py
+++ b/retail/services/tests/test_connect.py
@@ -89,6 +89,21 @@ class ConnectServiceTest(TestCase):
 
         self.assertIsNone(result)
 
+    def test_link_vtex_account_delegates_to_client(self):
+        """link_vtex_account forwards project_uuid and vtex_account."""
+        self.mock_client.link_vtex_account.return_value = {"success": True}
+
+        result = self.service.link_vtex_account(
+            project_uuid="project-uuid",
+            vtex_account="mystore",
+        )
+
+        self.assertEqual(result, {"success": True})
+        self.mock_client.link_vtex_account.assert_called_once_with(
+            project_uuid="project-uuid",
+            vtex_account="mystore",
+        )
+
     def test_default_connect_client_initialization(self):
         """Test that ConnectService initializes with default ConnectClient when none provided"""
         service = ConnectService()

--- a/retail/vtex/serializers.py
+++ b/retail/vtex/serializers.py
@@ -23,6 +23,12 @@ class CreateProjectUserSerializer(serializers.Serializer):
     user_email = serializers.EmailField(required=True)
 
 
+class LinkProjectSerializer(serializers.Serializer):
+    """Validates the payload for linking a project to a VTEX account."""
+
+    project_uuid = serializers.UUIDField(required=True)
+
+
 class VtexProxySerializer(serializers.Serializer):
     """
     Validates the payload for VTEX proxy requests.

--- a/retail/vtex/tests/test_link_project_view.py
+++ b/retail/vtex/tests/test_link_project_view.py
@@ -1,0 +1,89 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from retail.clients.exceptions import CustomAPIException
+
+
+def _auth_bypass():
+    """Patches InternalOIDCAuthentication to always authenticate."""
+
+    return patch(
+        "retail.internal.authenticators.InternalOIDCAuthentication.authenticate",
+        return_value=(MagicMock(is_authenticated=True), None),
+    )
+
+
+class TestLinkProjectView(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = "/vtex/account/mystore/link-project/"
+        self.project_uuid = str(uuid4())
+
+    @_auth_bypass()
+    @patch("retail.vtex.views.LinkProjectUseCase")
+    def test_returns_200_with_success(self, mock_cls, _auth):
+        mock_cls.return_value.execute.return_value = {"success": True}
+
+        response = self.client.post(
+            self.url,
+            {"project_uuid": self.project_uuid},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+
+    @_auth_bypass()
+    @patch("retail.vtex.views.LinkProjectUseCase")
+    def test_passes_correct_dto(self, mock_cls, _auth):
+        mock_cls.return_value.execute.return_value = {"success": True}
+
+        self.client.post(
+            self.url,
+            {"project_uuid": self.project_uuid},
+            format="json",
+        )
+
+        dto = mock_cls.return_value.execute.call_args[0][0]
+        self.assertEqual(dto.vtex_account, "mystore")
+        self.assertEqual(dto.project_uuid, self.project_uuid)
+
+    @_auth_bypass()
+    def test_returns_400_when_project_uuid_missing(self, _auth):
+        response = self.client.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    @_auth_bypass()
+    def test_returns_400_for_invalid_project_uuid(self, _auth):
+        response = self.client.post(
+            self.url,
+            {"project_uuid": "not-a-uuid"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    @_auth_bypass()
+    @patch("retail.vtex.views.LinkProjectUseCase")
+    def test_returns_connect_error_status(self, mock_cls, _auth):
+        mock_cls.return_value.execute.side_effect = CustomAPIException(
+            detail="already linked", status_code=400
+        )
+
+        response = self.client.post(
+            self.url,
+            {"project_uuid": self.project_uuid},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_returns_401_without_auth(self):
+        response = self.client.post(
+            self.url,
+            {"project_uuid": self.project_uuid},
+            format="json",
+        )
+        self.assertIn(response.status_code, [401, 403])

--- a/retail/vtex/tests/usecases/test_link_project.py
+++ b/retail/vtex/tests/usecases/test_link_project.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.clients.exceptions import CustomAPIException
+from retail.projects.models import Project, ProjectOnboarding
+from retail.vtex.usecases.link_project import LinkProjectDTO, LinkProjectUseCase
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "link-project-usecase-tests",
+        }
+    }
+)
+class TestLinkProjectUseCase(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.connect_service = MagicMock()
+        self.usecase = LinkProjectUseCase(connect_service=self.connect_service)
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_execute_links_via_connect_and_locally(self):
+        project = Project.objects.create(uuid=uuid4(), name="Project")
+        dto = LinkProjectDTO(vtex_account="mystore", project_uuid=str(project.uuid))
+
+        result = self.usecase.execute(dto)
+
+        self.assertEqual(result, {"success": True})
+        self.connect_service.link_vtex_account.assert_called_once_with(
+            project_uuid=str(project.uuid),
+            vtex_account="mystore",
+        )
+        project.refresh_from_db()
+        self.assertEqual(project.vtex_account, "mystore")
+
+    def test_execute_links_pending_onboarding(self):
+        project = Project.objects.create(uuid=uuid4(), name="Project")
+        onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore", project=None
+        )
+        dto = LinkProjectDTO(vtex_account="mystore", project_uuid=str(project.uuid))
+
+        self.usecase.execute(dto)
+
+        onboarding.refresh_from_db()
+        self.assertEqual(onboarding.project_id, project.id)
+        self.assertEqual(onboarding.current_step, "PROJECT_CONFIG")
+        self.assertEqual(onboarding.progress, 30)
+
+    def test_execute_when_local_project_missing(self):
+        dto = LinkProjectDTO(vtex_account="mystore", project_uuid=str(uuid4()))
+
+        result = self.usecase.execute(dto)
+
+        self.assertEqual(result, {"success": True})
+        self.connect_service.link_vtex_account.assert_called_once()
+
+    def test_execute_propagates_connect_error(self):
+        project = Project.objects.create(uuid=uuid4(), name="Project")
+        self.connect_service.link_vtex_account.side_effect = CustomAPIException(
+            detail="already linked", status_code=400
+        )
+        dto = LinkProjectDTO(vtex_account="mystore", project_uuid=str(project.uuid))
+
+        with self.assertRaises(CustomAPIException):
+            self.usecase.execute(dto)
+
+        project.refresh_from_db()
+        self.assertIsNone(project.vtex_account)

--- a/retail/vtex/urls.py
+++ b/retail/vtex/urls.py
@@ -3,6 +3,7 @@ from retail.vtex.views import (
     AccountIdentifierProxyView,
     CreateProjectUserView,
     LeadView,
+    LinkProjectView,
     OrderFormTrackingView,
     OrderDetailsProxyView,
     OrdersProxyView,
@@ -54,6 +55,11 @@ urlpatterns = [
         "account/<str:vtex_account>/project-user/",
         CreateProjectUserView.as_view(),
         name="create-project-user",
+    ),
+    path(
+        "account/<str:vtex_account>/link-project/",
+        LinkProjectView.as_view(),
+        name="link-project",
     ),
     path(
         "lead/",

--- a/retail/vtex/usecases/link_project.py
+++ b/retail/vtex/usecases/link_project.py
@@ -1,0 +1,69 @@
+"""
+Use case for linking an existing project to a VTEX account.
+
+The vtex_account uniqueness validations live at the root (Connect), so this
+use case delegates the linking + Insights migration trigger to Connect and
+then mirrors the link locally (Retail Project + onboarding).
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from retail.projects.models import Project
+from retail.projects.usecases.link_project_to_onboarding import (
+    LinkProjectToOnboardingUseCase,
+)
+from retail.services.connect.service import ConnectService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LinkProjectDTO:
+    vtex_account: str
+    project_uuid: str
+
+
+class LinkProjectUseCase:
+    """Links a project to a VTEX account across Connect, Retail and Insights.
+
+    Steps:
+        1. Delegate to Connect, which validates the vtex_account rules,
+           persists the link and triggers the Insights migration.
+        2. Mirror the link on the local Retail project and onboarding.
+    """
+
+    def __init__(self, connect_service: Optional[ConnectService] = None):
+        self.connect_service = connect_service or ConnectService()
+
+    def execute(self, dto: LinkProjectDTO) -> Dict:
+        self.connect_service.link_vtex_account(
+            project_uuid=dto.project_uuid,
+            vtex_account=dto.vtex_account,
+        )
+        logger.info(
+            f"[LinkProject] Connect linked vtex_account={dto.vtex_account} "
+            f"project_uuid={dto.project_uuid}"
+        )
+
+        self._link_local_project(dto)
+
+        return {"success": True}
+
+    def _link_local_project(self, dto: LinkProjectDTO) -> None:
+        try:
+            project = Project.objects.get(uuid=dto.project_uuid)
+        except Project.DoesNotExist:
+            logger.warning(
+                f"[LinkProject] Local project not found, skipping local link: "
+                f"project_uuid={dto.project_uuid}"
+            )
+            return
+
+        if project.vtex_account != dto.vtex_account:
+            project.vtex_account = dto.vtex_account
+            project.save(update_fields=["vtex_account"])
+            project.clear_cache()
+
+        LinkProjectToOnboardingUseCase.execute(project)

--- a/retail/vtex/views.py
+++ b/retail/vtex/views.py
@@ -13,6 +13,7 @@ from retail.vtex.dtos.register_order_form_dto import RegisterOrderFormDTO
 from retail.vtex.serializers import (
     CreateProjectUserSerializer,
     LeadSerializer,
+    LinkProjectSerializer,
     OrderFormTrackingSerializer,
     OrdersQueryParamsSerializer,
     PaymentGatewayProxySerializer,
@@ -23,6 +24,10 @@ from retail.services.vtex_io.service import VtexIOService
 from retail.vtex.usecases.create_project_user import (
     CreateProjectUserDTO,
     CreateProjectUserUseCase,
+)
+from retail.vtex.usecases.link_project import (
+    LinkProjectDTO,
+    LinkProjectUseCase,
 )
 from retail.vtex.usecases.get_account_identifier import GetAccountIdentifierUsecase
 from retail.vtex.usecases.get_store_url import GetStoreUrlUseCase
@@ -445,6 +450,40 @@ class CreateProjectUserView(KeycloakAPIView):
         except CustomAPIException as e:
             logger.error(
                 f"[CreateProjectUser] Connect error: "
+                f"vtex_account={vtex_account} detail={e.detail}"
+            )
+            return Response(
+                {"detail": e.detail},
+                status=e.status_code or status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return Response(result, status=status.HTTP_200_OK)
+
+
+class LinkProjectView(KeycloakAPIView):
+    """
+    Links an existing project to a VTEX account.
+
+    The IO front-end calls this route to attach a project_uuid to the
+    vtex_account in the path. The vtex_account uniqueness validations are
+    enforced at the root (Connect), which also triggers the Insights
+    migration; this view then mirrors the link locally.
+    """
+
+    def post(self, request: Request, vtex_account: str) -> Response:
+        serializer = LinkProjectSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dto = LinkProjectDTO(
+            vtex_account=vtex_account,
+            project_uuid=str(serializer.validated_data["project_uuid"]),
+        )
+
+        try:
+            result = LinkProjectUseCase().execute(dto)
+        except CustomAPIException as e:
+            logger.error(
+                f"[LinkProject] Connect error: "
                 f"vtex_account={vtex_account} detail={e.detail}"
             )
             return Response(


### PR DESCRIPTION
## What

Adds the `POST /vtex/account/<vtex_account>/link-project/` endpoint that the
IO front-end calls to attach an existing `project_uuid` to a VTEX account.
The endpoint returns `{"success": true}` and authenticates via Keycloak
(`KeycloakAPIView`), following the same pattern as `CreateProjectUserView`.

Retail acts as the entry point and delegates the heavy lifting to Connect
(root): `LinkProjectUseCase` calls `ConnectService.link_vtex_account` →
`ConnectClient.link_vtex_account` → `POST {CONNECT_REST_ENDPOINT}/v2/commerce/
projects/<project_uuid>/link-vtex-account/` (internal OIDC client_credentials
auth). Connect enforces the uniqueness rules (project already has an account /
account already linked → 400) and triggers the Insights migration. Connect
errors surface as `CustomAPIException` and the view forwards `e.status_code`
(or 502 as fallback).

After Connect confirms the link, the use case mirrors it locally: it loads the
local `Project` by uuid and, if the account differs, sets `vtex_account`,
saves and clears the project cache, then runs `LinkProjectToOnboardingUseCase`
to attach the pending `ProjectOnboarding` (`current_step="PROJECT_CONFIG"`,
`progress=30`). If the local project does not exist yet, it logs a warning and
proceeds — the operation is idempotent.

## Why

The IO front-end needs a single entry point in Retail to link a project to a
VTEX account without calling Connect/Insights directly. Centralizing the
uniqueness validation and the Insights migration in Connect avoids duplicating
business rules and keeps Retail thin.