### PR TITLE
fix: Serve agent-logs export download via signed redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.29.1
+- fix: Serve agent-logs export download via signed redirect
+
 # 5.29.0
 - feat: set 100% rollout for order status agent on assignment
 - feat: Add position attribute to WWC webchat onboarding config

--- a/retail/agents/api/urls.py
+++ b/retail/agents/api/urls.py
@@ -4,6 +4,7 @@ from rest_framework.routers import SimpleRouter
 
 from retail.agents.domains.agent_execution.views import (
     AgentLogJsonView,
+    AgentLogsExportDownloadView,
     AgentLogsExportView,
     AgentLogsView,
 )
@@ -77,6 +78,11 @@ urlpatterns = [
         "assigneds/<uuid:agent_uuid>/logs/export/",
         AgentLogsExportView.as_view(),
         name="agent-logs-export",
+    ),
+    path(
+        "logs/export/download/",
+        AgentLogsExportDownloadView.as_view(),
+        name="agent-logs-export-download",
     ),
     path(
         "assigneds/<uuid:agent_uuid>/logs/<uuid:log_uuid>/json/",

--- a/retail/agents/domains/agent_execution/serializers.py
+++ b/retail/agents/domains/agent_execution/serializers.py
@@ -136,6 +136,12 @@ class ExportAgentLogsBodySerializer(_BaseAgentLogsFilterSerializer):
     user_email = serializers.EmailField(required=True)
 
 
+class ExportDownloadQuerySerializer(serializers.Serializer):
+    """Parse the signed token from the export download link query string."""
+
+    token = serializers.CharField()
+
+
 class AgentLogRowSerializer(serializers.Serializer):
     """Render an ``AgentExecution`` in the agent-logs row shape.
 

--- a/retail/agents/domains/agent_execution/tests/test_agent_logs_export_download_view.py
+++ b/retail/agents/domains/agent_execution/tests/test_agent_logs_export_download_view.py
@@ -1,0 +1,47 @@
+"""End-to-end tests for ``GET /logs/export/download/``.
+
+The endpoint is public and token-authorized: it validates the signed
+token, mints a fresh presigned URL via ``ResolveExportDownloadUseCase``,
+and 302-redirects to it. These tests pin that loop without any platform
+authentication, mirroring a click straight from the export email.
+"""
+
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.test import APITestCase
+
+
+class AgentLogsExportDownloadViewTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("agent-logs-export-download")
+
+    @patch(
+        "retail.agents.domains.agent_execution.views.ResolveExportDownloadUseCase"
+    )
+    def test_valid_token_redirects_to_fresh_presigned_url(self, mock_use_case_cls):
+        mock_use_case_cls.return_value.execute.return_value = "https://s3/presigned"
+
+        response = self.client.get(self.url, {"token": "signed-token"})
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], "https://s3/presigned")
+        mock_use_case_cls.return_value.execute.assert_called_once_with("signed-token")
+
+    def test_missing_token_returns_400(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch(
+        "retail.agents.domains.agent_execution.views.ResolveExportDownloadUseCase"
+    )
+    def test_invalid_token_returns_404(self, mock_use_case_cls):
+        mock_use_case_cls.return_value.execute.side_effect = NotFound("bad")
+
+        response = self.client.get(self.url, {"token": "bad-token"})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/retail/agents/domains/agent_execution/tests/test_export_agent_logs_usecase.py
+++ b/retail/agents/domains/agent_execution/tests/test_export_agent_logs_usecase.py
@@ -22,7 +22,6 @@ from retail.agents.domains.agent_execution.models import (
 )
 from retail.agents.domains.agent_execution.usecases.export_agent_logs import (
     CSV_HEADER,
-    PRESIGNED_URL_TTL_SECONDS,
     ExportAgentLogsDTO,
     ExportAgentLogsUseCase,
 )
@@ -32,19 +31,14 @@ from retail.projects.models import Project
 
 
 class _FakeS3Service:
-    """Minimal stand-in that captures streamed upload / presign calls."""
+    """Minimal stand-in that captures streamed upload calls."""
 
     def __init__(self):
         self.upload_calls = []
-        self.presign_calls = []
 
     def upload_fileobj(self, fileobj, key, content_type="application/octet-stream"):
         self.upload_calls.append((key, fileobj.read(), content_type))
         return key
-
-    def generate_presigned_url(self, key, expiration=3600):
-        self.presign_calls.append((key, expiration))
-        return f"https://s3.amazonaws.com/{key}?signature=fake&expiration={expiration}"
 
     def get_object(self, key):  # pragma: no cover - unused in tests
         return None
@@ -136,14 +130,14 @@ class ExportAgentLogsUseCaseTests(TestCase):
         )
         self.assertTrue(key.endswith(".csv"))
 
-    def test_returns_presigned_url_and_logs_row_count(self):
+    def test_returns_uploaded_key(self):
         _make_execution(self.integrated_agent)
         _make_execution(self.integrated_agent)
 
-        key, presigned_url = self.use_case.execute(self._filter())
+        key = self.use_case.execute(self._filter())
 
-        self.assertEqual(self.fake_s3.presign_calls, [(key, PRESIGNED_URL_TTL_SECONDS)])
-        self.assertIn("signature=fake", presigned_url)
+        uploaded_key, _, _ = self.fake_s3.upload_calls[0]
+        self.assertEqual(key, uploaded_key)
 
     def test_filter_smoke_check_search_pipes_through(self):
         """One smoke-check that ``ExportAgentLogsDTO`` is forwarded to
@@ -239,7 +233,7 @@ class ExportAgentLogsKeyTests(TestCase):
             "export_agent_logs.timezone.now",
             return_value=fixed_now,
         ):
