### PR TITLE
fix: Use Meta WABA template name in agent logs CSV export

### DIFF
--- a/retail/agents/domains/agent_execution/row_mapper.py
+++ b/retail/agents/domains/agent_execution/row_mapper.py
@@ -106,6 +106,24 @@ def resolve_template_name(execution: AgentExecution) -> Optional[str]:
     return template_display_name(execution.template)
 
 
+def resolve_meta_template_name(execution: AgentExecution) -> Optional[str]:
+    """Return the WABA-registered template name used at dispatch time.
+
+    Unlike ``resolve_template_name`` (human-readable ``display_name`` for
+    the list API), this reads ``Template.current_version.template_name``
+    so the CSV export matches the identifier Meta stores for the message.
+    """
+    template = execution.template
+    if template is None:
+        return None
+
+    current_version = getattr(template, "current_version", None)
+    if current_version is not None:
+        return current_version.template_name
+
+    return template.name
+
+
 def resolve_template_uuid(execution: AgentExecution) -> Optional[str]:
     if execution.template_id is None:
         return None

--- a/retail/agents/domains/agent_execution/tests/test_export_agent_logs_usecase.py
+++ b/retail/agents/domains/agent_execution/tests/test_export_agent_logs_usecase.py
@@ -28,6 +28,7 @@ from retail.agents.domains.agent_execution.usecases.export_agent_logs import (
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_management.models import Agent
 from retail.projects.models import Project
+from retail.templates.models import Template, Version
 
 
 class _FakeS3Service:
@@ -173,6 +174,37 @@ class ExportAgentLogsUseCaseTests(TestCase):
         self.assertEqual(len(rows), 2, "header + one in-range execution")
         data_row = dict(zip(rows[0], rows[1]))
         self.assertEqual(data_row["uuid"], str(inside.uuid))
+
+    def test_template_name_uses_meta_waba_name_not_display_name(self):
+        app_uuid = uuid4()
+        template = Template.objects.create(
+            uuid=uuid4(),
+            name="order_shipped",
+            display_name="Order shipped",
+            integrated_agent=self.integrated_agent,
+        )
+        version = Version.objects.create(
+            template=template,
+            template_name="weni_order_shipped_1739284723",
+            integrations_app_uuid=app_uuid,
+            project=self.project,
+            status="APPROVED",
+        )
+        template.current_version = version
+        template.save(update_fields=["current_version"])
+
+        _make_execution(self.integrated_agent, template=template)
+
+        self.use_case.execute(self._filter())
+
+        _, content, _ = self.fake_s3.upload_calls[0]
+        rows = self._csv_rows(content)
+        self.assertEqual(rows[0], CSV_HEADER)
+        self.assertNotIn("template_uuid", rows[0])
+        self.assertNotIn("summary", rows[0])
+        data_row = dict(zip(rows[0], rows[1]))
+        self.assertEqual(data_row["template_name"], "weni_order_shipped_1739284723")
+        self.assertNotEqual(data_row["template_name"], "Order shipped")
 
 
 class ExportAgentLogsBucketResolutionTests(TestCase):

--- a/retail/agents/domains/agent_execution/tests/test_row_mapper.py
+++ b/retail/agents/domains/agent_execution/tests/test_row_mapper.py
@@ -21,6 +21,7 @@ from retail.agents.domains.agent_execution.row_mapper import (
     resolve_currency,
     resolve_has_json,
     resolve_log_status,
+    resolve_meta_template_name,
     resolve_summary,
     resolve_template_name,
     resolve_template_uuid,
@@ -103,6 +104,33 @@ class TemplateResolutionTests(SimpleTestCase):
         execution = _stub_execution(template=None, template_id=None)
         self.assertIsNone(resolve_template_name(execution))
         self.assertIsNone(resolve_template_uuid(execution))
+
+
+class MetaTemplateNameResolutionTests(SimpleTestCase):
+    def test_returns_current_version_template_name_when_present(self):
+        version = SimpleNamespace(template_name="weni_order_shipped_1739284723")
+        template = SimpleNamespace(
+            name="order_shipped",
+            display_name="Order shipped",
+            current_version=version,
+        )
+        execution = _stub_execution(template=template)
+        self.assertEqual(
+            resolve_meta_template_name(execution), "weni_order_shipped_1739284723"
+        )
+
+    def test_falls_back_to_template_name_when_no_current_version(self):
+        template = SimpleNamespace(
+            name="order_shipped",
+            display_name="Order shipped",
+            current_version=None,
+        )
+        execution = _stub_execution(template=template)
+        self.assertEqual(resolve_meta_template_name(execution), "order_shipped")
+
+    def test_returns_none_when_no_template(self):
+        execution = _stub_execution(template=None)
+        self.assertIsNone(resolve_meta_template_name(execution))
 
 
 class AmountAndCurrencyResolutionTests(SimpleTestCase):

--- a/retail/agents/domains/agent_execution/usecases/export_agent_logs.py
+++ b/retail/agents/domains/agent_execution/usecases/export_agent_logs.py
@@ -36,9 +36,7 @@ from retail.agents.domains.agent_execution.row_mapper import (
     format_contact,
     resolve_currency,
     resolve_log_status,
-    resolve_summary,
-    resolve_template_name,
-    resolve_template_uuid,
+    resolve_meta_template_name,
 )
 from retail.agents.domains.agent_execution.status_mapping import (
     build_status_filter,
@@ -52,7 +50,6 @@ logger = logging.getLogger(__name__)
 
 CSV_HEADER = [
     "uuid",
-    "template_uuid",
     "template_name",
     "sent_at",
     "contact",
@@ -60,7 +57,6 @@ CSV_HEADER = [
     "amount",
     "currency",
     "status",
-    "summary",
 ]
 
 # CSV rows accumulate in memory up to this size before the spooled
@@ -195,7 +191,7 @@ class ExportAgentLogsUseCase:
     def _build_queryset(self, dto: ExportAgentLogsDTO):
         queryset = AgentExecution.objects.select_related(
             "template",
-            "template__parent",
+            "template__current_version",
             "integrated_agent",
             "broadcast_message",
         ).filter(
@@ -232,15 +228,13 @@ class ExportAgentLogsUseCase:
         )
         return [
             str(execution.uuid),
-            resolve_template_uuid(execution) or "",
-            resolve_template_name(execution) or "",
+            resolve_meta_template_name(execution) or "",
             sent_at,
             format_contact(execution.contact_urn),
             execution.order_id or "",
             format_amount_value(execution),
             resolve_currency(execution),
             log_status,
-            resolve_summary(log_status),
         ]
 
     @staticmethod


### PR DESCRIPTION
## What

Agent logs CSV export now writes the WABA-registered template identifier
(`Template.current_version.template_name`) in the `template_name` column
instead of the human-readable `display_name` shown in the list API.

A new mapper `resolve_meta_template_name` in `row_mapper.py` encapsulates
this resolution (with fallback to `template.name` when no approved version
exists). `ExportAgentLogsUseCase` drops the `template_uuid` and `summary`
columns from the CSV header and prefetches `template__current_version`
instead of `template__parent`.

The JSON list endpoint is unchanged — it still exposes `template_name`
(display name), `template_uuid`, and `summary`.

## Why

Operations and support need the Meta/WABA template name in exported files
to correlate rows with message templates in Meta Business Manager. The
previous export used the UI display name, which does not match what Meta
stores for the dispatched message.