### PR TITLE
feat: Persist payment and order timestamps on broadcast conversions

### DIFF
--- a/retail/broadcasts/migrations/0005_broadcastconversion_order_payment_metadata.py
+++ b/retail/broadcasts/migrations/0005_broadcastconversion_order_payment_metadata.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("broadcasts", "0004_broadcastconversion_broadcast"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="broadcastconversion",
+            name="order_created_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="broadcastconversion",
+            name="payment_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="broadcastconversion",
+            name="payment_type",
+            field=models.CharField(blank=True, default="", max_length=128),
+        ),
+    ]

--- a/retail/broadcasts/models.py
+++ b/retail/broadcasts/models.py
@@ -259,6 +259,10 @@ class BroadcastConversion(models.Model):
     value = models.DecimalField(max_digits=14, decimal_places=2, null=True, blank=True)
     currency = models.CharField(max_length=8, blank=True, default="")
 
+    order_created_at = models.DateTimeField(null=True, blank=True)
+    payment_at = models.DateTimeField(null=True, blank=True)
+    payment_type = models.CharField(max_length=128, blank=True, default="")
+
     converted_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/retail/broadcasts/tests/test_mark_broadcast_converted.py
+++ b/retail/broadcasts/tests/test_mark_broadcast_converted.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -109,11 +109,25 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
         order_form_id="of-123",
         value=15050,
         currency_code="BRL",
+        creation_date="2026-06-01T10:15:30.1234567+00:00",
+        authorized_date="2026-06-01T11:20:45.9876543+00:00",
+        payment_system_name="Visa",
     ):
         return {
             "orderFormId": order_form_id,
             "value": value,
             "storePreferencesData": {"currencyCode": currency_code},
+            "creationDate": creation_date,
+            "authorizedDate": authorized_date,
+            "paymentData": {
+                "transactions": [
+                    {
+                        "payments": [
+                            {"paymentSystemName": payment_system_name},
+                        ]
+                    }
+                ]
+            },
         }
 
     def test_skips_when_order_id_is_empty(self):
@@ -147,6 +161,15 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
         self.assertEqual(conversion.order_form_id, "of-99")
         self.assertEqual(conversion.value, Decimal("299.00"))
         self.assertEqual(conversion.currency, "BRL")
+        self.assertEqual(
+            conversion.order_created_at,
+            datetime(2026, 6, 1, 10, 15, 30, 123456, tzinfo=dt_timezone.utc),
+        )
+        self.assertEqual(
+            conversion.payment_at,
+            datetime(2026, 6, 1, 11, 20, 45, 987654, tzinfo=dt_timezone.utc),
+        )
+        self.assertEqual(conversion.payment_type, "Visa")
         self.assertIsNotNone(conversion.converted_at)
 
     def test_creates_conversion_matching_by_order_form_id(self):
@@ -305,6 +328,40 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
         conversion = BroadcastConversion.objects.get(order_id="order-50")
         self.assertEqual(conversion.currency, "")
         self.assertEqual(conversion.value, Decimal("75.00"))
