### PR TITLE
feat: Add broadcast dispatch and conversion report APIs

### DIFF
--- a/retail/broadcasts/api/serializers.py
+++ b/retail/broadcasts/api/serializers.py
@@ -1,0 +1,58 @@
+"""DRF serializers for broadcast dispatch and summary report APIs."""
+
+from rest_framework import serializers
+
+from retail.broadcasts.usecases.list_broadcast_dispatches import BroadcastDispatchRow
+
+
+class _DateRangeQuerySerializer(serializers.Serializer):
+    start_date = serializers.DateField(required=True)
+    end_date = serializers.DateField(required=True)
+
+    def validate(self, attrs):
+        if attrs["start_date"] > attrs["end_date"]:
+            raise serializers.ValidationError(
+                "start_date must be on or before end_date."
+            )
+        return attrs
+
+
+class ListBroadcastDispatchesQuerySerializer(_DateRangeQuerySerializer):
+    """Query params for the paginated dispatch report."""
+
+    page = serializers.IntegerField(required=False, default=1, min_value=1)
+    page_size = serializers.IntegerField(required=False, default=20, min_value=1)
+
+
+class GetBroadcastSummaryQuerySerializer(_DateRangeQuerySerializer):
+    """Query params for the consolidated delivered/converted report."""
+
+
+class BroadcastDispatchRowSerializer(serializers.Serializer):
+    contact_urn = serializers.CharField()
+    order_id = serializers.CharField(allow_null=True)
+    status = serializers.CharField()
+    converted = serializers.BooleanField()
+    dispatched_at = serializers.DateTimeField()
+    converted_at = serializers.DateTimeField(allow_null=True)
+
+    def to_representation(self, instance: BroadcastDispatchRow) -> dict:
+        return {
+            "contact_urn": instance.contact_urn,
+            "order_id": instance.order_id,
+            "status": instance.status,
+            "converted": instance.converted,
+            "dispatched_at": instance.dispatched_at,
+            "converted_at": instance.converted_at,
+        }
+
+
+class BroadcastSummarySerializer(serializers.Serializer):
+    delivered = serializers.IntegerField()
+    converted = serializers.IntegerField()
+
+    def to_representation(self, instance) -> dict:
+        return {
+            "delivered": instance.delivered,
+            "converted": instance.converted,
+        }

--- a/retail/broadcasts/api/urls.py
+++ b/retail/broadcasts/api/urls.py
@@ -1,0 +1,32 @@
+from django.urls import path
+
+from retail.broadcasts.api.views import (
+    BroadcastAgentDispatchesView,
+    BroadcastAgentSummaryView,
+    BroadcastProjectDispatchesView,
+    BroadcastProjectSummaryView,
+)
+
+
+urlpatterns = [
+    path(
+        "projects/dispatches/",
+        BroadcastProjectDispatchesView.as_view(),
+        name="broadcast-project-dispatches",
+    ),
+    path(
+        "projects/summary/",
+        BroadcastProjectSummaryView.as_view(),
+        name="broadcast-project-summary",
+    ),
+    path(
+        "assigneds/<uuid:agent_uuid>/dispatches/",
+        BroadcastAgentDispatchesView.as_view(),
+        name="broadcast-agent-dispatches",
+    ),
+    path(
+        "assigneds/<uuid:agent_uuid>/summary/",
+        BroadcastAgentSummaryView.as_view(),
+        name="broadcast-agent-summary",
+    ),
+]

