### PR TITLE
feat: Add content-base crawl and upload progress endpoint

### DIFF
--- a/retail/projects/serializer.py
+++ b/retail/projects/serializer.py
@@ -76,6 +76,12 @@ class RequestOnboardingSupportSerializer(serializers.Serializer):
     data = serializers.DictField(required=False, default=dict)
 
 
+class ContentBaseProgressSerializer(serializers.Serializer):
+    """Serializer for the content base crawl/upload progress response."""
+
+    progress = serializers.IntegerField(read_only=True)
+
+
 class ProjectOnboardingSerializer(serializers.Serializer):
     """Serializer for the ProjectOnboarding status response."""
 

--- a/retail/projects/tasks.py
+++ b/retail/projects/tasks.py
@@ -10,6 +10,10 @@ from retail.projects.usecases.pre_crawl_channel import PreCrawlChannelUseCase
 from retail.projects.usecases.save_background_failure import (
     SaveBackgroundFailureUseCase,
 )
+from retail.projects.usecases.content_base_progress_helpers import (
+    STATUS_FAILED,
+    persist_content_base_progress,
+)
 from retail.projects.usecases.upload_nexus_contents import UploadNexusContentsUseCase
 from retail.services.vtex_io.service import VtexIOService
 
@@ -192,6 +196,14 @@ def _run_upload_nexus_contents(vtex_account: str, contents: list) -> None:
             f"Background nexus upload failed for vtex_account={vtex_account}"
         )
         SaveBackgroundFailureUseCase.execute(vtex_account, "nexus_upload", str(exc))
+        try:
+            onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
+            persist_content_base_progress(onboarding, status=STATUS_FAILED)
+        except ProjectOnboarding.DoesNotExist:
+            logger.warning(
+                f"Could not persist content base failure for "
+                f"vtex_account={vtex_account}: onboarding not found"
+            )
     finally:
         release_task_lock(UPLOAD_NEXUS_LOCK_NAME, vtex_account)
 

--- a/retail/projects/tests/test_content_base_progress_helpers.py
+++ b/retail/projects/tests/test_content_base_progress_helpers.py
@@ -1,0 +1,104 @@
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.content_base_progress_helpers import (
+    STATUS_COMPLETE,
+    STATUS_CRAWLING,
+    STATUS_FAILED,
+    STATUS_UPLOADING,
+    compute_overall_percent,
+    persist_content_base_progress,
+)
+
+
+class TestComputeOverallPercent(TestCase):
+    def test_returns_zero_for_empty_snapshot(self):
+        self.assertEqual(compute_overall_percent({}), 0)
+
+    def test_returns_zero_when_not_started(self):
+        snapshot = {
+            "crawl_percent": 0,
+            "upload_percent": 0,
+            "status": "pending",
+        }
+        self.assertEqual(compute_overall_percent(snapshot), 0)
+
+    def test_returns_crawl_weighted_progress(self):
+        snapshot = {"crawl_percent": 50, "upload_percent": 0}
+        self.assertEqual(compute_overall_percent(snapshot), 16)
+
+    def test_returns_thirty_three_when_crawl_done_upload_not_started(self):
+        snapshot = {
+            "crawl_percent": 100,
+            "upload_percent": 0,
+            "status": STATUS_UPLOADING,
+        }
+        self.assertEqual(compute_overall_percent(snapshot), 33)
+
+    def test_returns_sixty_seven_when_upload_halfway(self):
+        snapshot = {"crawl_percent": 100, "upload_percent": 50}
+        self.assertEqual(compute_overall_percent(snapshot), 66)
+
+    def test_returns_one_hundred_when_complete_status(self):
+        snapshot = {
+            "crawl_percent": 100,
+            "upload_percent": 0,
+            "status": STATUS_COMPLETE,
+        }
+        self.assertEqual(compute_overall_percent(snapshot), 100)
+
+    def test_returns_partial_on_failed_status(self):
+        snapshot = {
+            "crawl_percent": 60,
+            "upload_percent": 0,
+            "status": STATUS_FAILED,
+        }
+        self.assertEqual(compute_overall_percent(snapshot), 20)
+
+
+class TestPersistContentBaseProgress(TestCase):
+    def setUp(self):
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            config={
+                "channels": {"wwc": {"app_uuid": str(uuid4())}},
+                "vtex_host_store": "https://www.mystore.com/",
+            },
+        )
+
+    def test_merges_without_removing_other_config_keys(self):
+        persist_content_base_progress(
+            self.onboarding,
+            crawl_percent=35,
+            status=STATUS_CRAWLING,
+        )
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(
+            self.onboarding.config["content_base_progress"]["crawl_percent"], 35
+        )
+        self.assertEqual(
+            self.onboarding.config["content_base_progress"]["status"], STATUS_CRAWLING
+        )
+        self.assertIn("channels", self.onboarding.config)
+        self.assertEqual(
+            self.onboarding.config["vtex_host_store"], "https://www.mystore.com/"
+        )
+
+    def test_updates_existing_snapshot_in_place(self):
+        persist_content_base_progress(
+            self.onboarding,
+            crawl_percent=100,
+            upload_percent=0,
+            status=STATUS_UPLOADING,
+            total_files=2,
+        )
+        persist_content_base_progress(self.onboarding, upload_percent=50)
+
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["crawl_percent"], 100)
+        self.assertEqual(snapshot["upload_percent"], 50)
+        self.assertEqual(snapshot["total_files"], 2)

