### PR TITLE
refactor: Collapse CRAWL step into NEXUS_CONFIG orchestrator

### DIFF
--- a/retail/projects/tasks.py
+++ b/retail/projects/tasks.py
@@ -4,7 +4,6 @@ from celery import shared_task
 from django.core.cache import cache
 
 from retail.projects.models import ProjectOnboarding
-from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_orchestrator import OnboardingOrchestrator
 from retail.projects.usecases.pre_crawl_channel import PreCrawlChannelUseCase
@@ -58,11 +57,10 @@ def _run_setup_channel_and_start_crawl(task, vtex_account: str, crawl_url: str) 
     Pipeline order (single Celery task, sequential):
       1. Wait until the project is linked (retries up to ~10 minutes).
       2. Pre-crawl channel setup (WWC or WPP Cloud).
-      3. Kick off the crawl (fire-and-forget; soft-fails internally).
-      4. Run the post-crawl orchestrator inline (manager + payment +
-         agents -- no content upload). The wizard completes here; the
-         content upload happens in background later when the crawler
-         webhook arrives.
+      3. Run the NEXUS_CONFIG orchestrator inline (crawl kickoff +
+         manager + payment + agents -- no content upload). The wizard
+         completes here; the content upload happens in background later
+         when the crawler webhook arrives.
 
     Args:
         task: The bound Celery task instance (provides ``retry`` /
@@ -111,9 +109,7 @@ def _run_setup_channel_and_start_crawl(task, vtex_account: str, crawl_url: str) 
         mark_onboarding_failed(vtex_account, f"Channel creation failed: {exc}")
         raise
 
-    InitiateCrawlUseCase().execute(onboarding.project, vtex_account, crawl_url)
-
-    OnboardingOrchestrator().execute(vtex_account)
+    OnboardingOrchestrator().execute(vtex_account, crawl_url)
 
 
 @shared_task(
@@ -123,19 +119,19 @@ def _run_setup_channel_and_start_crawl(task, vtex_account: str, crawl_url: str) 
 )
 def task_setup_channel_and_start_crawl(self, vtex_account: str, crawl_url: str) -> None:
     """
-    Pre-crawl + post-crawl orchestration: wait for project link, create
-    channel, kick off the crawl, then run the post-crawl orchestrator
-    inline so the wizard completes without waiting for the crawl.
+    Pre-crawl + NEXUS_CONFIG orchestration: wait for project link, create
+    channel, then run the NEXUS_CONFIG orchestrator inline (crawl kickoff +
+    manager + payment + agents) so the wizard completes without waiting
+    for the crawl.
 
     The Facebook ``auth_code`` from Embedded Signup is short-lived, so the
     channel must be created (and the code exchanged on the
     integrations-engine side) before the long-running crawl can expire it.
 
-    Retries while the project is not linked. Once linked, runs the
-    channel use case (resolves wwc or wpp-cloud), kicks off the crawl
-    (background), and runs the orchestrator. If channel creation fails,
-    the onboarding is marked failed and the orchestrator is not invoked
-    -- the user must redo Embedded Signup.
+    Retries while the project is not linked. Once linked, runs the channel
+    use case (resolves wwc or wpp-cloud) and the orchestrator. If channel
+    creation fails, the onboarding is marked failed and the orchestrator is
+    not invoked -- the user must redo Embedded Signup.
     """
     return _run_setup_channel_and_start_crawl(self, vtex_account, crawl_url)
 

--- a/retail/projects/tests/test_configure_wpp_cloud.py
+++ b/retail/projects/tests/test_configure_wpp_cloud.py
@@ -80,7 +80,7 @@ class TestConfigureWPPCloudUseCase(TestCase):
                 }
             }
         }
-        self.onboarding.current_step = "CRAWL"
+        self.onboarding.current_step = "NEXUS_CONFIG"
         self.onboarding.progress = 50
         self.onboarding.save()
 
@@ -89,7 +89,7 @@ class TestConfigureWPPCloudUseCase(TestCase):
         self.mock_integrations_service.create_wpp_cloud_channel.assert_not_called()
         self.onboarding.refresh_from_db()
         # State must not change when we skip