--- a/retail/broadcasts/api/views.py
+++ b/retail/broadcasts/api/views.py
@@ -1,0 +1,171 @@
+"""HTTP layer for broadcast dispatch and conversion report APIs."""
+
+from typing import Optional
+from uuid import UUID
+
+from rest_framework import status
+from rest_framework.exceptions import NotFound, ParseError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.shared.permissions import IsIntegratedAgentFromProject
+from retail.broadcasts.api.serializers import (
+    BroadcastDispatchRowSerializer,
+    BroadcastSummarySerializer,
+    GetBroadcastSummaryQuerySerializer,
+    ListBroadcastDispatchesQuerySerializer,
+)
+from retail.broadcasts.usecases.get_broadcast_summary import (
+    GetBroadcastSummaryDTO,
+    GetBroadcastSummaryUseCase,
+)
+from retail.broadcasts.usecases.list_broadcast_dispatches import (
+    ListBroadcastDispatchesDTO,
+    ListBroadcastDispatchesUseCase,
+)
+from retail.internal.permissions import HasProjectPermission
+from retail.internal.views import KeycloakAPIView
+
+
+class _BroadcastReportBaseView(KeycloakAPIView):
+    permission_classes = [IsAuthenticated, HasProjectPermission]
+
+    @staticmethod
+    def _parse_project_uuid(request: Request) -> UUID:
+        try:
+            return UUID(request.headers.get("Project-Uuid"))
+        except (TypeError, ValueError) as exc:
+            raise ParseError("Project-Uuid header must be a valid UUID.") from exc
+
+    @staticmethod
+    def _build_dispatches_response(
+        dto: ListBroadcastDispatchesDTO,
+        rows: list,
+        total: int,
+    ) -> Response:
+        row_serializer = BroadcastDispatchRowSerializer(rows, many=True)
+        return Response(
+            {
+                "results": row_serializer.data,
+                "pagination": {
+                    "page": dto.page,
+                    "page_size": dto.page_size,
+                    "total": total,
+                },
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    def _list_dispatches(
+        self,
+        request: Request,
+        *,
+        project_uuid: UUID,
+        integrated_agent_uuid: Optional[UUID] = None,
+    ) -> Response:
+        query_serializer = ListBroadcastDispatchesQuerySerializer(
+            data=request.query_params
+        )
+        query_serializer.is_valid(raise_exception=True)
+        validated = query_serializer.validated_data
+
+        dto = ListBroadcastDispatchesDTO(
+            project_uuid=project_uuid,
+            integrated_agent_uuid=integrated_agent_uuid,
+            start_date=validated["start_date"],
+            end_date=validated["end_date"],
+            page=validated.get("page", 1),
+            page_size=validated.get("page_size", 20),
+        )
+        rows, total = ListBroadcastDispatchesUseCase().execute(dto)
+        return self._build_dispatches_response(dto, rows, total)
+
+    def _build_summary_response(
+        self,
+        request: Request,
+        *,
+        project_uuid: UUID,
+        integrated_agent_uuid: Optional[UUID] = None,
+    ) -> Response:
+        query_serializer = GetBroadcastSummaryQuerySerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        validated = query_serializer.validated_data
+
+        dto = GetBroadcastSummaryDTO(
+            project_uuid=project_uuid,
+            integrated_agent_uuid=integrated_agent_uuid,
+            start_date=validated["start_date"],
+            end_date=validated["end_date"],
+        )
+        result = GetBroadcastSummaryUseCase().execute(dto)
+        return Response(
+            BroadcastSummarySerializer(result).data,
+            status=status.HTTP_200_OK,
+        )
+
+
+class BroadcastProjectDispatchesView(_BroadcastReportBaseView):
+    """GET ``/api/v3/broadcasts/projects/dispatches/`` — project-wide report."""
+
+    def get(self, request: Request) -> Response:
+        return self._list_dispatches(
+            request,
+            project_uuid=self._parse_project_uuid(request),
+        )
+
+
+class _BroadcastAgentReportBaseView(_BroadcastReportBaseView):
+    permission_classes = [
+        IsAuthenticated,
+        HasProjectPermission,
+        IsIntegratedAgentFromProject,
+    ]
+
+    def _get_integrated_agent(
+        self, request: Request, agent_uuid: UUID
+    ) -> IntegratedAgent:
+        try:
+            integrated_agent = IntegratedAgent.objects.select_related("project").get(
+                uuid=agent_uuid
+            )
+        except IntegratedAgent.DoesNotExist:
+            raise NotFound(f"Integrated agent not found: {agent_uuid}")
+
+        self.check_object_permissions(request, integrated_agent)
+        return integrated_agent
+
+
+class BroadcastAgentDispatchesView(_BroadcastAgentReportBaseView):
+    """GET ``/api/v3/broadcasts/assigneds/{agent_uuid}/dispatches/``."""
+
+    def get(self, request: Request, agent_uuid: UUID) -> Response:
+        integrated_agent = self._get_integrated_agent(request, agent_uuid)
+        return self._list_dispatches(
+            request,
+            project_uuid=integrated_agent.project.uuid,
+            integrated_agent_uuid=integrated_agent.uuid,
+        )
+
+
+class BroadcastProjectSummaryView(_BroadcastReportBaseView):
+    """GET ``/api/v3/broadcasts/projects/summary/`` — project-wide totals."""
+
+    def get(self, request: Request) -> Response:
+        return self._build_summary_response(
+            request,
+            project_uuid=self._parse_project_uuid(request),
+        )
+
+
+class BroadcastAgentSummaryView(_BroadcastAgentReportBaseView):
+    """GET ``/api/v3/broadcasts/assigneds/{agent_uuid}/summary/``."""
+
+    def get(self, request: Request, agent_uuid: UUID) -> Response:
+        integrated_agent = self._get_integrated_agent(request, agent_uuid)
+        return self._build_summary_response(
+            request,
+            project_uuid=integrated_agent.project.uuid,
+            integrated_agent_uuid=integrated_agent.uuid,
+        )

--- a/retail/broadcasts/tests/test_broadcast_report_views.py
+++ b/retail/broadcasts/tests/test_broadcast_report_views.py
@@ -126,6 +126,15 @@ class BroadcastReportViewsTest(BaseTestMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_project_dispatches_rejects_invalid_project_header(self):
+        response = self._get(
+            self.project_dispatches_url,
+            project_uuid="not-a-valid-uuid",
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_summary_returns_delivered_and_converted_totals(self):
         BroadcastMessage.objects.create(
             project=self.project,

--- a/retail/broadcasts/tests/test_broadcast_report_views.py
+++ b/retail/broadcasts/tests/test_broadcast_report_views.py
@@ -1,0 +1,278 @@
+"""End-to-end tests for broadcast report APIs."""
+
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.broadcasts.models import (
+    BroadcastConversion,
+    BroadcastMessage,
+    BroadcastStatus,
+)
+from retail.internal.test_mixins import BaseTestMixin, with_test_settings
+from retail.projects.models import Project
+
+
+User = get_user_model()
+
+
+@with_test_settings
+class BroadcastReportViewsTest(BaseTestMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions={"project_authorization": 2},
+        )
+
+        self.project = Project.objects.create(name="Project A", uuid=uuid4())
+        self.other_project = Project.objects.create(name="Project B", uuid=uuid4())
+        self.agent = Agent.objects.create(
+            uuid=uuid4(),
+            name="Agent",
+            slug="agent",
+            description="",
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+        self.second_integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+        self.other_integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.other_project,
+            channel_uuid=uuid4(),
+        )
+
+        self.user = User.objects.create_user(
+            username="tester",
+            password="x",
+            email="tester@example.com",
+        )
+        self.client.force_authenticate(self.user)
+
+        self.project_dispatches_url = reverse("broadcast-project-dispatches")
+        self.project_summary_url = reverse("broadcast-project-summary")
+        self.agent_dispatches_url = reverse(
+            "broadcast-agent-dispatches",
+            kwargs={"agent_uuid": str(self.integrated_agent.uuid)},
+        )
+        self.summary_url = reverse(
+            "broadcast-agent-summary",
+            kwargs={"agent_uuid": str(self.integrated_agent.uuid)},
+        )
+        self.query = "start_date=2026-06-01&end_date=2026-06-30"
+
+    def _get(self, url, *, project_uuid=None, query=None):
+        headers = {"HTTP_AUTHORIZATION": "Bearer token"}
+        if project_uuid is not None:
+            headers["HTTP_PROJECT_UUID"] = str(project_uuid)
+        full_url = url
+        if query:
+            full_url = f"{url}?{query}"
+        return self.client.get(full_url, **headers)
+
+    def test_project_dispatches_returns_report_rows(self):
+        broadcast = BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511888888888",
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-99",
+        )
+        converted_at = timezone.now()
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            broadcast=broadcast,
+            order_id="order-99",
+            converted_at=converted_at,
+        )
+
+        response = self._get(
+            self.project_dispatches_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["pagination"]["total"], 1)
+        row = response.data["results"][0]
+        self.assertEqual(row["contact_urn"], "whatsapp:5511888888888")
+        self.assertEqual(row["order_id"], "order-99")
+        self.assertEqual(row["status"], BroadcastStatus.DELIVERED)
+        self.assertTrue(row["converted"])
+        self.assertIsNotNone(row["dispatched_at"])
+        self.assertIsNotNone(row["converted_at"])
+
+    def test_project_dispatches_requires_project_header(self):
+        response = self._get(self.project_dispatches_url, query=self.query)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_summary_returns_delivered_and_converted_totals(self):
+        BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511777777777",
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-1",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            order_id="order-1",
+        )
+
+        response = self._get(
+            self.summary_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["delivered"], 1)
+        self.assertEqual(response.data["converted"], 1)
+
+    def test_summary_rejects_agent_from_other_project(self):
+        response = self._get(
+            self.summary_url,
+            project_uuid=self.other_project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_project_dispatches_rejects_invalid_date_range(self):
+        response = self._get(
+            self.project_dispatches_url,
+            project_uuid=self.project.uuid,
+            query="start_date=2026-06-30&end_date=2026-06-01",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_summary_returns_404_for_unknown_agent(self):
+        unknown_url = reverse(
+            "broadcast-agent-summary",
+            kwargs={"agent_uuid": str(uuid4())},
+        )
+
+        response = self._get(
+            unknown_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_project_summary_returns_totals_for_all_agents(self):
+        BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511444444444",
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-a",
+        )
+        BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.second_integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511333333333",
+            status=BroadcastStatus.READ,
+            order_id="order-b",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            order_id="order-a",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.second_integrated_agent,
+            order_id="order-b",
+        )
+
+        response = self._get(
+            self.project_summary_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["delivered"], 2)
+        self.assertEqual(response.data["converted"], 2)
+
+    def test_project_summary_requires_project_header(self):
+        response = self._get(self.project_summary_url, query=self.query)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_agent_dispatches_returns_only_matching_agent_rows(self):
+        BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511666666666",
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-agent",
+        )
+        BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.second_integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511555555555",
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-other-agent",
+        )
+
+        response = self._get(
+            self.agent_dispatches_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["pagination"]["total"], 1)
+        self.assertEqual(response.data["results"][0]["order_id"], "order-agent")
+
+    def test_agent_dispatches_rejects_agent_from_other_project(self):
+        response = self._get(
+            self.agent_dispatches_url,
+            project_uuid=self.other_project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_agent_dispatches_returns_404_for_unknown_agent(self):
+        unknown_url = reverse(
+            "broadcast-agent-dispatches",
+            kwargs={"agent_uuid": str(uuid4())},
+        )
+
+        response = self._get(
+            unknown_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/retail/broadcasts/tests/test_get_broadcast_summary.py
+++ b/retail/broadcasts/tests/test_get_broadcast_summary.py
@@ -1,0 +1,152 @@
+"""Tests for ``GetBroadcastSummaryUseCase``."""
+
+from datetime import date, datetime, timezone as dt_timezone
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.broadcasts.models import (
+    BroadcastConversion,
+    BroadcastMessage,
+    BroadcastStatus,
+)
+from retail.broadcasts.usecases.get_broadcast_summary import (
+    GetBroadcastSummaryDTO,
+    GetBroadcastSummaryUseCase,
+)
+from retail.projects.models import Project
+
+
+class GetBroadcastSummaryUseCaseTest(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Project A", uuid=uuid4())
+        self.other_project = Project.objects.create(name="Project B", uuid=uuid4())
+        self.agent = Agent.objects.create(name="Agent", project=self.project)
+        self.integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+        self.other_integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+        self.use_case = GetBroadcastSummaryUseCase()
+        self.start_date = date(2026, 6, 1)
+        self.end_date = date(2026, 6, 30)
+
+    def _create_broadcast(
+        self, *, integrated_agent=None, status=BroadcastStatus.DELIVERED, **overrides
+    ):
+        defaults = {
+            "project": self.project,
+            "integrated_agent": integrated_agent or self.integrated_agent,
+            "template_name": "payment_recovery",
+            "contact_urn": "whatsapp:5511999999999",
+            "status": status,
+            "order_id": "order-1",
+        }
+        defaults.update(overrides)
+        return BroadcastMessage.objects.create(**defaults)
+
+    def _execute(self, **overrides):
+        dto = GetBroadcastSummaryDTO(
+            project_uuid=self.project.uuid,
+            integrated_agent_uuid=self.integrated_agent.uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            **overrides,
+        )
+        return self.use_case.execute(dto)
+
+    def test_counts_delivered_and_converted_for_agent(self):
+        broadcast = self._create_broadcast(status=BroadcastStatus.DELIVERED)
+        self._create_broadcast(
+            integrated_agent=self.integrated_agent,
+            status=BroadcastStatus.READ,
+            order_id="order-2",
+        )
+        self._create_broadcast(
+            integrated_agent=self.integrated_agent,
+            status=BroadcastStatus.SENT,
+            order_id="order-3",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            broadcast=broadcast,
+            order_id="order-1",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            order_id="order-4",
+        )
+
+        result = self._execute()
+
+        self.assertEqual(result.delivered, 2)
+        self.assertEqual(result.converted, 2)
+
+    def test_excludes_other_agents_and_out_of_range_rows(self):
+        self._create_broadcast(status=BroadcastStatus.DELIVERED)
+        self._create_broadcast(
+            integrated_agent=self.other_integrated_agent,
+            status=BroadcastStatus.DELIVERED,
+            order_id="other-agent",
+        )
+        out_of_range = self._create_broadcast(
+            status=BroadcastStatus.DELIVERED,
+            order_id="old-order",
+        )
+        BroadcastMessage.objects.filter(pk=out_of_range.pk).update(
+            created_at=datetime(2026, 5, 1, 12, 0, tzinfo=dt_timezone.utc)
+        )
+        conversion = BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            order_id="order-conv",
+        )
+        BroadcastConversion.objects.filter(pk=conversion.pk).update(
+            converted_at=datetime(2026, 5, 2, 12, 0, tzinfo=dt_timezone.utc)
+        )
+
+        result = self._execute()
+
+        self.assertEqual(result.delivered, 1)
+        self.assertEqual(result.converted, 0)
+
+    def test_aggregates_all_agents_when_integrated_agent_uuid_is_omitted(self):
+        self._create_broadcast(
+            integrated_agent=self.integrated_agent,
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-a",
+        )
+        self._create_broadcast(
+            integrated_agent=self.other_integrated_agent,
+            status=BroadcastStatus.READ,
+            order_id="order-b",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            order_id="order-a",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.other_integrated_agent,
+            order_id="order-b",
+        )
+
+        dto = GetBroadcastSummaryDTO(
+            project_uuid=self.project.uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+        )
+        result = self.use_case.execute(dto)
+
+        self.assertEqual(result.delivered, 2)
+        self.assertEqual(result.converted, 2)

--- a/retail/broadcasts/tests/test_list_broadcast_dispatches.py
+++ b/retail/broadcasts/tests/test_list_broadcast_dispatches.py
@@ -1,0 +1,147 @@
+"""Tests for ``ListBroadcastDispatchesUseCase``."""
+
+from datetime import date, datetime, timedelta, timezone as dt_timezone
+from uuid import uuid4
+
+from django.test import TestCase
+from django.utils import timezone
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.broadcasts.models import (
+    BroadcastConversion,
+    BroadcastMessage,
+    BroadcastStatus,
+)
+from retail.broadcasts.usecases.list_broadcast_dispatches import (
+    ListBroadcastDispatchesDTO,
+    ListBroadcastDispatchesUseCase,
+)
+from retail.projects.models import Project
+
+
+class ListBroadcastDispatchesUseCaseTest(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Project A", uuid=uuid4())
+        self.other_project = Project.objects.create(name="Project B", uuid=uuid4())
+        self.agent = Agent.objects.create(name="Agent", project=self.project)
+        self.integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+        self.other_integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+        self.use_case = ListBroadcastDispatchesUseCase()
+        self.start_date = date(2026, 6, 1)
+        self.end_date = date(2026, 6, 30)
+
+    def _create_broadcast(self, *, project=None, **overrides):
+        defaults = {
+            "project": project or self.project,
+            "integrated_agent": self.integrated_agent,
+            "template_name": "payment_recovery",
+            "contact_urn": "whatsapp:5511999999999",
+            "status": BroadcastStatus.DELIVERED,
+            "order_id": "order-1",
+        }
+        defaults.update(overrides)
+        broadcast = BroadcastMessage.objects.create(**defaults)
+        return broadcast
+
+    def _execute(self, **overrides):
+        dto = ListBroadcastDispatchesDTO(
+            project_uuid=self.project.uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            **overrides,
+        )
+        return self.use_case.execute(dto)
+
+    def test_returns_dispatch_rows_with_conversion_metadata(self):
+        broadcast = self._create_broadcast(order_id="order-conv")
+        converted_at = timezone.now()
+        conversion = BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            broadcast=broadcast,
+            order_id="order-conv",
+        )
+        BroadcastConversion.objects.filter(pk=conversion.pk).update(
+            converted_at=converted_at
+        )
+
+        rows, total = self._execute()
+
+        self.assertEqual(total, 1)
+        row = rows[0]
+        self.assertEqual(row.contact_urn, "whatsapp:5511999999999")
+        self.assertEqual(row.order_id, "order-conv")
+        self.assertEqual(row.status, BroadcastStatus.DELIVERED)
+        self.assertTrue(row.converted)
+        self.assertEqual(row.dispatched_at, broadcast.created_at)
+        self.assertEqual(row.converted_at, converted_at)
+
+    def test_marks_dispatch_as_not_converted_when_no_attribution(self):
+        self._create_broadcast(order_id="order-no-conv")
+
+        rows, total = self._execute()
+
+        self.assertEqual(total, 1)
+        self.assertFalse(rows[0].converted)
+        self.assertIsNone(rows[0].converted_at)
+
+    def test_filters_by_project_and_dispatch_date_range(self):
+        in_range = self._create_broadcast(order_id="in-range")
+        out_of_range = self._create_broadcast(order_id="out-range")
+        BroadcastMessage.objects.filter(pk=out_of_range.pk).update(
+            created_at=datetime(2026, 5, 1, 12, 0, tzinfo=dt_timezone.utc)
+        )
+        other_project_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.other_project,
+            channel_uuid=uuid4(),
+        )
+        self._create_broadcast(
+            project=self.other_project,
+            integrated_agent=other_project_agent,
+            order_id="other-project",
+        )
+
+        rows, total = self._execute()
+
+        self.assertEqual(total, 1)
+        self.assertEqual(rows[0].order_id, in_range.order_id)
+
+    def test_paginates_results(self):
+        for index in range(3):
+            broadcast = self._create_broadcast(
+                contact_urn=f"whatsapp:551199999999{index}",
+                order_id=f"order-{index}",
+            )
+            BroadcastMessage.objects.filter(pk=broadcast.pk).update(
+                created_at=timezone.now() - timedelta(minutes=index)
+            )
+
+        rows, total = self._execute(page=2, page_size=1)
+
+        self.assertEqual(total, 3)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].order_id, "order-1")
+
+    def test_filters_by_integrated_agent_when_uuid_is_provided(self):
+        self._create_broadcast(order_id="order-agent-a")
+        self._create_broadcast(
+            integrated_agent=self.other_integrated_agent,
+            order_id="order-agent-b",
+        )
+
+        rows, total = self._execute(
+            integrated_agent_uuid=self.integrated_agent.uuid,
+        )
+
+        self.assertEqual(total, 1)
+        self.assertEqual(rows[0].order_id, "order-agent-a")