--- a/retail/projects/tests/test_get_content_base_progress.py
+++ b/retail/projects/tests/test_get_content_base_progress.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.content_base_progress_helpers import STATUS_COMPLETE
+from retail.projects.usecases.get_content_base_progress import (
+    GetContentBaseProgressUseCase,
+)
+
+
+class TestGetContentBaseProgressUseCase(TestCase):
+    def test_returns_weighted_progress_from_config(self):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            config={
+                "content_base_progress": {
+                    "crawl_percent": 100,
+                    "upload_percent": 50,
+                    "status": "uploading",
+                }
+            },
+        )
+
+        progress = GetContentBaseProgressUseCase().execute("mystore")
+
+        self.assertEqual(progress, 66)
+
+    def test_returns_zero_when_snapshot_missing(self):
+        ProjectOnboarding.objects.create(vtex_account="mystore")
+
+        progress = GetContentBaseProgressUseCase().execute("mystore")
+
+        self.assertEqual(progress, 0)
+
+    def test_returns_one_hundred_when_complete(self):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            config={
+                "content_base_progress": {
+                    "crawl_percent": 100,
+                    "upload_percent": 100,
+                    "status": STATUS_COMPLETE,
+                }
+            },
+        )
+
+        progress = GetContentBaseProgressUseCase().execute("mystore")
+
+        self.assertEqual(progress, 100)
+
+    def test_raises_when_onboarding_not_found(self):
+        with self.assertRaises(ProjectOnboarding.DoesNotExist):
+            GetContentBaseProgressUseCase().execute("unknown")

--- a/retail/projects/tests/test_onboarding_full_flow.py
+++ b/retail/projects/tests/test_onboarding_full_flow.py
@@ -28,6 +28,12 @@ from retail.projects.usecases.onboarding_dto import (
     CrawlerWebhookDTO,
     StartSetupDTO,
 )
+from retail.projects.usecases.content_base_progress_helpers import (
+    compute_overall_percent,
+)
+from retail.projects.usecases.get_content_base_progress import (
+    GetContentBaseProgressUseCase,
+)
 from retail.projects.usecases.initiate_crawl import InitiateCrawlUseCase
 from retail.projects.usecases.onboarding_orchestrator import (
     CRAWL_KICKOFF_PROGRESS,
@@ -202,6 +208,11 @@ class TestFullOnboardingFlow(TestCase):
         )
         self.assertEqual(result.current_step, "NEXUS_CONFIG")
         self.assertEqual(result.progress, 100)