+        self.assertIsNone(conversion.order_created_at)
+        self.assertIsNone(conversion.payment_at)
+        self.assertEqual(conversion.payment_type, "")
+
+    def test_handles_missing_payment_metadata_in_order_details(self):
+        self._create_broadcast(order_id="order-63")
+        self.vtex_io_service.get_order_details_by_id.return_value = {
+            "orderFormId": "of-63",
+            "value": 9900,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+
+        self.use_case.execute(order_id="order-63", project_uuid=str(self.project.uuid))
+
+        conversion = BroadcastConversion.objects.get(order_id="order-63")
+        self.assertIsNone(conversion.order_created_at)
+        self.assertIsNone(conversion.payment_at)
+        self.assertEqual(conversion.payment_type, "")
+
+    def test_handles_invalid_datetime_in_order_details(self):
+        self._create_broadcast(order_id="order-64")
+        self.vtex_io_service.get_order_details_by_id.return_value = (
+            self._vtex_order_details(
+                order_form_id="of-64",
+                creation_date="not-a-date",
+                authorized_date="also-invalid",
+            )
+        )
+
+        self.use_case.execute(order_id="order-64", project_uuid=str(self.project.uuid))
+
+        conversion = BroadcastConversion.objects.get(order_id="order-64")
+        self.assertIsNone(conversion.order_created_at)
+        self.assertIsNone(conversion.payment_at)
 
     def test_handles_missing_value_in_order_details(self):
         self._create_broadcast(order_id="order-60")
@@ -317,6 +374,9 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
 
         conversion = BroadcastConversion.objects.get(order_id="order-60")
         self.assertIsNone(conversion.value)
+        self.assertIsNone(conversion.order_created_at)
+        self.assertIsNone(conversion.payment_at)
+        self.assertEqual(conversion.payment_type, "")
 
     def test_handles_invalid_value_in_order_details(self):
         self._create_broadcast(order_id="order-61")
@@ -330,6 +390,9 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
 
         conversion = BroadcastConversion.objects.get(order_id="order-61")
         self.assertIsNone(conversion.value)
+        self.assertIsNone(conversion.order_created_at)
+        self.assertIsNone(conversion.payment_at)
+        self.assertEqual(conversion.payment_type, "")
 
     def test_handles_missing_store_preferences_data(self):
         self._create_broadcast(order_id="order-62")
@@ -359,6 +422,9 @@ class MarkBroadcastConvertedUseCaseTest(TestCase):
         conversion = BroadcastConversion.objects.get(order_id="order-empty")
         self.assertEqual(conversion.order_form_id, "of-empty")
         self.assertIsNone(conversion.value)
+        self.assertIsNone(conversion.order_created_at)
+        self.assertIsNone(conversion.payment_at)
+        self.assertEqual(conversion.payment_type, "")
         self.assertEqual(conversion.currency, "")
 
     def test_proceeds_when_vtex_lookup_raises(self):
@@ -654,4 +720,48 @@ class MarkBroadcastConvertedProjectResolutionTest(TestCase):
         self.vtex_io_service.get_order_details_by_id.assert_not_called()
         self.assertTrue(
             any("conversion_skip_multiple_projects" in msg for msg in cm.output)
+        )
+
+
+class MarkBroadcastConvertedParsingTest(TestCase):
+    """Unit tests for VTEX payload parsing helpers."""
+
+    def test_parse_vtex_datetime_truncates_fractional_seconds(self):
+        parsed = MarkBroadcastConvertedUseCase._parse_vtex_datetime(
+            "2026-06-01T10:15:30.1234567+00:00"
+        )
+
+        self.assertEqual(
+            parsed,
+            datetime(2026, 6, 1, 10, 15, 30, 123456, tzinfo=dt_timezone.utc),
+        )
+
+    def test_parse_vtex_datetime_handles_z_suffix(self):
+        parsed = MarkBroadcastConvertedUseCase._parse_vtex_datetime(
+            "2026-06-01T11:20:45.9876543Z"
+        )
+
+        self.assertEqual(
+            parsed,
+            datetime(2026, 6, 1, 11, 20, 45, 987654, tzinfo=dt_timezone.utc),
+        )
+
+    def test_parse_vtex_datetime_returns_none_for_invalid(self):
+        self.assertIsNone(MarkBroadcastConvertedUseCase._parse_vtex_datetime("bad"))
+        self.assertIsNone(MarkBroadcastConvertedUseCase._parse_vtex_datetime(None))
+
+    def test_extract_payment_type_from_nested_payload(self):
+        order_details = {
+            "paymentData": {
+                "transactions": [{"payments": [{"paymentSystemName": "Pix"}]}]
+            }
+        }
+
+        self.assertEqual(
+            MarkBroadcastConvertedUseCase._extract_payment_type(order_details),
+            "Pix",
+        )
+        self.assertEqual(
+            MarkBroadcastConvertedUseCase._extract_payment_type({"paymentData": {}}),
+            "",
         )

--- a/retail/broadcasts/tests/test_models.py
+++ b/retail/broadcasts/tests/test_models.py
@@ -115,9 +115,14 @@ class BroadcastConversionTest(TestCase):
         self.assertIsNone(conversion.order_form_id)
         self.assertIsNone(conversion.value)
         self.assertEqual(conversion.currency, "")
+        self.assertIsNone(conversion.order_created_at)
+        self.assertIsNone(conversion.payment_at)
+        self.assertEqual(conversion.payment_type, "")
         self.assertIsNotNone(conversion.converted_at)
 
     def test_persists_full_payload(self):
+        order_created_at = timezone.now()
+        payment_at = timezone.now()
         conversion = BroadcastConversion.objects.create(
             project=self.project,
             integrated_agent=self.integrated_agent,
@@ -125,6 +130,9 @@ class BroadcastConversionTest(TestCase):
             order_form_id="of-1",
             value=Decimal("199.99"),
             currency="BRL",
+            order_created_at=order_created_at,
+            payment_at=payment_at,
+            payment_type="Pix",
         )
 
         conversion.refresh_from_db()
@@ -133,6 +141,9 @@ class BroadcastConversionTest(TestCase):
         self.assertEqual(conversion.order_form_id, "of-1")
         self.assertEqual(conversion.value, Decimal("199.99"))
         self.assertEqual(conversion.currency, "BRL")
+        self.assertEqual(conversion.order_created_at, order_created_at)
+        self.assertEqual(conversion.payment_at, payment_at)
+        self.assertEqual(conversion.payment_type, "Pix")
 
     def test_unique_constraint_on_project_and_order_id(self):
         BroadcastConversion.objects.create(

--- a/retail/broadcasts/usecases/mark_broadcast_converted.py
+++ b/retail/broadcasts/usecases/mark_broadcast_converted.py
@@ -1,6 +1,8 @@
 import logging
+import re
 
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
@@ -35,6 +37,8 @@ _BROADCAST_STATUSES_INELIGIBLE_FOR_CONVERSION = (
     BroadcastStatus.UNKNOWN,
 )
 
+_VTEX_DATETIME_FRACTION = re.compile(r"(\.\d{6})\d+(?=[Z+-]|$)")
+
 
 @dataclass(frozen=True)
 class _OrderConversionDetails:
@@ -43,11 +47,29 @@ class _OrderConversionDetails:
     Empty / ``None`` fields signal "VTEX lookup did not return that
     information" and translate to leaving the corresponding column on
     the ``BroadcastConversion`` row NULL or empty.
+
+    Datetime fields come from VTEX ``creationDate`` (order placed) and
+    ``authorizedDate`` (payment approved). ``payment_type`` is the first
+    ``paymentSystemName`` under ``paymentData.transactions``.
     """
 
     order_form_id: Optional[str]
     value: Optional[Decimal]
     currency: str
+    order_created_at: Optional[datetime]
+    payment_at: Optional[datetime]
+    payment_type: str
+
+    @classmethod
+    def empty(cls) -> "_OrderConversionDetails":
+        return cls(
+            order_form_id=None,
+            value=None,
+            currency="",
+            order_created_at=None,
+            payment_at=None,
+            payment_type="",
+        )
 
 
 class MarkBroadcastConvertedUseCase:
@@ -56,9 +78,10 @@ class MarkBroadcastConvertedUseCase:
     The trigger is the VTEX ``invoiced`` event arriving on
     ``task_order_status_update``. The use case follows three steps:
 
-    1. Pull the canonical ``order_form_id`` / ``value`` / ``currency``
-       from VTEX so the conversion row is filled with authoritative
-       data even if the originating broadcast only knew one identifier.
+    1. Pull the canonical ``order_form_id`` / ``value`` / ``currency`` /
+       ``order_created_at`` / ``payment_at`` / ``payment_type`` from VTEX
+       so the conversion row is filled with authoritative data even if the
+       originating broadcast only knew one identifier.
     2. Pick the last-touch broadcast from the **payment recovery agent**
        (most recent non-failed dispatch that matches by ``order_id`` or
        ``order_form_id``). Only payment recovery dispatches are eligible;
@@ -168,18 +191,10 @@ class MarkBroadcastConvertedUseCase:
                 f"[CONVERSION_TRACKING] conversion_vtex_lookup_failed: "
                 f"project_uuid={project.uuid} order_id={order_id} error={exc}"
             )
-            return _OrderConversionDetails(
-                order_form_id=None,
-                value=None,
-                currency="",
-            )
+            return _OrderConversionDetails.empty()
 
         if not order_details:
-            return _OrderConversionDetails(
-                order_form_id=None,
-                value=None,
-                currency="",
-            )
+            return _OrderConversionDetails.empty()
 
         order_form_id = order_details.get("orderFormId")
         store_preferences = order_details.get("storePreferencesData") or {}
@@ -189,6 +204,11 @@ class MarkBroadcastConvertedUseCase:
             order_form_id=str(order_form_id) if order_form_id else None,
             value=self._extract_value(order_details),
             currency=currency,
+            order_created_at=self._parse_vtex_datetime(
+                order_details.get("creationDate")
+            ),
+            payment_at=self._parse_vtex_datetime(order_details.get("authorizedDate")),
+            payment_type=self._extract_payment_type(order_details),
         )
 
     @staticmethod
@@ -206,6 +226,40 @@ class MarkBroadcastConvertedUseCase:
             return (Decimal(raw_value) / Decimal(100)).quantize(Decimal("0.01"))
         except (TypeError, ValueError, ArithmeticError):
             return None
+
+    @staticmethod
+    def _parse_vtex_datetime(raw_value: object) -> Optional[datetime]:
+        """Parse VTEX ISO-8601 timestamps into aware ``datetime`` objects.
+
+        VTEX may return fractional seconds with more than six digits or a
+        trailing ``Z`` suffix, both of which ``datetime.fromisoformat`` can
+        reject on some Python versions.
+        """
+        if not raw_value or not isinstance(raw_value, str):
+            return None
+
+        normalized = raw_value.strip().replace("Z", "+00:00")
+        normalized = _VTEX_DATETIME_FRACTION.sub(r"\1", normalized)
+        try:
+            return datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _extract_payment_type(order_details: dict) -> str:
+        """Return the first payment system name reported by VTEX."""
+        transactions = (order_details.get("paymentData") or {}).get(
+            "transactions"
+        ) or []
+        if not transactions:
+            return ""
+
+        payments = transactions[0].get("payments") or []
+        if not payments:
+            return ""
+
+        payment_system_name = payments[0].get("paymentSystemName")
+        return str(payment_system_name) if payment_system_name else ""
 
     def _select_last_touch_broadcast(
         self,
@@ -309,6 +363,9 @@ class MarkBroadcastConvertedUseCase:
                 "order_form_id": order_form_id,
                 "value": details.value,
                 "currency": details.currency,
+                "order_created_at": details.order_created_at,
+                "payment_at": details.payment_at,
+                "payment_type": details.payment_type,
             },
         )
 
@@ -329,5 +386,8 @@ class MarkBroadcastConvertedUseCase:
             f"order_id={conversion.order_id} "
             f"order_form_id={conversion.order_form_id} "
             f"value={conversion.value} currency={conversion.currency} "
+            f"order_created_at={conversion.order_created_at} "
+            f"payment_at={conversion.payment_at} "
+            f"payment_type={conversion.payment_type} "
             f"broadcast_uuid={last_touch_broadcast.uuid}"
         )


### PR DESCRIPTION
## What

Extends `BroadcastConversion` with three VTEX-sourced fields captured at
write time by `MarkBroadcastConvertedUseCase`: `order_created_at`
(`creationDate`), `payment_at` (`authorizedDate`), and `payment_type`
(first `paymentSystemName` under `paymentData.transactions`).

Changes span the model, migration `0005`, the use case extraction/persistence
logic, and unit/integration tests. Datetime parsing normalizes VTEX ISO-8601
variants (long fractional seconds and `Z` suffix) before calling
`datetime.fromisoformat`.

## Why

Conversion analytics need the order creation time, payment approval time, and
payment method alongside the existing value/currency fields. Pulling this
data from the same VTEX order-details lookup already performed on `invoiced`
adds no extra API call and keeps attribution idempotent.