--- a/retail/broadcasts/usecases/get_broadcast_summary.py
+++ b/retail/broadcasts/usecases/get_broadcast_summary.py
@@ -1,0 +1,71 @@
+"""Use case: consolidated delivered/converted counts for a project or agent."""
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone as dt_timezone
+from typing import Optional
+from uuid import UUID
+
+from retail.broadcasts.models import (
+    BroadcastConversion,
+    BroadcastMessage,
+    BroadcastStatus,
+)
+
+
+@dataclass(frozen=True)
+class GetBroadcastSummaryDTO:
+    """Input for ``GetBroadcastSummaryUseCase``.
+
+    When ``integrated_agent_uuid`` is omitted, totals aggregate every
+    dispatch/conversion in the project. When set, both counts are scoped
+    to that integrated agent.
+
+    ``delivered`` counts dispatches whose status reached the device
+    (``delivered`` or ``read``) within the dispatch date range.
+    ``converted`` counts ``BroadcastConversion`` rows within the conversion
+    date range.
+    """
+
+    project_uuid: UUID
+    start_date: date
+    end_date: date
+    integrated_agent_uuid: Optional[UUID] = None
+
+
+@dataclass(frozen=True)
+class BroadcastSummaryResult:
+    delivered: int
+    converted: int
+
+
+class GetBroadcastSummaryUseCase:
+    """Return delivered and converted totals for a project or integrated agent."""
+
+    _DELIVERED_STATUSES = (BroadcastStatus.DELIVERED, BroadcastStatus.READ)
+
+    def execute(self, dto: GetBroadcastSummaryDTO) -> BroadcastSummaryResult:
+        start_dt = datetime.combine(dto.start_date, time.min, tzinfo=dt_timezone.utc)
+        end_dt = datetime.combine(dto.end_date, time.max, tzinfo=dt_timezone.utc)
+
+        delivered_qs = BroadcastMessage.objects.filter(
+            project__uuid=dto.project_uuid,
+            created_at__range=(start_dt, end_dt),
+            status__in=self._DELIVERED_STATUSES,
+        )
+        converted_qs = BroadcastConversion.objects.filter(
+            project__uuid=dto.project_uuid,
+            converted_at__range=(start_dt, end_dt),
+        )
+
+        if dto.integrated_agent_uuid is not None:
+            delivered_qs = delivered_qs.filter(
+                integrated_agent__uuid=dto.integrated_agent_uuid
+            )
+            converted_qs = converted_qs.filter(
+                integrated_agent__uuid=dto.integrated_agent_uuid
+            )
+
+        return BroadcastSummaryResult(
+            delivered=delivered_qs.count(),
+            converted=converted_qs.count(),
+        )

