### PR TITLE
fix: Split broadcast build/send error logging by phase

### DIFF
--- a/retail/agents/domains/agent_webhook/usecases/webhook.py
+++ b/retail/agents/domains/agent_webhook/usecases/webhook.py
@@ -166,51 +166,67 @@ class AgentWebhookUseCase:
             return None
 
         try:
-            message = self.broadcast_handler.build_message(integrated_agent, data)
-            if not message:
-                logger.info(
-                    f"Failed to build broadcast message from payload data: "
-                    f"vtex_account={vtex_account} agent={integrated_agent.uuid} "
-                    f"data={data}"
-                )
-                exec_logger.log_execution_error(
-                    error_message="Failed to build broadcast message",
-                    error_data={"payload_data": data},
-                )
-                return None
+            template = self.broadcast_handler.get_current_template(
+                integrated_agent, data
+            )
+        except Exception as e:
+            logger.exception(f"Unexpected error while resolving broadcast template: {e}")
+            exec_logger.log_execution_error(
+                error_message=f"Error resolving broadcast template: {e}",
+                error_data={"phase": "broadcast_template_resolve"},
+            )
+            return None
 
+        try:
+            message = self.broadcast_handler.build_message(integrated_agent, data)
+        except Exception as e:
+            logger.exception(f"Unexpected error while building broadcast message: {e}")
+            exec_logger.log_execution_error(
+                error_message=f"Error building broadcast message: {e}",
+                error_data={"phase": "broadcast_build"},
+            )
+            return None
+
+        if not message:
+            logger.info(
+                f"Failed to build broadcast message from payload data: "
+                f"vtex_account={vtex_account} agent={integrated_agent.uuid} "
+                f"data={data}"
+            )
+            exec_logger.log_execution_error(
+                error_message="Failed to build broadcast message",
+                error_data={"payload_data": data},
+            )
+            return None
+
+        try:
             dispatch_result = self.broadcast_handler.send_message(
                 message,
                 integrated_agent,
                 data,
                 dispatch_context=dispatch_context,
             )
-            broadcast_response = dispatch_result.response
-            broadcast_message_uuid = dispatch_result.broadcast_message_uuid
-
-            template = self.broadcast_handler.get_current_template(
-                integrated_agent, data
-            )
-            template_uuid = (
-                template.uuid if template and template is not False else None
-            )
-            broadcast_id = broadcast_response.get("id") if broadcast_response else None
-
-            exec_logger.log_broadcast_sent(
-                broadcast_response=broadcast_response or {},
-                template_uuid=template_uuid,
-                broadcast_id=broadcast_id,
-                broadcast_message_uuid=broadcast_message_uuid,
-            )
-
-            return data
-
         except Exception as e:
-            logger.exception(f"Unexpected error while building broadcast message: {e}")
+            logger.exception(f"Unexpected error while sending broadcast message: {e}")
             exec_logger.log_execution_error(
-                error_message=f"Error building/sending broadcast: {str(e)}",
+                error_message=f"Error sending broadcast message: {e}",
+                error_data={"phase": "broadcast_send"},
             )
             return None