-            key, _ = use_case.execute(
+            key = use_case.execute(
                 ExportAgentLogsDTO(
                     agent_uuid=integrated_agent.uuid,
                     project_uuid=project.uuid,

--- a/retail/agents/domains/agent_execution/tests/test_export_download_usecase.py
+++ b/retail/agents/domains/agent_execution/tests/test_export_download_usecase.py
@@ -1,0 +1,96 @@
+"""Tests for the agent-logs export download use cases.
+
+``BuildExportDownloadUrlUseCase`` signs the uploaded S3 key into a stable
+URL pointing at our own download endpoint; ``ResolveExportDownloadUseCase``
+verifies that token on click and mints a fresh, short-lived presigned URL.
+Together they keep the link's lifetime under our control (a signed token)
+instead of AWS's session-token TTL.
+"""
+
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+from django.core import signing
+from django.test import SimpleTestCase, override_settings
+from django.urls import reverse
+from rest_framework.exceptions import NotFound
+
+from retail.agents.domains.agent_execution.usecases import export_download
+from retail.agents.domains.agent_execution.usecases.export_download import (
+    DOWNLOAD_PRESIGN_TTL_SECONDS,
+    EXPORT_DOWNLOAD_SALT,
+    BuildExportDownloadUrlUseCase,
+    ResolveExportDownloadUseCase,
+)
+
+
+@override_settings(DOMAIN="https://example.com", SECRET_KEY="test-secret-key")
+class BuildExportDownloadUrlUseCaseTests(SimpleTestCase):
+    def test_url_points_at_download_endpoint_with_signed_key(self):
+        key = "exports/agent_logs/p/a/20260101T000000Z.csv"
+
+        url = BuildExportDownloadUrlUseCase().execute(key)
+
+        parsed = urlparse(url)
+        self.assertEqual(f"{parsed.scheme}://{parsed.netloc}", "https://example.com")
+        self.assertEqual(parsed.path, reverse("agent-logs-export-download"))
+
+        token = parse_qs(parsed.query)["token"][0]
+        payload = signing.loads(token, salt=EXPORT_DOWNLOAD_SALT)
+        self.assertEqual(payload, {"key": key})
+
+    @override_settings(DOMAIN="https://example.com/")
+    def test_trailing_slash_on_domain_does_not_double_up(self):
+        url = BuildExportDownloadUrlUseCase().execute("some/key.csv")
+
+        self.assertTrue(url.startswith("https://example.com/api/"))
+        self.assertNotIn("example.com//", url)
+
+
+@override_settings(SECRET_KEY="test-secret-key")
+class ResolveExportDownloadUseCaseTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.fake_s3 = MagicMock()
+        self.fake_s3.generate_presigned_url.return_value = "https://s3/presigned"
+        self.use_case = ResolveExportDownloadUseCase(s3_service=self.fake_s3)
+        self.key = "exports/agent_logs/p/a/file.csv"
+        self.token = signing.dumps({"key": self.key}, salt=EXPORT_DOWNLOAD_SALT)
+
+    def test_valid_token_mints_short_lived_presigned_url(self):
+        result = self.use_case.execute(self.token)
+
+        self.assertEqual(result, "https://s3/presigned")
+        self.fake_s3.generate_presigned_url.assert_called_once_with(
+            self.key, expiration=DOWNLOAD_PRESIGN_TTL_SECONDS
+        )
+
+    def test_expired_token_raises_not_found(self):
+        # A negative max_age means any token already counts as expired,
+        # exercising the real ``SignatureExpired`` branch.
+        with patch.object(export_download, "EXPORT_DOWNLOAD_TOKEN_TTL_SECONDS", -1):
+            with self.assertRaises(NotFound):
+                self.use_case.execute(self.token)
+
+        self.fake_s3.generate_presigned_url.assert_not_called()
+
+    def test_tampered_token_raises_not_found(self):
+        with self.assertRaises(NotFound):
+            self.use_case.execute(self.token + "tampered")
+
+        self.fake_s3.generate_presigned_url.assert_not_called()
+
+    def test_token_signed_with_other_salt_raises_not_found(self):
+        foreign_token = signing.dumps({"key": self.key}, salt="some-other-salt")
+
+        with self.assertRaises(NotFound):
+            self.use_case.execute(foreign_token)
+
+        self.fake_s3.generate_presigned_url.assert_not_called()
+
+    @override_settings(AWS_STORAGE_BUCKET_NAME="export-bucket")
+    @patch("retail.agents.domains.agent_execution.usecases.export_download.S3Service")
+    def test_default_constructor_binds_export_bucket(self, mock_s3_service):
+        ResolveExportDownloadUseCase()
+
+        mock_s3_service.assert_called_once_with(bucket_name="export-bucket")

--- a/retail/agents/domains/agent_execution/tests/test_task_export_agent_logs.py
+++ b/retail/agents/domains/agent_execution/tests/test_task_export_agent_logs.py
@@ -10,7 +10,8 @@ It must:
 - Coerce ``statuses`` into a tuple (preserving the log-status
   values the API accepts).
 - Forward every filter to ``ExportAgentLogsUseCase.execute`` exactly.
-- Return the presigned URL produced by the use case on success.
+- Sign the uploaded key into a download URL and email that link.
+- Return the signed download URL on success.
 - Return ``None`` on any exception so the worker doesn't crash and
   the API surface stays fire-and-forget.
 """
@@ -33,15 +34,19 @@ class TaskExportAgentLogsTests(TestCase):
         self.project_uuid = uuid4()
 
     @patch("retail.agents.tasks.SendAgentLogsExportEmailUseCase")
+    @patch("retail.agents.tasks.BuildExportDownloadUrlUseCase")
     @patch("retail.agents.tasks.ExportAgentLogsUseCase")
-    def test_returns_presigned_url_and_passes_full_filter(
-        self, mock_use_case_cls, mock_email_use_case_cls
+    def test_returns_download_url_and_passes_full_filter(
+        self, mock_use_case_cls, mock_build_url_cls, mock_email_use_case_cls
     ):
         from retail.agents.tasks import task_export_agent_logs
 
         mock_use_case = MagicMock()
-        mock_use_case.execute.return_value = ("some/key.csv", "https://signed/url")
+        mock_use_case.execute.return_value = "some/key.csv"
         mock_use_case_cls.return_value = mock_use_case
+        mock_build_url_cls.return_value.execute.return_value = (
+            "https://app/download?token=abc"
+        )
 
         template_uuid_a = uuid4()
         template_uuid_b = uuid4()
@@ -57,7 +62,7 @@ class TaskExportAgentLogsTests(TestCase):
             user_email="tester@example.com",
         )
 
-        self.assertEqual(result, "https://signed/url")
+        self.assertEqual(result, "https://app/download?token=abc")
 
         mock_use_case.execute.assert_called_once()
         dto = mock_use_case.execute.call_args.args[0]
@@ -75,28 +80,34 @@ class TaskExportAgentLogsTests(TestCase):
         self.assertEqual(dto.statuses, ("sent", "skipped"))
         self.assertEqual(dto.user_email, "tester@example.com")
 
-        # The same DTO + presigned URL are handed to the email use case.
+        # The uploaded key is signed into the download URL...
+        mock_build_url_cls.return_value.execute.assert_called_once_with("some/key.csv")
+        # ...and that link (not a presigned URL) is what the email carries.
         mock_email_use_case_cls.return_value.execute.assert_called_once_with(
-            dto, file_url="https://signed/url"
+            dto, file_url="https://app/download?token=abc"
         )
 
     @patch("retail.agents.tasks.SendAgentLogsExportEmailUseCase")
+    @patch("retail.agents.tasks.BuildExportDownloadUrlUseCase")
     @patch("retail.agents.tasks.ExportAgentLogsUseCase")
     def test_optional_filters_default_to_empty_tuples(
-        self, mock_use_case_cls, mock_email_use_case_cls
+        self, mock_use_case_cls, mock_build_url_cls, mock_email_use_case_cls
     ):
         from retail.agents.tasks import task_export_agent_logs
 
         mock_use_case = MagicMock()
-        mock_use_case.execute.return_value = ("some/key.csv", "https://signed/url")
+        mock_use_case.execute.return_value = "some/key.csv"
         mock_use_case_cls.return_value = mock_use_case
+        mock_build_url_cls.return_value.execute.return_value = (
+            "https://app/download?token=abc"
+        )
 
         result = task_export_agent_logs(
             agent_uuid=str(self.agent_uuid),
             project_uuid=str(self.project_uuid),
         )
 
-        self.assertEqual(result, "https://signed/url")
+        self.assertEqual(result, "https://app/download?token=abc")
 
         dto = mock_use_case.execute.call_args.args[0]
         self.assertIsNone(dto.search)
@@ -107,9 +118,10 @@ class TaskExportAgentLogsTests(TestCase):
         self.assertIsNone(dto.user_email)
 
     @patch("retail.agents.tasks.SendAgentLogsExportEmailUseCase")
+    @patch("retail.agents.tasks.BuildExportDownloadUrlUseCase")
     @patch("retail.agents.tasks.ExportAgentLogsUseCase")
     def test_returns_none_when_use_case_raises(
-        self, mock_use_case_cls, mock_email_use_case_cls
+        self, mock_use_case_cls, mock_build_url_cls, mock_email_use_case_cls
     ):
         from retail.agents.tasks import task_export_agent_logs
 
@@ -124,7 +136,8 @@ class TaskExportAgentLogsTests(TestCase):
             )
 
         self.assertIsNone(result)
-        # No email when there is no file to deliver.
+        # No link is built and no email is sent when there is no file.
+        mock_build_url_cls.return_value.execute.assert_not_called()
         mock_email_use_case_cls.return_value.execute.assert_not_called()
         # Operators need to know which agent + project failed.
         joined = "\n".join(log_capture.output)

--- a/retail/agents/domains/agent_execution/usecases/export_agent_logs.py
+++ b/retail/agents/domains/agent_execution/usecases/export_agent_logs.py
@@ -11,10 +11,10 @@ as a single in-memory blob.
 
 The view layer treats the export as fire-and-forget (the API responds
 ``202 Accepted`` and the CSV is delivered out-of-band), so this use
-case only returns the deterministic key + presigned URL. Notifying the
-requester is a separate concern handled by
-``SendAgentLogsExportEmailUseCase``, which the task invokes with the
-presigned URL once the upload succeeds.
+case only returns the deterministic S3 key. Turning that key into the
+emailed download link is a separate concern: the task signs it via
+``BuildExportDownloadUrlUseCase`` and hands the result to
+``SendAgentLogsExportEmailUseCase``.
 """
 
 import csv
@@ -22,7 +22,7 @@ import logging
 import tempfile
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timezone as dt_timezone
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence
 from uuid import UUID
 
 from django.conf import settings
@@ -62,11 +62,6 @@ CSV_HEADER = [
     "status",
     "summary",
 ]
-
-# 7 days is the maximum lifetime AWS allows for a SigV4 presigned URL,
-# so the "Download File" link in the export-ready email stays valid for
-# the full week the file is retained.
-PRESIGNED_URL_TTL_SECONDS = 60 * 60 * 24 * 7
 
 # CSV rows accumulate in memory up to this size before the spooled
 # temp file rolls over to disk, keeping the working set bounded
@@ -166,8 +161,13 @@ class ExportAgentLogsUseCase:
         else:
             self.s3_service = S3Service(bucket_name=_resolve_export_bucket())
 
-    def execute(self, dto: ExportAgentLogsDTO) -> Tuple[str, str]:
-        """Build the CSV, upload it to S3, and return ``(key, presigned_url)``."""
+    def execute(self, dto: ExportAgentLogsDTO) -> str:
+        """Build the CSV, upload it to S3, and return the object key.
+
+        The link delivered to the user is built separately (see
+        ``BuildExportDownloadUrlUseCase``) so the download URL is minted
+        fresh on click and never embeds a long-lived presigned URL.
+        """
         queryset = self._build_queryset(dto)
         key = self._build_key(dto)
 
@@ -183,10 +183,6 @@ class ExportAgentLogsUseCase:
             spool.seek(0)
             self.s3_service.upload_fileobj(spool, key, content_type="text/csv")
 
-        presigned_url = self.s3_service.generate_presigned_url(
-            key, expiration=PRESIGNED_URL_TTL_SECONDS
-        )
-
         logger.info(
             "Exported %d agent log rows for agent=%s project=%s key=%s",
             row_count,
@@ -194,7 +190,7 @@ class ExportAgentLogsUseCase:
             dto.project_uuid,
             key,
         )
-        return key, presigned_url
+        return key
 
     def _build_queryset(self, dto: ExportAgentLogsDTO):
         queryset = AgentExecution.objects.select_related(

--- a/retail/agents/domains/agent_execution/usecases/export_download.py
+++ b/retail/agents/domains/agent_execution/usecases/export_download.py
@@ -1,0 +1,87 @@
+"""Use cases for the agent-logs export download link.
+
+The export-ready email used to embed a presigned S3 URL directly. Signed
+with the pod's temporary credentials, that URL died when the session
+token expired, so the advertised multi-day link broke within hours.
+
+Instead, the email now points at our own always-on download endpoint
+carrying a signed token (``BuildExportDownloadUrlUseCase``). When the
+recipient clicks it, the endpoint verifies the token and mints a fresh,
+short-lived presigned URL on the spot (``ResolveExportDownloadUseCase``),
+then redirects to it. The link's lifetime therefore lives in a token we
+sign with ``SECRET_KEY`` and is fully decoupled from AWS's session-token
+TTL.
+"""
+
+import logging
+from typing import Optional
+from urllib.parse import quote
+
+from django.conf import settings
+from django.core import signing
+from django.urls import reverse
+from rest_framework.exceptions import NotFound
+
+from retail.agents.domains.agent_execution.usecases.export_agent_logs import (
+    _resolve_export_bucket,
+)
+from retail.interfaces.services.aws_s3 import S3ServiceInterface
+from retail.services.aws_s3.service import S3Service
+
+
+logger = logging.getLogger(__name__)
+
+
+# Salt namespaces the signature so a token minted here can't be replayed
+# against any other ``django.core.signing`` consumer sharing SECRET_KEY.
+EXPORT_DOWNLOAD_SALT = "agent-logs-export-download"
+
+# The signed link stays valid for the full week the export file is
+# retained in S3 (matching the bucket's lifecycle rule). After that the
+# object is gone, so a longer token would be useless anyway.
+EXPORT_DOWNLOAD_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 7
+
+# The presigned URL is consumed by the redirect within seconds, so a
+# short lifetime is plenty — and keeps it well inside the pod's
+# session-token validity.
+DOWNLOAD_PRESIGN_TTL_SECONDS = 5 * 60
+
+# Reverse-resolved route name for the download endpoint.
+DOWNLOAD_URL_NAME = "agent-logs-export-download"
+
+
+class BuildExportDownloadUrlUseCase:
+    """Build the signed, app-hosted download URL emailed to the user."""
+
+    def execute(self, key: str) -> str:
+        token = signing.dumps({"key": key}, salt=EXPORT_DOWNLOAD_SALT)
+        path = reverse(DOWNLOAD_URL_NAME)
+        return f"{settings.DOMAIN.rstrip('/')}{path}?token={quote(token)}"
+
+
+class ResolveExportDownloadUseCase:
+    """Verify a download token and mint a fresh presigned URL for it."""
+
+    def __init__(self, s3_service: Optional[S3ServiceInterface] = None):
+        self.s3_service = s3_service or S3Service(bucket_name=_resolve_export_bucket())
+
+    def execute(self, token: str) -> str:
+        key = self._resolve_key(token)
+        return self.s3_service.generate_presigned_url(
+            key, expiration=DOWNLOAD_PRESIGN_TTL_SECONDS
+        )
+
+    @staticmethod
+    def _resolve_key(token: str) -> str:
+        try:
+            payload = signing.loads(
+                token,
+                salt=EXPORT_DOWNLOAD_SALT,
+                max_age=EXPORT_DOWNLOAD_TOKEN_TTL_SECONDS,
+            )
+        except signing.SignatureExpired:
+            raise NotFound("This download link has expired.")
+        except signing.BadSignature:
+            raise NotFound("Invalid download link.")
+
+        return payload["key"]

--- a/retail/agents/domains/agent_execution/views.py
+++ b/retail/agents/domains/agent_execution/views.py
@@ -19,16 +19,22 @@ import logging
 from typing import Optional
 from uuid import UUID
 
+from django.http import HttpResponseRedirect
 from rest_framework import status
 from rest_framework.exceptions import NotFound
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from retail.agents.domains.agent_execution.serializers import (
     AgentLogRowSerializer,
     ExportAgentLogsBodySerializer,
+    ExportDownloadQuerySerializer,
     ListAgentLogsQuerySerializer,
+)
+from retail.agents.domains.agent_execution.usecases.export_download import (
+    ResolveExportDownloadUseCase,
 )
 from retail.agents.domains.agent_execution.usecases.get_agent_log_json import (
     GetAgentLogJsonDTO,
@@ -163,3 +169,25 @@ class AgentLogsExportView(_AgentLogsBaseView):
         )
 
         return Response({"requested": True}, status=status.HTTP_202_ACCEPTED)
+
+
+class AgentLogsExportDownloadView(APIView):
+    """GET ``/logs/export/download/?token=...``.
+
+    Public, token-authorized entry point for the link emailed after an
+    export. The signed token (not a platform session) authorizes the
+    request, mirroring the webhook endpoints, so it works straight from
+    the recipient's email client. It mints a fresh, short-lived
+    presigned URL and redirects, keeping long-lived presigned URLs out
+    of the email entirely.
+    """
+
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    def get(self, request: Request) -> HttpResponseRedirect:
+        serializer = ExportDownloadQuerySerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        url = ResolveExportDownloadUseCase().execute(serializer.validated_data["token"])
+        return HttpResponseRedirect(url)

--- a/retail/agents/tasks.py
+++ b/retail/agents/tasks.py
@@ -13,6 +13,9 @@ from retail.agents.domains.agent_execution.usecases.export_agent_logs import (
     ExportAgentLogsDTO,
     ExportAgentLogsUseCase,
 )
+from retail.agents.domains.agent_execution.usecases.export_download import (
+    BuildExportDownloadUrlUseCase,
+)
 from retail.agents.domains.agent_execution.usecases.flush_executions import (
     FlushExecutionsUseCase,
 )
@@ -147,9 +150,10 @@ def task_export_agent_logs(
     Build the agent-logs CSV export, stash it on S3, and email the link.
 
     Fire-and-forget: the caller treats any non-error status as success
-    and we deliver the file out-of-band. Once the CSV is uploaded, the
-    presigned URL is emailed to ``user_email`` through Connect; that
-    notification is best-effort and never fails the export.
+    and we deliver the file out-of-band. Once the CSV is uploaded, a
+    signed link to our download endpoint is emailed to ``user_email``
+    through Connect; that notification is best-effort and never fails
+    the export.
 
     Args:
         agent_uuid: ``IntegratedAgent.uuid`` to scope the export to.
@@ -162,7 +166,7 @@ def task_export_agent_logs(
         user_email: Recipient of the export-ready email (the requester).
 
     Returns:
-        The presigned S3 URL on success, or ``None`` on failure.
+        The signed download URL on success, or ``None`` on failure.
         Errors are logged so a failed export never crashes the
         worker.
     """
@@ -177,18 +181,19 @@ def task_export_agent_logs(
             statuses=statuses,
             user_email=user_email,
         )
-        _, presigned_url = ExportAgentLogsUseCase().execute(dto)
+        key = ExportAgentLogsUseCase().execute(dto)
+        download_url = BuildExportDownloadUrlUseCase().execute(key)
 
         logger.info(
-            "[AGENT_LOGS_EXPORT] CSV ready for agent=%s project=%s url=%s",
+            "[AGENT_LOGS_EXPORT] CSV ready for agent=%s project=%s key=%s",
             agent_uuid,
             project_uuid,
-            presigned_url,
+            key,
         )
 
-        SendAgentLogsExportEmailUseCase().execute(dto, file_url=presigned_url)
+        SendAgentLogsExportEmailUseCase().execute(dto, file_url=download_url)
 
-        return presigned_url
+        return download_url
     except Exception:
         logger.exception(
             "[AGENT_LOGS_EXPORT] Failed to build CSV for agent=%s project=%s",

--- a/retail/swagger.py
+++ b/retail/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Gallery API Documentation",
-        default_version="v5.29.0",
+        default_version="v5.29.1",
         description="Documentation of the Gallery APIs",
     ),
     public=True,


### PR DESCRIPTION
## What
Replace the presigned S3 URL emailed for agent-logs exports with a stable
link to a new public, token-authorized download endpoint
(`GET /api/v3/agents/logs/export/download/?token=...`). On click it
verifies a `SECRET_KEY`-signed token and 302-redirects to a freshly
minted, short-lived presigned URL.
- `ExportAgentLogsUseCase.execute` now returns only the S3 key (no
  long-lived presign).
- New `export_download.py`: `BuildExportDownloadUrlUseCase` signs the key
  into the link; `ResolveExportDownloadUseCase` verifies it (7-day
  `max_age`, salted) and mints a 5-minute presigned URL, raising
  `NotFound` for bad/expired tokens.
- `task_export_agent_logs` builds the signed link and emails that instead
  of a presigned URL.
- New `AgentLogsExportDownloadView` (`AllowAny`, no authentication) with a
  `token` query serializer and route.
  
## Why
The export email embedded a 7-day presigned S3 URL, but in production it
is signed with the pod's temporary credentials (which carry a session
token). AWS caps such URLs to the earlier of `ExpiresIn` or the
session-token lifetime, so the link returned `ExpiredToken` within hours
of being sent. Moving the 7-day window into a token we sign with
`SECRET_KEY` decouples the link's lifetime from STS; the presigned URL is
generated on click and consumed within seconds, so it never outlives the
session token. This works with the existing temporary pod credentials —
no static keys to provision.