--- a/retail/broadcasts/usecases/list_broadcast_dispatches.py
+++ b/retail/broadcasts/usecases/list_broadcast_dispatches.py
@@ -1,0 +1,87 @@
+"""Use case: paginated broadcast dispatch report for a project."""
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone as dt_timezone
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+from django.db.models import Exists, OuterRef, Subquery
+
+from retail.broadcasts.models import BroadcastConversion, BroadcastMessage
+
+
+@dataclass(frozen=True)
+class ListBroadcastDispatchesDTO:
+    """Input for ``ListBroadcastDispatchesUseCase``.
+
+    ``project_uuid`` scopes every row to a single tenant. When
+    ``integrated_agent_uuid`` is set, results are further restricted to
+    dispatches from that integrated agent. The date range filters on
+    ``BroadcastMessage.created_at`` (dispatch time), inclusive on both
+    calendar days in UTC.
+    """
+
+    project_uuid: UUID
+    start_date: date
+    end_date: date
+    integrated_agent_uuid: Optional[UUID] = None
+    page: int = 1
+    page_size: int = 20
+
+
+@dataclass(frozen=True)
+class BroadcastDispatchRow:
+    """One broadcast dispatch row for the report API."""
+
+    contact_urn: str
+    order_id: Optional[str]
+    status: str
+    converted: bool
+    dispatched_at: datetime
+    converted_at: Optional[datetime]
+
+
+class ListBroadcastDispatchesUseCase:
+    """List broadcast dispatches with conversion attribution flags."""
+
+    def execute(
+        self, dto: ListBroadcastDispatchesDTO
+    ) -> Tuple[List[BroadcastDispatchRow], int]:
+        start_dt = datetime.combine(dto.start_date, time.min, tzinfo=dt_timezone.utc)
+        end_dt = datetime.combine(dto.end_date, time.max, tzinfo=dt_timezone.utc)
+
+        conversion_at_subquery = BroadcastConversion.objects.filter(
+            broadcast_id=OuterRef("pk")
+        ).values("converted_at")[:1]
+
+        queryset = BroadcastMessage.objects.filter(
+            project__uuid=dto.project_uuid,
+            created_at__range=(start_dt, end_dt),
+        )
+        if dto.integrated_agent_uuid is not None:
+            queryset = queryset.filter(integrated_agent__uuid=dto.integrated_agent_uuid)
+
+        queryset = queryset.annotate(
+            is_converted=Exists(
+                BroadcastConversion.objects.filter(broadcast_id=OuterRef("pk"))
+            ),
+            conversion_converted_at=Subquery(conversion_at_subquery),
+        ).order_by("-created_at", "uuid")
+
+        total = queryset.count()
+        page = max(dto.page, 1)
+        page_size = max(dto.page_size, 1)
+        offset = (page - 1) * page_size
+
+        rows = [
+            BroadcastDispatchRow(
+                contact_urn=message.contact_urn,
+                order_id=message.order_id,
+                status=message.status,
+                converted=message.is_converted,
+                dispatched_at=message.created_at,
+                converted_at=message.conversion_converted_at,
+            )
+            for message in queryset[offset : offset + page_size]  # noqa: E203
+        ]
+        return rows, total