-        self.assertEqual(self.onboarding.current_step, "CRAWL")
+        self.assertEqual(self.onboarding.current_step, "NEXUS_CONFIG")
         self.assertEqual(self.onboarding.progress, 50)
         self.assertEqual(
             self.onboarding.config["channels"]["wpp-cloud"]["app_uuid"],

--- a/retail/projects/tests/test_configure_wwc.py
+++ b/retail/projects/tests/test_configure_wwc.py
@@ -67,7 +67,7 @@ class TestConfigureWWCUseCase(TestCase):
         """
         existing_app_uuid = str(uuid4())
         self.onboarding.config = {"channels": {"wwc": {"app_uuid": existing_app_uuid}}}
-        self.onboarding.current_step = "CRAWL"
+        self.onboarding.current_step = "NEXUS_CONFIG"
         self.onboarding.progress = 50
         self.onboarding.save()
 
@@ -76,7 +76,7 @@ class TestConfigureWWCUseCase(TestCase):
         self.mock_integrations_service.create_channel_app.assert_not_called()
         self.mock_integrations_service.configure_channel_app.assert_not_called()
         self.onboarding.refresh_from_db()
-        self.assertEqual(self.onboarding.current_step, "CRAWL")
+        self.assertEqual(self.onboarding.current_step, "NEXUS_CONFIG")
         self.assertEqual(self.onboarding.progress, 50)
         self.assertEqual(
             self.onboarding.config["channels"]["wwc"]["app_uuid"], existing_app_uuid

--- a/retail/projects/tests/test_link_project_to_onboarding.py
+++ b/retail/projects/tests/test_link_project_to_onboarding.py
@@ -30,7 +30,7 @@ class TestLinkProjectToOnboardingUseCase(TestCase):
         """
         Linking the project advances PROJECT_CONFIG to a partial progress
         value; the remaining progress is driven by the pre-crawl channel
-        setup task before the CRAWL transition.
+        setup task before the NEXUS_CONFIG orchestrator runs.
         """
         from retail.projects.usecases.link_project_to_onboarding import (
             PROJECT_LINKED_PROGRESS,

--- a/retail/projects/tests/test_onboarding_full_flow.py
+++ b/retail/projects/tests/test_onboarding_full_flow.py
@@ -28,11 +28,13 @@ from retail.projects.usecases.onboarding_dto import (
     CrawlerWebhookDTO,
     StartSetupDTO,
 )
-from retail.projects.usecases.onboarding_orchestrator import OnboardingOrchestrator
-from retail.projects.usecases.start_crawl import (
+from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
+from retail.projects.usecases.onboarding_orchestrator import (
     CRAWL_KICKOFF_PROGRESS,
-    StartCrawlUseCase,
+    NEXUS_CONFIG_START_PROGRESS,
+    OnboardingOrchestrator,
 )
+from retail.projects.usecases.start_crawl import StartCrawlUseCase
 from retail.projects.usecases.start_setup import StartSetupUseCase
 from retail.projects.usecases.update_onboarding_progress import (
     UpdateOnboardingProgressUseCase,
@@ -51,16 +53,17 @@ class TestFullOnboardingFlow(TestCase):
       1. Front-end calls start-setup (project not linked yet) -> PROJECT_CONFIG 0%
       2. EDA links the project                                -> PROJECT_CONFIG 30%
       3. Pre-crawl channel setup runs                         -> PROJECT_CONFIG 100%
-      4. Crawl kicked off (fire-and-forget)                   -> CRAWL 100%
-      5. Orchestrator: agent manager configured               -> NEXUS_CONFIG 10 -> 75
-      6. Orchestrator: agent integration                      -> NEXUS_CONFIG 100
+      4. Orchestrator: NEXUS_CONFIG starts                    -> NEXUS_CONFIG 0%
+      5. Orchestrator: crawl kickoff                          -> NEXUS_CONFIG 40%
+      6. Orchestrator: agent manager configured               -> NEXUS_CONFIG 75%
+      7. Orchestrator: agent integration                      -> NEXUS_CONFIG 100%
 
     Background path (decoupled from the wizard):
-      7. Crawler sends progress events                        -> NO main progress change
-      8. Crawler sends crawl.completed                        -> crawler_result=SUCCESS,
+      8. Crawler sends progress events                        -> NO main progress change
+      9. Crawler sends crawl.completed                        -> crawler_result=SUCCESS,
                                                                  task_upload_nexus_contents
                                                                  dispatched
-      9. task_upload_nexus_contents uploads contents to Nexus -> NO main progress change
+     10. task_upload_nexus_contents uploads contents to Nexus -> NO main progress change
     """
 
     def setUp(self):
@@ -122,58 +125,71 @@ class TestFullOnboardingFlow(TestCase):
             self.channel_app_uuid,
         )
 
-        # -- Step 4: Crawl kicked off (background, CRAWL 100%) --
+        # -- Step 4: Orchestrator marks NEXUS_CONFIG started --
+        OnboardingOrchestrator._mark_nexus_config_started(self.vtex_account)
+
+        onboarding.refresh_from_db()
+        self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
+        self.assertEqual(onboarding.progress, NEXUS_CONFIG_START_PROGRESS)
+
+        # -- Step 5: Crawl kickoff --
         mock_crawler_service = MagicMock()
         mock_crawler_service.start_crawling.return_value = {"status": "started"}
 
-        crawl_usecase = StartCrawlUseCase(crawler_client=MagicMock())
-        crawl_usecase.crawler_service = mock_crawler_service
-        crawl_usecase.execute(self.vtex_account, self.crawl_url)
+        start_crawl_usecase = StartCrawlUseCase(crawler_client=MagicMock())
+        start_crawl_usecase.crawler_service = mock_crawler_service
+
+        initiate_crawl_usecase = InitiateCrawlUseCase(connect_service=MagicMock())
+        initiate_crawl_usecase.start_crawl_usecase = start_crawl_usecase
+        initiate_crawl_usecase.detect_storefront_usecase = MagicMock()
+
+        initiate_crawl_usecase.execute(project, self.vtex_account, self.crawl_url)
+        OnboardingOrchestrator._mark_crawl_kickoff(self.vtex_account)
 
         onboarding.refresh_from_db()
-        self.assertEqual(onboarding.current_step, "CRAWL")
+        self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
         self.assertEqual(onboarding.progress, CRAWL_KICKOFF_PROGRESS)
+        mock_crawler_service.start_crawling.assert_called_once()
 
-        # -- Steps 5 + 6: Inline orchestrator runs the post-crawl steps --
+        # -- Step 6: Agent manager configured --
         mock_nexus_service = MagicMock()
         mock_nexus_service.check_agent_builder_exists.return_value = {
             "data": {"has_agent": False}
         }
         mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
 
+        agent_usecase = ConfigureAgentBuilderUseCase(nexus_client=MagicMock())
+        agent_usecase.nexus_service = mock_nexus_service
+        agent_usecase.execute(self.vtex_account)
+
+        onboarding.refresh_from_db()
+        self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
+        self.assertEqual(onboarding.progress, MANAGER_DONE_PROGRESS)
+        mock_nexus_service.configure_agent_attributes.assert_called_once()
+        mock_nexus_service.upload_content_base_file.assert_not_called()
+
+        # -- Step 7: Agent integration completes the wizard --
         mock_nexus_service_agents = MagicMock()
         mock_nexus_service_agents.integrate_agent.return_value = {"ok": True}
 