+        onboarding.refresh_from_db()
+        self.assertEqual(
+            compute_overall_percent(onboarding.config["content_base_progress"]),
+            16,
+        )
 
         # -- Step 9: Crawler sends crawl.completed (background) --
         crawled_contents = [
@@ -241,6 +252,8 @@ class TestFullOnboardingFlow(TestCase):
         mock_nexus_task.delay.assert_called_once_with(
             self.vtex_account, crawled_contents
         )
+        onboarding.refresh_from_db()
+        self.assertEqual(GetContentBaseProgressUseCase().execute(self.vtex_account), 33)
 
         # -- Step 10: Background upload runs -- NO main progress change --
         background_nexus = MagicMock()
@@ -265,6 +278,9 @@ class TestFullOnboardingFlow(TestCase):
         self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
         self.assertEqual(onboarding.progress, 100)
         self.assertEqual(background_nexus.upload_content_base_file.call_count, 2)
+        self.assertEqual(
+            GetContentBaseProgressUseCase().execute(self.vtex_account), 100
+        )
 
         # -- Final state check --
         self.assertFalse(onboarding.completed)

--- a/retail/projects/tests/test_start_onboarding.py
+++ b/retail/projects/tests/test_start_onboarding.py
@@ -70,6 +70,11 @@ class TestStartSetupUseCase(TestCase):
                     "stage": "nexus_upload",
                     "error": "previous background error",
                 },
+                "content_base_progress": {
+                    "crawl_percent": 100,
+                    "upload_percent": 50,
+                    "status": "uploading",
+                },
             },
         )
 
@@ -84,6 +89,7 @@ class TestStartSetupUseCase(TestCase):
         self.assertNotIn("last_failure", onboarding.config)
         self.assertNotIn("reason_failed", onboarding.config)
         self.assertNotIn("background_error", onboarding.config)
+        self.assertNotIn("content_base_progress", onboarding.config)
 
     @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
     def test_reset_clears_previous_channel_app_uuid(self, _mock_task):

--- a/retail/projects/tests/test_tasks.py
+++ b/retail/projects/tests/test_tasks.py
@@ -269,6 +269,15 @@ class TestTaskUploadNexusContents(TestCase):
     def test_soft_fails_and_records_background_failure(
         self, mock_release, mock_upload_cls, mock_save_background_cls
     ):
+        self.onboarding.config = {
+            "content_base_progress": {
+                "crawl_percent": 100,
+                "upload_percent": 50,
+                "status": "uploading",
+            }
+        }
+        self.onboarding.save(update_fields=["config"])
+
         mock_upload = MagicMock()
         mock_upload.execute.side_effect = RuntimeError("nexus down")
         mock_upload_cls.return_value = mock_upload
@@ -281,6 +290,10 @@ class TestTaskUploadNexusContents(TestCase):
             "mystore", "nexus_upload", "nexus down"
         )
         mock_release.assert_called_once_with("upload_nexus_contents", "mystore")
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["status"], "failed")
+        self.assertEqual(snapshot["upload_percent"], 50)
 
     @patch("retail.projects.tasks.UploadNexusContentsUseCase")
     @patch("retail.projects.tasks.release_task_lock")

--- a/retail/projects/tests/test_update_onboarding_progress.py
+++ b/retail/projects/tests/test_update_onboarding_progress.py
@@ -52,6 +52,10 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
         result = self.use_case.execute(self.onboarding_uuid, dto)
 
         self.assertEqual(result.progress, 75)
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["crawl_percent"], 35)
+        self.assertEqual(snapshot["status"], "crawling")
 
     def test_does_not_overwrite_higher_main_progress(self):
         dto = CrawlerWebhookDTO(
@@ -101,6 +105,12 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
         self.assertEqual(result.crawler_result, ProjectOnboarding.SUCCESS)
         mock_lock.assert_called_once_with("upload_nexus_contents", "mystore")
         mock_task.delay.assert_called_once_with("mystore", contents)
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["crawl_percent"], 100)
+        self.assertEqual(snapshot["upload_percent"], 0)
+        self.assertEqual(snapshot["status"], "uploading")
+        self.assertEqual(snapshot["total_files"], 1)
 
     @patch(
         "retail.projects.usecases.update_onboarding_progress.task_upload_nexus_contents"
@@ -123,6 +133,10 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
 
         self.assertEqual(result.crawler_result, ProjectOnboarding.SUCCESS)
         mock_task.delay.assert_not_called()
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["status"], "complete")
+        self.assertEqual(snapshot["upload_percent"], 100)
 
     # ── Failed event ───────────────────────────────────────────────
 