--- a/retail/urls.py
+++ b/retail/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path("", include(webhooks_urls)),
     path("api/v3/templates/", include("retail.templates.urls")),
     path("api/v3/agents/", include("retail.agents.api.urls")),
+    path("api/v3/broadcasts/", include("retail.broadcasts.api.urls")),
     path("vtex/", include(vtex_urls)),
     path("docs/", swagger_view, name="swagger"),
 ]


### PR DESCRIPTION
## What

Adds four read-only report endpoints under `/api/v3/broadcasts/` for
broadcast dispatch and conversion analytics:

- `GET /projects/dispatches/` — paginated dispatch rows for the project
- `GET /projects/summary/` — project-wide `delivered` / `converted` totals
- `GET /assigneds/{agent_uuid}/dispatches/` — paginated rows scoped to one integrated agent
- `GET /assigneds/{agent_uuid}/summary/` — agent-scoped totals

All endpoints require `Authorization` and `Project-Uuid` headers. Query
params: `start_date`, `end_date` (required); list endpoints also accept
`page` and `page_size` (defaults 1/20).

Implementation follows Clean Architecture: thin views in
`retail/broadcasts/api/`, DTOs + use cases in
`retail/broadcasts/usecases/`, serializers for validation/response
shaping. List rows expose `contact_urn`, `order_id`, `status`, `converted`,
`dispatched_at`, and `converted_at`. Summary returns `{ "delivered", "converted" }`.
`converted` is true when a `BroadcastConversion` FK exists on the dispatch
(last-touch). `delivered` counts dispatches with status `delivered` or
`read` within the dispatch date range; `converted` counts conversions
within the conversion date range.

## Why

Product and operations teams need project- and agent-level visibility
into broadcast performance (deliveries vs. conversions) over configurable
date ranges, without querying the database directly.