+        integrate_usecase = IntegrateAgentsUseCase(nexus_client=MagicMock())
+        integrate_usecase.nexus_service = mock_nexus_service_agents
+
         with patch(
-            "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
-        ) as mock_agent_cls, patch(
-            "retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase"
-        ) as mock_integrate_cls:
-            agent_usecase = ConfigureAgentBuilderUseCase(nexus_client=MagicMock())
-            agent_usecase.nexus_service = mock_nexus_service
-            mock_agent_cls.return_value = agent_usecase
-
-            integrate_usecase = IntegrateAgentsUseCase(nexus_client=MagicMock())
-            integrate_usecase.nexus_service = mock_nexus_service_agents
-            mock_integrate_cls.return_value = integrate_usecase
-
-            with patch(
-                "retail.projects.usecases.integrate_agents.get_channel_agents",
-                return_value=[],
-            ):
-                OnboardingOrchestrator().execute(self.vtex_account)
+            "retail.projects.usecases.integrate_agents.get_channel_agents",
+            return_value=[],
+        ):
+            integrate_usecase.execute(self.vtex_account)
 
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
         self.assertEqual(onboarding.progress, 100)
-        mock_nexus_service.configure_agent_attributes.assert_called_once()
-        mock_nexus_service.upload_content_base_file.assert_not_called()
 
         # The wizard is effectively done here; main onboarding is complete
         # from the user's perspective. The background phase below MUST
         # NOT regress current_step or progress.
 