@@ -154,6 +168,10 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
         self.assertFalse(result.failed)
         mock_save_background_cls.execute.assert_called_once_with(
             "mystore", "crawl", "Connection timeout"
+        )
+        self.onboarding.refresh_from_db()
+        self.assertEqual(
+            self.onboarding.config["content_base_progress"]["status"], "failed"
         )
 
     # ── URL redirected event ───────────────────────────────────────

--- a/retail/projects/tests/test_upload_nexus_contents.py
+++ b/retail/projects/tests/test_upload_nexus_contents.py
@@ -151,6 +151,9 @@ class TestUploadNexusContentsUseCase(TestCase):
 
         self.onboarding.refresh_from_db()
         self.assertEqual(self.onboarding.progress, 100)
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["upload_percent"], 100)
+        self.assertEqual(snapshot["status"], "complete")
 
     def test_stops_on_upload_failure(self):
         self.mock_nexus_service.upload_content_base_file.side_effect = [

--- a/retail/projects/tests/test_views.py
+++ b/retail/projects/tests/test_views.py
@@ -226,6 +226,35 @@ class TestOnboardingStatusView(TestCase):
         self.assertIn("channels", response.json()["config"])
 
 
+class TestContentBaseProgressView(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    @_auth_bypass(None)
+    def test_returns_weighted_progress(self, _mock_auth):
+        ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            config={
+                "content_base_progress": {
+                    "crawl_percent": 100,
+                    "upload_percent": 50,
+                    "status": "uploading",
+                }
+            },
+        )
+
+        response = self.client.get("/api/onboard/mystore/content-base-progress/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"progress": 66})
+
+    @_auth_bypass(None)
+    def test_returns_404_when_onboarding_missing(self, _mock_auth):
+        response = self.client.get("/api/onboard/unknown/content-base-progress/")
+
+        self.assertEqual(response.status_code, 404)
+
+
 class TestOnboardingPatchView(TestCase):
     def setUp(self):
         self.client = APIClient()

--- a/retail/projects/urls.py
+++ b/retail/projects/urls.py
@@ -54,6 +54,11 @@ urlpatterns = [
         name="onboarding-support-contact",
     ),
     path(
+        "onboard/<str:vtex_account>/content-base-progress/",
+        project_views.ContentBaseProgressView.as_view(),
+        name="onboarding-content-base-progress",
+    ),
+    path(
         "onboard/<str:vtex_account>/",
         project_views.OnboardingPatchView.as_view(),
         name="onboarding-patch",

--- a/retail/projects/usecases/content_base_progress_helpers.py
+++ b/retail/projects/usecases/content_base_progress_helpers.py
@@ -1,0 +1,37 @@
+"""
+Shared helpers for background content-base crawl and upload progress.
+
+Used by ``UpdateOnboardingProgressUseCase``, ``UploadNexusContentsUseCase``,
+``GetContentBaseProgressUseCase``, and the Nexus upload Celery task to persist
+and compute progress under ``config["content_base_progress"]``.
+"""
+
+from retail.projects.models import ProjectOnboarding
+
+CRAWL_WEIGHT = 33
+UPLOAD_WEIGHT = 67
+
+STATUS_PENDING = "pending"
+STATUS_CRAWLING = "crawling"
+STATUS_UPLOADING = "uploading"
+STATUS_COMPLETE = "complete"
+STATUS_FAILED = "failed"
+
+
+def compute_overall_percent(snapshot: dict) -> int:
+    if not snapshot:
+        return 0
+    if snapshot.get("status") == STATUS_COMPLETE:
+        return 100
+    crawl = snapshot.get("crawl_percent", 0)
+    upload = snapshot.get("upload_percent", 0)
+    return min(100, round(crawl * CRAWL_WEIGHT / 100 + upload * UPLOAD_WEIGHT / 100))
+
+
+def persist_content_base_progress(onboarding: ProjectOnboarding, **updates) -> None:
+    config = onboarding.config or {}
+    snapshot = dict(config.get("content_base_progress") or {})
+    snapshot.update(updates)
+    config["content_base_progress"] = snapshot
+    onboarding.config = config
+    onboarding.save(update_fields=["config"])

--- a/retail/projects/usecases/get_content_base_progress.py
+++ b/retail/projects/usecases/get_content_base_progress.py
@@ -1,0 +1,11 @@
+from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.content_base_progress_helpers import (
+    compute_overall_percent,
+)
+
+
+class GetContentBaseProgressUseCase:
+    def execute(self, vtex_account: str) -> int:
+        onboarding = ProjectOnboarding.objects.get(vtex_account=vtex_account)
+        snapshot = (onboarding.config or {}).get("content_base_progress") or {}
+        return compute_overall_percent(snapshot)

--- a/retail/projects/usecases/start_setup.py
+++ b/retail/projects/usecases/start_setup.py
@@ -92,6 +92,7 @@ class StartSetupUseCase:
         config.pop("last_failure", None)
         config.pop("reason_failed", None)
         config.pop("background_error", None)
+        config.pop("content_base_progress", None)
 
         channels = config.get("channels", {})
         for channel_config in channels.values():

--- a/retail/projects/usecases/update_onboarding_progress.py
+++ b/retail/projects/usecases/update_onboarding_progress.py
@@ -7,6 +7,13 @@ from retail.projects.tasks import (
     acquire_task_lock,
     task_upload_nexus_contents,
 )
+from retail.projects.usecases.content_base_progress_helpers import (
+    STATUS_COMPLETE,
+    STATUS_CRAWLING,
+    STATUS_FAILED,
+    STATUS_UPLOADING,
+    persist_content_base_progress,
+)
 from retail.projects.usecases.onboarding_dto import CrawlerWebhookDTO
 from retail.projects.usecases.save_background_failure import (
     SaveBackgroundFailureUseCase,
@@ -79,6 +86,24 @@ class UpdateOnboardingProgressUseCase:
         onboarding.save(update_fields=["crawler_result"])
 
         contents = dto.data.get("contents", [])
+        total_files = len(contents)
+        if total_files == 0:
+            persist_content_base_progress(
+                onboarding,
+                crawl_percent=100,
+                upload_percent=100,
+                status=STATUS_COMPLETE,
+                total_files=0,
+            )
+        else:
+            persist_content_base_progress(
+                onboarding,
+                crawl_percent=100,
+                upload_percent=0,
+                status=STATUS_UPLOADING,
+                total_files=total_files,
+            )
+
         vtex_account = onboarding.vtex_account
 
         logger.info(
@@ -115,6 +140,7 @@ class UpdateOnboardingProgressUseCase:
         SaveBackgroundFailureUseCase.execute(
             onboarding.vtex_account, "crawl", error_msg
         )
+        persist_content_base_progress(onboarding, status=STATUS_FAILED)
         logger.warning(
             f"Background crawl failed for onboarding={onboarding.uuid}: {error_msg}"
         )
@@ -202,7 +228,8 @@ class UpdateOnboardingProgressUseCase:
         onboarding: ProjectOnboarding, dto: CrawlerWebhookDTO
     ) -> ProjectOnboarding:
         """
-        Logs a background-crawl progress event.
+        Logs a background-crawl progress event and persists crawl phase
+        progress under ``config["content_base_progress"]``.
 
         Does NOT touch ``onboarding.progress`` -- the main wizard
         progress is owned by the inline orchestrator path (which has
@@ -213,5 +240,10 @@ class UpdateOnboardingProgressUseCase:
         logger.info(
             f"Crawl background progress for onboarding={onboarding.uuid}: "
             f"event={dto.event} crawl_progress={dto.progress}%"
+        )
+        persist_content_base_progress(
+            onboarding,
+            crawl_percent=dto.progress,
+            status=STATUS_CRAWLING,
         )
         return onboarding

--- a/retail/projects/usecases/upload_nexus_contents.py
+++ b/retail/projects/usecases/upload_nexus_contents.py
@@ -12,6 +12,11 @@ from retail.projects.usecases.agent_builder_helpers import (
     ensure_agent_manager_configured,
     load_onboarding_with_linked_project,
 )
+from retail.projects.usecases.content_base_progress_helpers import (
+    STATUS_COMPLETE,
+    STATUS_UPLOADING,
+    persist_content_base_progress,
+)
 from retail.services.nexus.service import NexusService
 
 logger = logging.getLogger(__name__)
@@ -93,7 +98,7 @@ class UploadNexusContentsUseCase:
             f"Uploading {total} content files to Nexus for project={project_uuid}"
         )
 
-        for filename, file_bytes, content_type in files:
+        for index, (filename, file_bytes, content_type) in enumerate(files):
             response = self.nexus_service.upload_content_base_file(
                 project_uuid=project_uuid,
                 file=(filename, file_bytes, content_type),
@@ -113,6 +118,18 @@ class UploadNexusContentsUseCase:
             if file_uuid:
                 self._wait_for_processing(project_uuid, file_uuid, filename)
 
+            upload_percent = round((index + 1) / total * 100)
+            persist_content_base_progress(
+                onboarding,
+                upload_percent=upload_percent,
+                status=STATUS_UPLOADING,
+            )
+
+        persist_content_base_progress(
+            onboarding,
+            upload_percent=100,
+            status=STATUS_COMPLETE,
+        )
         logger.info(
             f"Content base upload completed for project={project_uuid} "
             f"({total} files uploaded)"

--- a/retail/projects/views.py
+++ b/retail/projects/views.py
@@ -21,6 +21,7 @@ from retail.projects.serializer import (
     InstallChannelAgentsSerializer,
     OnboardingPatchSerializer,
     ProjectOnboardingSerializer,
+    ContentBaseProgressSerializer,
 )
 from retail.projects.usecases.get_project_vtex_account import (
     GetProjectVtexAccountUseCase,
@@ -43,6 +44,9 @@ from retail.projects.usecases.save_onboarding_failure import (
     SaveOnboardingFailureUseCase,
 )
 from retail.projects.usecases.start_setup import StartSetupUseCase
+from retail.projects.usecases.get_content_base_progress import (
+    GetContentBaseProgressUseCase,
+)
 from retail.projects.usecases.update_onboarding_progress import (
     UpdateOnboardingProgressUseCase,
 )
@@ -213,6 +217,26 @@ class OnboardingStatusView(KeycloakAPIView):
             ProjectOnboardingSerializer(onboarding).data,
             status=status.HTTP_200_OK,
         )
+
+
+class ContentBaseProgressView(KeycloakAPIView):
+    """
+    Returns background crawl + Nexus content-base upload progress (0-100).
+
+    Crawl contributes ~33% and upload ~67% of the overall value.
+    """
+
+    def get(self, request, vtex_account: str) -> Response:
+        try:
+            progress = GetContentBaseProgressUseCase().execute(vtex_account)
+        except ProjectOnboarding.DoesNotExist:
+            return Response(
+                {"detail": "No onboarding found for this vtex_account."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        serializer = ContentBaseProgressSerializer({"progress": progress})
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class OnboardingPatchView(KeycloakAPIView):


### PR DESCRIPTION
## What

Adds background progress tracking for the content-base pipeline (crawler
webhook → Nexus upload) stored under `config["content_base_progress"]`.
Crawl contributes 33% and Nexus upload 67% of the overall 0–100 value,
computed by `compute_overall_percent`.

A new authenticated endpoint `GET /api/onboard/<vtex_account>/content-base-progress/`
returns `{"progress": <int>}`. Progress is persisted by:

- `UpdateOnboardingProgressUseCase` (crawl events, completion, failure)
- `UploadNexusContentsUseCase` (per-file upload updates)
- `_run_upload_nexus_contents` Celery task (failure status)

The main wizard `onboarding.progress` is intentionally untouched. On
`start-setup` retry, `content_base_progress` is cleared along with other
transient config keys.

## Why

The front-end needs a dedicated progress bar for the background crawl +
Nexus content-base upload that runs after the wizard reaches `NEXUS_CONFIG`.
The main onboarding progress no longer reflects this work since the CRAWL
step was decoupled from the inline wizard flow.