+
+        broadcast_response = dispatch_result.response
+        broadcast_message_uuid = dispatch_result.broadcast_message_uuid
+        template_uuid = template.uuid if template and template is not False else None
+        broadcast_id = broadcast_response.get("id") if broadcast_response else None
+
+        exec_logger.log_broadcast_sent(
+            broadcast_response=broadcast_response or {},
+            template_uuid=template_uuid,
+            broadcast_id=broadcast_id,
+            broadcast_message_uuid=broadcast_message_uuid,
+        )
+
+        return data
 
     def execute_from_task(
         self,

--- a/retail/agents/tests/usecases/test_agent_webhook.py
+++ b/retail/agents/tests/usecases/test_agent_webhook.py
@@ -563,9 +563,7 @@ class AgentWebhookUseCaseLoggingTest(TestCase):
 
         self.usecase.execute(self.mock_agent, self._build_request_data())
 
-        self.mock_lambda_handler.parse_log_tail.assert_called_once_with(
-            invoke_response
-        )
+        self.mock_lambda_handler.parse_log_tail.assert_called_once_with(invoke_response)
         self.exec_logger.log_lambda_response.assert_called_once_with(
             response_data=parsed,
             log_tail="START RequestId: abc\nhello from print\nEND RequestId: abc\n",
@@ -671,7 +669,12 @@ class AgentWebhookUseCaseLoggingTest(TestCase):
 
         self.exec_logger.log_execution_error.assert_called_once_with(
             error_message="Failed to build broadcast message",
-            error_data={"payload_data": {"template": "missing_one", "contact_urn": "whatsapp:123"}},
+            error_data={
+                "payload_data": {
+                    "template": "missing_one",
+                    "contact_urn": "whatsapp:123",
+                }
+            },
         )
         self.mock_broadcast_handler.send_message.assert_not_called()
 
@@ -687,7 +690,12 @@ class AgentWebhookUseCaseLoggingTest(TestCase):
 
         self.exec_logger.log_execution_error.assert_called_once_with(
             error_message="Failed to build broadcast message",
-            error_data={"payload_data": {"template": "order_update", "contact_urn": "whatsapp:123"}},
+            error_data={
+                "payload_data": {
+                    "template": "order_update",
+                    "contact_urn": "whatsapp:123",
+                }
+            },
         )
         self.mock_broadcast_handler.send_message.assert_not_called()
 
@@ -783,7 +791,8 @@ class AgentWebhookUseCaseLoggingTest(TestCase):
         self.usecase.execute(self.mock_agent, self._build_request_data())
 
         self.exec_logger.log_execution_error.assert_called_once_with(
-            error_message="Error building/sending broadcast: kaboom",
+            error_message="Error building broadcast message: kaboom",
+            error_data={"phase": "broadcast_build"},
         )
         self.exec_logger.log_broadcast_sent.assert_not_called()
         self.mock_broadcast_handler.send_message.assert_not_called()
@@ -802,7 +811,31 @@ class AgentWebhookUseCaseLoggingTest(TestCase):
         self.usecase.execute(self.mock_agent, self._build_request_data())
 
         self.exec_logger.log_execution_error.assert_called_once_with(
-            error_message="Error building/sending broadcast: flows down",
+            error_message="Error sending broadcast message: flows down",
+            error_data={"phase": "broadcast_send"},
+        )
+        self.exec_logger.log_broadcast_sent.assert_not_called()
+
+    def test_execute_logs_error_when_get_current_template_raises(self):
+        parsed = {"template": "order_update", "contact_urn": "whatsapp:123"}
+        self.mock_lambda_handler.invoke.return_value = {"Payload": MagicMock()}
+        self.mock_lambda_handler.parse_response.return_value = parsed
+        self.mock_lambda_handler.validate_response.return_value = True
+        self.mock_broadcast_handler.can_send_to_contact.return_value = True
+        self.mock_broadcast_handler.build_message.return_value = {"msg": "ok"}
+        self.mock_broadcast_handler.send_message.return_value = _dispatch_result(
+            response={"id": 7},
+            broadcast_message_uuid=uuid4(),
+        )
+        self.mock_broadcast_handler.get_current_template.side_effect = RuntimeError(
+            "template lookup failed"
+        )
+
+        self.usecase.execute(self.mock_agent, self._build_request_data())
+
+        self.exec_logger.log_execution_error.assert_called_once_with(
+            error_message="Error resolving broadcast template: template lookup failed",
+            error_data={"phase": "broadcast_template_resolve"},
         )
         self.exec_logger.log_broadcast_sent.assert_not_called()
 


### PR DESCRIPTION
## What

Refactors `_process_lambda_response` in `AgentWebhookUseCase` to use
separate try/except blocks for `build_message` and `send_message`.
Each failure path now logs a phase-specific message and sets
`error_data.phase` to `broadcast_build` or `broadcast_send`, replacing
the previous combined "Error building/sending broadcast" string.

Tests in `AgentWebhookUseCaseLoggingTest` are updated to assert the new
error messages and phase tags.

## Why

When triaging production execution traces, a single combined error
message made it impossible to tell whether the failure happened during
message construction or during the Flows dispatch call. Distinct phases
speed up root-cause analysis without changing the happy path.