-        # -- Step 7: Crawler sends progress (background, ignored by main) --
+        # -- Step 8: Crawler sends progress (background, ignored by main) --
         progress_dto = CrawlerWebhookDTO(
             task_id="task-1",
             event="crawl.subpage.progress",
@@ -187,7 +203,7 @@ class TestFullOnboardingFlow(TestCase):
         self.assertEqual(result.current_step, "NEXUS_CONFIG")
         self.assertEqual(result.progress, 100)
 
-        # -- Step 8: Crawler sends crawl.completed (background) --
+        # -- Step 9: Crawler sends crawl.completed (background) --
         crawled_contents = [
             {
                 "link": "https://www.flowstore.com.br/",
@@ -226,7 +242,7 @@ class TestFullOnboardingFlow(TestCase):
             self.vtex_account, crawled_contents
         )
 
-        # -- Step 9: Background upload runs -- NO main progress change --
+        # -- Step 10: Background upload runs -- NO main progress change --
         background_nexus = MagicMock()
         background_nexus.check_agent_builder_exists.return_value = {
             "data": {"has_agent": True}

--- a/retail/projects/tests/test_onboarding_orchestrator.py
+++ b/retail/projects/tests/test_onboarding_orchestrator.py
@@ -5,9 +5,11 @@ from django.test import TestCase
 
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.onboarding_orchestrator import (
-    NEXUS_CONFIG_START_PROGRESS,
+    CRAWL_KICKOFF_PROGRESS,
     OnboardingOrchestrator,
 )
+
+CRAWL_URL = "https://www.mystore.com.br/"
 
 
 class TestOnboardingOrchestrator(TestCase):
@@ -20,7 +22,7 @@ class TestOnboardingOrchestrator(TestCase):
         self.onboarding = ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
-            current_step="CRAWL",
+            current_step="PROJECT_CONFIG",
             progress=100,
             config={
                 "channels": {
@@ -31,31 +33,39 @@ class TestOnboardingOrchestrator(TestCase):
             },
         )
 
+    @patch("retail.projects.usecases.onboarding_orchestrator.InitiateCrawlUseCase")
     @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
     @patch(
         "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
     )
-    def test_runs_agent_builder_then_integrate(
-        self, mock_agent_builder_cls, mock_integrate_cls
+    def test_runs_crawl_agent_builder_then_integrate(
+        self, mock_agent_builder_cls, mock_integrate_cls, mock_initiate_cls
     ):
+        mock_initiate = MagicMock()
+        mock_initiate_cls.return_value = mock_initiate
         mock_agent_builder = MagicMock()
         mock_agent_builder_cls.return_value = mock_agent_builder
         mock_integrate = MagicMock()
         mock_integrate_cls.return_value = mock_integrate
 
-        OnboardingOrchestrator().execute("mystore")
+        OnboardingOrchestrator().execute("mystore", CRAWL_URL)
 
+        mock_initiate.execute.assert_called_once_with(
+            self.project, "mystore", CRAWL_URL
+        )
         mock_agent_builder.execute.assert_called_once_with("mystore")
         mock_integrate.execute.assert_called_once_with("mystore")
 
+    @patch("retail.projects.usecases.onboarding_orchestrator.InitiateCrawlUseCase")
     @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
     @patch(
         "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
     )
-    def test_transitions_to_nexus_config_step(
-        self, mock_agent_builder_cls, _mock_integrate_cls
+    def test_transitions_to_nexus_config_and_marks_crawl_kickoff(
+        self, mock_agent_builder_cls, _mock_integrate_cls, mock_initiate_cls
     ):
-        """The orchestrator must mark NEXUS_CONFIG so the UI advances."""
+        """The orchestrator must mark NEXUS_CONFIG and crawl kickoff progress."""
+        mock_initiate_cls.return_value = MagicMock()
         progress_at_agent_time = {}
 
         def capture(vtex_account):
@@ -67,14 +77,13 @@ class TestOnboardingOrchestrator(TestCase):
         mock_agent_builder.execute.side_effect = capture
         mock_agent_builder_cls.return_value = mock_agent_builder
 
-        OnboardingOrchestrator().execute("mystore")
+        OnboardingOrchestrator().execute("mystore", CRAWL_URL)
 
         self.assertEqual(progress_at_agent_time["step"], "NEXUS_CONFIG")
-        self.assertEqual(
-            progress_at_agent_time["progress"], NEXUS_CONFIG_START_PROGRESS
-        )
+        self.assertEqual(progress_at_agent_time["progress"], CRAWL_KICKOFF_PROGRESS)
 
     @patch("retail.projects.usecases.onboarding_orchestrator.mark_onboarding_failed")
+    @patch("retail.projects.usecases.onboarding_orchestrator.InitiateCrawlUseCase")
     @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
     @patch(
         "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
@@ -83,8 +92,10 @@ class TestOnboardingOrchestrator(TestCase):
         self,
         mock_agent_builder_cls,
         mock_integrate_cls,
+        mock_initiate_cls,
         mock_mark_failed,
     ):
+        mock_initiate_cls.return_value = MagicMock()
         mock_agent_builder = MagicMock()
         mock_agent_builder.execute.side_effect = RuntimeError("nexus down")
         mock_agent_builder_cls.return_value = mock_agent_builder
@@ -93,12 +104,13 @@ class TestOnboardingOrchestrator(TestCase):
         mock_integrate_cls.return_value = mock_integrate
 
         with self.assertRaises(RuntimeError):
-            OnboardingOrchestrator().execute("mystore")
+            OnboardingOrchestrator().execute("mystore", CRAWL_URL)
 
         mock_mark_failed.assert_called_once()
         mock_integrate.execute.assert_not_called()
 
     @patch("retail.projects.usecases.onboarding_orchestrator.mark_onboarding_failed")
+    @patch("retail.projects.usecases.onboarding_orchestrator.InitiateCrawlUseCase")
     @patch("retail.projects.usecases.onboarding_orchestrator.IntegrateAgentsUseCase")
     @patch(
         "retail.projects.usecases.onboarding_orchestrator.ConfigureAgentBuilderUseCase"
@@ -107,8 +119,10 @@ class TestOnboardingOrchestrator(TestCase):
         self,
         mock_agent_builder_cls,
         mock_integrate_cls,
+        mock_initiate_cls,
         mock_mark_failed,
     ):
+        mock_initiate_cls.return_value = MagicMock()
         mock_agent_builder = MagicMock()
         mock_agent_builder_cls.return_value = mock_agent_builder
 
@@ -117,7 +131,7 @@ class TestOnboardingOrchestrator(TestCase):
         mock_integrate_cls.return_value = mock_integrate
 
         with self.assertRaises(RuntimeError):
-            OnboardingOrchestrator().execute("mystore")
+            OnboardingOrchestrator().execute("mystore", CRAWL_URL)
 
         mock_mark_failed.assert_called_once()
 
@@ -153,12 +167,14 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
     """Verifies the One-Click Payment step is wired only for wpp-cloud."""
 
     ORCHESTRATOR_PATH = "retail.projects.usecases.onboarding_orchestrator"
+    CRAWL_URL = CRAWL_URL
 
     def setUp(self):
         self.project = Project.objects.create(
             name="Test", uuid=uuid4(), vtex_account="mystore"
         )
 
+        self._patch_target("InitiateCrawlUseCase")
         self._patch_target("ConfigureAgentBuilderUseCase")
         self.mock_integrate_cls = self._patch_target("IntegrateAgentsUseCase")
         self.mock_payment_cls = self._patch_target("ConfigureOneClickPaymentUseCase")
@@ -187,7 +203,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
     def test_runs_payment_step_for_wpp_cloud(self):
         self._make_onboarding("wpp-cloud")
 
-        OnboardingOrchestrator().execute("mystore")
+        OnboardingOrchestrator().execute("mystore", self.CRAWL_URL)
 
         self.mock_payment_cls.assert_called_once_with()
         self.mock_payment_cls.return_value.execute.assert_called_once_with("mystore")
@@ -195,7 +211,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
     def test_skips_payment_step_for_wwc(self):
         self._make_onboarding("wwc")
 
-        OnboardingOrchestrator().execute("mystore")
+        OnboardingOrchestrator().execute("mystore", self.CRAWL_URL)
 
         self.mock_payment_cls.assert_not_called()
 
@@ -211,7 +227,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
             lambda *_: call_order.append("integrate")
         )
 
-        OnboardingOrchestrator().execute("mystore")
+        OnboardingOrchestrator().execute("mystore", self.CRAWL_URL)
 
         self.assertEqual(call_order, ["ocp", "integrate"])
 
@@ -222,7 +238,7 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
         with patch(
             "retail.projects.usecases.onboarding_orchestrator.mark_onboarding_failed"
         ) as mock_mark_failed, self.assertRaises(RuntimeError):
-            OnboardingOrchestrator().execute("mystore")
+            OnboardingOrchestrator().execute("mystore", self.CRAWL_URL)
 
         mock_mark_failed.assert_called_once_with("mystore", "boom")
 
@@ -236,6 +252,6 @@ class TestOnboardingOrchestratorPaymentRouting(TestCase):
         with patch(
             "retail.projects.usecases.onboarding_orchestrator.mark_onboarding_failed"
         ), self.assertRaises(ValueError) as ctx:
-            OnboardingOrchestrator().execute("mystore")
+            OnboardingOrchestrator().execute("mystore", self.CRAWL_URL)
 
         self.assertIn("No channel configured", str(ctx.exception))

--- a/retail/projects/tests/test_request_onboarding_support.py
+++ b/retail/projects/tests/test_request_onboarding_support.py
@@ -24,7 +24,7 @@ class TestRequestOnboardingSupportUseCase(TestCase):
         onboarding = ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=project,
-            current_step="CRAWL",
+            current_step="NEXUS_CONFIG",
             current_page="setup_channel",
             progress=42,
             failed=True,
@@ -50,7 +50,7 @@ class TestRequestOnboardingSupportUseCase(TestCase):
         self.assertEqual(snapshot["uuid"], str(onboarding.uuid))
         self.assertEqual(snapshot["project_name"], "My Store")
         self.assertEqual(snapshot["project_uuid"], str(project.uuid))
-        self.assertEqual(snapshot["current_step"], "CRAWL")
+        self.assertEqual(snapshot["current_step"], "NEXUS_CONFIG")
         self.assertEqual(snapshot["current_page"], "setup_channel")
         self.assertEqual(snapshot["progress"], 42)
         self.assertTrue(snapshot["failed"])

--- a/retail/projects/tests/test_start_crawl.py
+++ b/retail/projects/tests/test_start_crawl.py
@@ -5,10 +5,7 @@ from django.test import TestCase, override_settings
 
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.manager_defaults import MANAGER_DEFAULTS
-from retail.projects.usecases.start_crawl import (
-    CRAWL_KICKOFF_PROGRESS,
-    StartCrawlUseCase,
-)
+from retail.projects.usecases.start_crawl import StartCrawlUseCase
 
 
 @override_settings(DOMAIN="https://retail.weni.ai")
@@ -23,26 +20,22 @@ class TestStartCrawlUseCase(TestCase):
         self.onboarding = ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
+            current_step="NEXUS_CONFIG",
+            progress=0,
         )
         self.mock_crawler_service = MagicMock()
         self.usecase = StartCrawlUseCase(crawler_client=MagicMock())
         self.usecase.crawler_service = self.mock_crawler_service
 
-    def test_sets_step_to_crawl_with_kickoff_progress(self):
-        """
-        Bumps progress to 100 to signal "crawl phase done from the
-        wizard's perspective" -- the actual long-running crawl runs in
-        background and its outcome lands in ``crawler_result``, NOT in
-        ``progress``.
-        """
+    def test_does_not_change_step_or_progress(self):
+        """Step/progress transitions are owned by OnboardingOrchestrator."""
         self.mock_crawler_service.start_crawling.return_value = {"status": "started"}
 
         self.usecase.execute("mystore", "https://www.mystore.com.br/")
 
         self.onboarding.refresh_from_db()
-        self.assertEqual(self.onboarding.current_step, "CRAWL")
-        self.assertEqual(self.onboarding.progress, CRAWL_KICKOFF_PROGRESS)
-        self.assertEqual(self.onboarding.progress, 100)
+        self.assertEqual(self.onboarding.current_step, "NEXUS_CONFIG")
+        self.assertEqual(self.onboarding.progress, 0)
 
     def test_calls_crawler_service_with_correct_args(self):
         self.mock_crawler_service.start_crawling.return_value = {"status": "started"}
@@ -55,15 +48,13 @@ class TestStartCrawlUseCase(TestCase):
         self.assertIn(str(self.onboarding.uuid), args[0][1])  # webhook_url
         self.assertEqual(args[0][2]["account_name"], "mystore")
 
-    @patch(
-        "retail.projects.usecases.start_crawl.SaveBackgroundFailureUseCase"
-    )
+    @patch("retail.projects.usecases.start_crawl.SaveBackgroundFailureUseCase")
     def test_soft_fails_when_crawler_unreachable(self, mock_save_background_cls):
         """
         On crawler-comms failure the use case must NOT raise (so the
-        inline post-crawl orchestrator can still complete the wizard)
-        but must record a soft failure under
-        ``config["background_error"]`` and set ``crawler_result=FAIL``.
+        inline orchestrator can still complete the wizard) but must record
+        a soft failure under ``config["background_error"]`` and set
+        ``crawler_result=FAIL``.
         """
         self.mock_crawler_service.start_crawling.return_value = None
 

--- a/retail/projects/tests/test_start_onboarding.py
+++ b/retail/projects/tests/test_start_onboarding.py
@@ -59,7 +59,7 @@ class TestStartSetupUseCase(TestCase):
         """When an onboarding already exists, should reset transient fields."""
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
-            current_step="CRAWL",
+            current_step="NEXUS_CONFIG",
             progress=80,
             crawler_result=ProjectOnboarding.SUCCESS,
             completed=True,

--- a/retail/projects/tests/test_tasks.py
+++ b/retail/projects/tests/test_tasks.py
@@ -54,10 +54,9 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         )
 
     @patch("retail.projects.tasks.OnboardingOrchestrator")
-    @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
-    def test_runs_channel_crawl_and_orchestrator_when_project_linked(
-        self, mock_channel_cls, mock_initiate_cls, mock_orch_cls
+    def test_runs_channel_and_orchestrator_when_project_linked(
+        self, mock_channel_cls, mock_orch_cls
     ):
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
@@ -67,33 +66,27 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
 
         mock_channel = MagicMock()
         mock_channel_cls.return_value = mock_channel
-        mock_initiate = MagicMock()
-        mock_initiate_cls.return_value = mock_initiate
         mock_orch = MagicMock()
         mock_orch_cls.return_value = mock_orch
 
         call_order = []
         mock_channel.execute.side_effect = lambda *_: call_order.append("channel")
-        mock_initiate.execute.side_effect = lambda *_: call_order.append("crawl")
         mock_orch.execute.side_effect = lambda *_: call_order.append("orchestrator")
 
         from retail.projects.tasks import task_setup_channel_and_start_crawl
 
-        task_setup_channel_and_start_crawl("mystore", "https://mystore.com.br/")
+        crawl_url = "https://mystore.com.br/"
+        task_setup_channel_and_start_crawl("mystore", crawl_url)
 
         mock_channel.execute.assert_called_once_with("mystore")
-        mock_initiate.execute.assert_called_once_with(
-            self.project, "mystore", "https://mystore.com.br/"
-        )
-        mock_orch.execute.assert_called_once_with("mystore")
+        mock_orch.execute.assert_called_once_with("mystore", crawl_url)
 
-        self.assertEqual(call_order, ["channel", "crawl", "orchestrator"])
+        self.assertEqual(call_order, ["channel", "orchestrator"])
 
     @patch("retail.projects.tasks.OnboardingOrchestrator")
-    @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
     def test_sets_project_linked_progress_before_channel_setup(
-        self, mock_channel_cls, _mock_initiate, _mock_orch
+        self, mock_channel_cls, _mock_orch
     ):
         """When start-setup linked the project inline, the task still bumps progress."""
         ProjectOnboarding.objects.create(
@@ -125,10 +118,9 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         self.assertEqual(progress_at_channel_time["step"], "PROJECT_CONFIG")
 
     @patch("retail.projects.tasks.OnboardingOrchestrator")
-    @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
     def test_does_not_regress_progress_when_eda_linked_project(
-        self, mock_channel_cls, _mock_initiate, _mock_orch
+        self, mock_channel_cls, _mock_orch
     ):
         """When EDA already set progress >= 30, the task must not regress it."""
         ProjectOnboarding.objects.create(
@@ -179,12 +171,10 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
 
     @patch("retail.projects.tasks.mark_onboarding_failed")
     @patch("retail.projects.tasks.OnboardingOrchestrator")
-    @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
-    def test_marks_failed_and_skips_crawl_when_channel_fails(
+    def test_marks_failed_and_skips_orchestrator_when_channel_fails(
         self,
         mock_channel_cls,
-        mock_initiate_cls,
         mock_orch_cls,
         mock_mark_failed,
     ):
@@ -198,9 +188,6 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         mock_channel.execute.side_effect = RuntimeError("auth_code expired")
         mock_channel_cls.return_value = mock_channel
 
-        mock_initiate = MagicMock()
-        mock_initiate_cls.return_value = mock_initiate
-
         mock_orch = MagicMock()
         mock_orch_cls.return_value = mock_orch
 
@@ -212,7 +199,6 @@ class TestTaskSetupChannelAndStartCrawl(TestCase):
         mock_mark_failed.assert_called_once()
         called_with_reason = mock_mark_failed.call_args[0][1]
         self.assertIn("Channel creation failed", called_with_reason)
-        mock_initiate.execute.assert_not_called()
         mock_orch.execute.assert_not_called()
 
 
@@ -225,11 +211,8 @@ class TestTaskWaitAndStartCrawlAlias(TestCase):
         )
 
     @patch("retail.projects.tasks.OnboardingOrchestrator")
-    @patch("retail.projects.tasks.InitiateCrawlUseCase")
     @patch("retail.projects.tasks.PreCrawlChannelUseCase")
-    def test_alias_runs_channel_crawl_and_orchestrator(
-        self, mock_channel_cls, mock_initiate_cls, mock_orch_cls
-    ):
+    def test_alias_runs_channel_and_orchestrator(self, mock_channel_cls, mock_orch_cls):
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
@@ -238,20 +221,16 @@ class TestTaskWaitAndStartCrawlAlias(TestCase):
 
         mock_channel = MagicMock()
         mock_channel_cls.return_value = mock_channel
-        mock_initiate = MagicMock()
-        mock_initiate_cls.return_value = mock_initiate
         mock_orch = MagicMock()
         mock_orch_cls.return_value = mock_orch
 
         from retail.projects.tasks import task_wait_and_start_crawl
 
-        task_wait_and_start_crawl("mystore", "https://mystore.com.br/")
+        crawl_url = "https://mystore.com.br/"
+        task_wait_and_start_crawl("mystore", crawl_url)
 
         mock_channel.execute.assert_called_once_with("mystore")
-        mock_initiate.execute.assert_called_once_with(
-            self.project, "mystore", "https://mystore.com.br/"
-        )
-        mock_orch.execute.assert_called_once_with("mystore")
+        mock_orch.execute.assert_called_once_with("mystore", crawl_url)
 
 
 class TestTaskUploadNexusContents(TestCase):
@@ -332,9 +311,7 @@ class TestTaskConfigureNexusDeprecatedAlias(TestCase):
 
     @patch("retail.projects.tasks.UploadNexusContentsUseCase")
     @patch("retail.projects.tasks.release_task_lock")
-    def test_alias_delegates_to_upload_use_case(
-        self, mock_release, mock_upload_cls
-    ):
+    def test_alias_delegates_to_upload_use_case(self, mock_release, mock_upload_cls):
         mock_upload = MagicMock()
         mock_upload_cls.return_value = mock_upload
 

--- a/retail/projects/tests/test_views.py
+++ b/retail/projects/tests/test_views.py
@@ -115,7 +115,7 @@ class TestCrawlerWebhookView(TestCase):
         self.onboarding = ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=self.project,
-            current_step="CRAWL",
+            current_step="NEXUS_CONFIG",
         )
 
     @patch(
@@ -188,7 +188,7 @@ class TestOnboardingStatusView(TestCase):
         ProjectOnboarding.objects.create(
             vtex_account="mystore",
             project=project,
-            current_step="CRAWL",
+            current_step="NEXUS_CONFIG",
             progress=50,
         )
 
@@ -198,7 +198,7 @@ class TestOnboardingStatusView(TestCase):
         data = response.json()
         self.assertEqual(data["vtex_account"], "mystore")
         self.assertEqual(data["progress"], 50)
-        self.assertEqual(data["current_step"], "CRAWL")
+        self.assertEqual(data["current_step"], "NEXUS_CONFIG")
         self.assertEqual(data["project_uuid"], str(project.uuid))
 
     @_auth_bypass(None)

--- a/retail/projects/usecases/initiate_crawl.py
+++ b/retail/projects/usecases/initiate_crawl.py
@@ -18,8 +18,8 @@ class InitiateCrawlUseCase:
       2. Starts the crawl via the Crawler MS (critical).
       3. Detects the storefront type (non-blocking).
 
-    Invoked by ``task_setup_channel_and_start_crawl`` after the pre-crawl
-    channel setup completes successfully.
+    Invoked by ``OnboardingOrchestrator`` as the first sub-phase of
+    ``NEXUS_CONFIG``, after pre-crawl channel setup completes.
     """
 
     def __init__(self, connect_service: Optional[ConnectService] = None):

--- a/retail/projects/usecases/link_project_to_onboarding.py
+++ b/retail/projects/usecases/link_project_to_onboarding.py
@@ -16,8 +16,8 @@ class LinkProjectToOnboardingUseCase:
     Called from the EDA consumer when a project creation event is received.
     Sets ``current_step = "PROJECT_CONFIG"`` and a partial progress
     (``PROJECT_LINKED_PROGRESS``) so the pre-crawl channel setup task
-    can drive progress the rest of the way to 100% before transitioning
-    to CRAWL.
+    can drive progress the rest of the way to 100% before the
+    NEXUS_CONFIG orchestrator runs.
     """
 
     @staticmethod

--- a/retail/projects/usecases/onboarding_orchestrator.py
+++ b/retail/projects/usecases/onboarding_orchestrator.py
@@ -7,13 +7,15 @@ from retail.projects.usecases.configure_agent_builder import (
 from retail.projects.usecases.configure_one_click_payment import (
     ConfigureOneClickPaymentUseCase,
 )
+from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
 from retail.projects.usecases.integrate_agents import IntegrateAgentsUseCase
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 
 logger = logging.getLogger(__name__)
 
 
-NEXUS_CONFIG_START_PROGRESS = 10
+NEXUS_CONFIG_START_PROGRESS = 0
+CRAWL_KICKOFF_PROGRESS = 40
 
 # Channels that require the One-Click Payment configuration step.
 # Kept as a registry so future channels can opt in (or out) without
@@ -23,44 +25,59 @@ CHANNELS_WITH_ONE_CLICK_PAYMENT = {"wpp-cloud"}
 
 class OnboardingOrchestrator:
     """
-    Orchestrates post-crawl configuration that runs INLINE in the main
-    onboarding flow (right after the crawler is kicked off):
+    Orchestrates the NEXUS_CONFIG step inline in the main onboarding flow:
 
-      1. Nexus manager configuration (10-75%) -- configures the agent
-                                                  manager attributes ONLY.
-                                                  Content upload happens
-                                                  in background later, when
-                                                  the crawl webhook arrives.
-      2. One-Click Payment (wpp-cloud)        -- registers keys + creates
-                                                  + publishes Meta Flow
-                                                  (runs BEFORE agent
-                                                  integration so the
-                                                  One-Click Payment agent
-                                                  can consume the published
-                                                  flow_id as a credential)
-      3. Agent integration (75-100%)          -- integrates Nexus agents
-                                                  for the channel
+      1. Crawl kickoff (0-40%)               -- sends the store URL to the
+                                               Crawler MS (fire-and-forget;
+                                               soft-fails internally).
+      2. Nexus manager configuration (75%)  -- configures the agent manager
+                                               attributes ONLY. Content upload
+                                               happens in background later, when
+                                               the crawl webhook arrives.
+      3. One-Click Payment (wpp-cloud)      -- registers keys + creates +
+                                               publishes Meta Flow (runs BEFORE
+                                               agent integration so the
+                                               One-Click Payment agent can
+                                               consume the published flow_id as
+                                               a credential)
+      4. Agent integration (75-100%)        -- integrates Nexus agents for
+                                               the channel
 
-    Channel creation runs before the crawl (see ``PreCrawlChannelUseCase``)
-    so the short-lived Facebook ``auth_code`` is not exposed to the
-    crawl's runtime. Both channels' ``app_uuid`` / ``flow_object_uuid``
-    are already persisted by the time this orchestrator runs.
+    Channel creation runs before this orchestrator (see
+    ``PreCrawlChannelUseCase``) so the short-lived Facebook ``auth_code`` is
+    not exposed to the crawl's runtime. Both channels' ``app_uuid`` /
+    ``flow_object_uuid`` are already persisted by the time this orchestrator
+    runs.
 
-    Crawl + Nexus content upload run in the background and do NOT affect
-    the main onboarding progress: the user-visible wizard completes once
-    this orchestrator returns. The content upload to Nexus is dispatched
-    by ``UpdateOnboardingProgressUseCase`` when the ``crawl.completed``
-    webhook arrives.
+    The actual long-running crawl and Nexus content upload run in the
+    background and do NOT affect the main onboarding progress: the
+    user-visible wizard completes once this orchestrator returns. The content
+    upload to Nexus is dispatched by ``UpdateOnboardingProgressUseCase``
+    when the ``crawl.completed`` webhook arrives.
 
-    Each step is sequential. If any step fails, progress freezes
-    at the last saved value and the error propagates.
+    Each step is sequential. If any step fails, progress freezes at the last
+    saved value and the error propagates.
     """
 
-    def execute(self, vtex_account: str) -> None:
-        logger.info(f"Starting post-crawl config for vtex_account={vtex_account}")
+    def execute(self, vtex_account: str, crawl_url: str) -> None:
+        logger.info(
+            f"Starting NEXUS_CONFIG for vtex_account={vtex_account} "
+            f"crawl_url={crawl_url}"
+        )
 
         try:
+            onboarding = ProjectOnboarding.objects.select_related("project").get(
+                vtex_account=vtex_account,
+            )
+            if onboarding.project is None:
+                raise ValueError(
+                    f"Onboarding for vtex_account={vtex_account} has no project linked."
+                )
+
             self._mark_nexus_config_started(vtex_account)
+
+            InitiateCrawlUseCase().execute(onboarding.project, vtex_account, crawl_url)
+            self._mark_crawl_kickoff(vtex_account)
 
             ConfigureAgentBuilderUseCase().execute(vtex_account)
 
@@ -82,6 +99,13 @@ class OnboardingOrchestrator:
         onboarding.current_step = "NEXUS_CONFIG"
         onboarding.progress = NEXUS_CONFIG_START_PROGRESS
         onboarding.save(update_fields=["current_step", "progress"])
+
+    @staticmethod
+    def _mark_crawl_kickoff(vtex_account: str) -> None:
+        """Records that the crawler was kicked off within NEXUS_CONFIG."""
+        onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
+        onboarding.progress = CRAWL_KICKOFF_PROGRESS
+        onboarding.save(update_fields=["progress"])
 
     @staticmethod
     def _resolve_channel_code(vtex_account: str) -> str:

--- a/retail/projects/usecases/start_crawl.py
+++ b/retail/projects/usecases/start_crawl.py
@@ -15,25 +15,17 @@ from retail.services.crawler.service import CrawlerService
 logger = logging.getLogger(__name__)
 
 
-CRAWL_KICKOFF_PROGRESS = 100
-
-
 class StartCrawlUseCase:
     """
     Kicks off the crawl by calling the Crawler MS.
 
-    Sets ``current_step`` to ``CRAWL`` with ``progress=100`` to signal
-    that the crawl phase is done from the wizard's perspective the
-    moment the crawler is kicked off. The actual long-running crawl
-    runs in background and its real outcome lands in
-    ``crawler_result`` (``SUCCESS`` / ``FAIL``), NOT in ``progress``.
-
-    The orchestrator that runs immediately after this use case will
-    overwrite ``current_step`` with ``NEXUS_CONFIG`` in the same Celery
-    task, so the ``CRAWL`` step is visible only transiently.
+    Invoked as the first sub-phase of ``NEXUS_CONFIG`` by
+    ``OnboardingOrchestrator`` (via ``InitiateCrawlUseCase``). Does not
+    own ``current_step`` or ``progress`` transitions — the orchestrator
+    sets those before and after this call.
 
     Soft-fails on crawler-comms errors: the main onboarding must still
-    be able to complete even when the crawler cannot be reached -- the
+    be able to complete even when the crawler cannot be reached — the
     crawl is no longer mandatory for the wizard to finish.
     """
 
@@ -56,10 +48,6 @@ class StartCrawlUseCase:
         onboarding = ProjectOnboarding.objects.select_related("project").get(
             vtex_account=vtex_account,
         )
-
-        onboarding.current_step = "CRAWL"
-        onboarding.progress = CRAWL_KICKOFF_PROGRESS
-        onboarding.save(update_fields=["current_step", "progress"])
 
         onboarding_uuid = str(onboarding.uuid)
         language = onboarding.project.language or "" if onboarding.project else ""

--- a/retail/services/notification/tests/test_onboarding_support_service.py
+++ b/retail/services/notification/tests/test_onboarding_support_service.py
@@ -12,7 +12,7 @@ def _snapshot(**overrides) -> dict:
         "uuid": "onboarding-uuid",
         "project_name": "My Store",
         "project_uuid": "project-uuid",
-        "current_step": "CRAWL",
+        "current_step": "NEXUS_CONFIG",
         "current_page": "setup_channel",
         "progress": 42,
         "completed": False,
@@ -52,7 +52,7 @@ class TestOnboardingSupportNotificationService(TestCase):
         serialized = str(self.slack_service.send_blocks.call_args.kwargs["blocks"])
         self.assertIn("mystore", serialized)
         self.assertIn("My Store", serialized)
-        self.assertIn("CRAWL", serialized)
+        self.assertIn("NEXUS_CONFIG", serialized)
         self.assertIn("setup_channel", serialized)
         self.assertIn("42%", serialized)
         self.assertIn("failed", serialized)
@@ -140,7 +140,7 @@ class TestOnboardingSupportNotificationService(TestCase):
     def test_notify_omits_ids_block_when_snapshot_has_no_uuids(self):
         self.service.notify(
             vtex_account="mystore",
-            onboarding={"current_step": "CRAWL"},
+            onboarding={"current_step": "NEXUS_CONFIG"},
         )
 
         serialized = str(self.slack_service.send_blocks.call_args.kwargs["blocks"])


### PR DESCRIPTION
## What

Removes the transient `CRAWL` onboarding step and folds crawl kickoff into
the `NEXUS_CONFIG` phase. `OnboardingOrchestrator.execute` now accepts
`crawl_url` and runs: mark NEXUS_CONFIG (0%) → `InitiateCrawlUseCase` → mark
crawl kickoff (40%) → agent manager (75%) → one-click payment (wpp-cloud) →
agent integration (100%).

`StartCrawlUseCase` no longer mutates `current_step` or `progress`; the
orchestrator owns those transitions. `task_setup_channel_and_start_crawl`
delegates crawl initiation to the orchestrator instead of calling
`InitiateCrawlUseCase` directly.

## Why

The `CRAWL` step was only visible transiently (overwritten immediately by
`NEXUS_CONFIG` in the same Celery task). Collapsing it simplifies the wizard
state machine, aligns backend progress with the user-visible step, and
reduces coupling between `tasks.py` and crawl initiation.