### PR TITLE
feat: Switch Nexus content upload to batch direct-ingest API

### DIFF
--- a/retail/clients/nexus/client.py
+++ b/retail/clients/nexus/client.py
@@ -169,58 +169,61 @@ class NexusClient(RequestClient, NexusClientInterface):
         )
         return response.json()
 
-    def get_content_base_file_status(self, project_uuid: str, file_uuid: str) -> Dict:
-        """
-        Checks the processing status of a previously uploaded content base file.
-
-        Args:
-            project_uuid: The project's unique identifier.
-            file_uuid: The UUID returned by the upload endpoint.
-
-        Returns:
-            Dict with file status (e.g. "Processing", "success", "failed").
-        """
-        url = (
-            f"{self.base_url}/api/{project_uuid}"
-            f"/inline-content-base-file/{file_uuid}/"
-        )
-        response = self.make_request(
-            url,
-            method="GET",
-            headers=self.authentication_instance.headers,
-        )
-        return response.json()
-
-    def upload_content_base_file(
+    def upload_content_base_files_batch(
         self,
         project_uuid: str,
-        file: Tuple[str, bytes, str],
+        files: List[Tuple[str, bytes, str]],
         extension_file: str = "txt",
     ) -> Dict:
         """
-        Uploads a file to the project's inline content base in Nexus.
-
-        Sends the actual binary file as multipart/form-data along with
-        the required metadata fields (extension_file, load_type).
+        Uploads up to 25 files to the project's inline content base in Nexus.
 
         Args:
             project_uuid: The project's unique identifier.
-            file: Tuple of (filename, file_bytes, content_type).
+            files: List of (filename, file_bytes, content_type) tuples.
             extension_file: The file extension without dot (e.g. "txt").
 
         Returns:
-            Dict: Upload response data.
+            Dict with uploaded file metadata and optional errors.
         """
-        url = f"{self.base_url}/api/{str(project_uuid)}/inline-content-base-file/"
+        url = (
+            f"{self.base_url}/api/{str(project_uuid)}"
+            f"/inline-content-base-file/batch/"
+        )
+        files_payload = [("files", file_tuple) for file_tuple in files]
 
         response = self.make_request(
             url,
             method="POST",
             headers=self._get_auth_header(),
-            files={"file": file},
-            data={
-                "extension_file": extension_file,
-                "load_type": "pdfminer",
-            },
+            files=files_payload,
+            data={"extension_file": extension_file},
+        )
+        return response.json()
+
+    def get_content_base_batch_progress(
+        self,
+        project_uuid: str,
+        file_uuids: List[str],
+    ) -> Dict:
+        """
+        Returns aggregate ingestion progress for a batch of uploaded files.
+
+        Args:
+            project_uuid: The project's unique identifier.
+            file_uuids: UUIDs returned by the batch upload endpoint.
+
+        Returns:
+            Dict with aggregate progress fields (total, completed, status, etc.).
+        """
+        url = (
+            f"{self.base_url}/api/{str(project_uuid)}"
+            f"/inline-content-base-file/batch/progress/"
+        )
+        response = self.make_request(
+            url,
+            method="POST",
+            json={"file_uuids": file_uuids},
+            headers=self.authentication_instance.headers,
         )
         return response.json()

--- a/retail/interfaces/clients/nexus/client.py
+++ b/retail/interfaces/clients/nexus/client.py
@@ -107,34 +107,38 @@ class NexusClientInterface(Protocol):
         """
         ...
 
-    def get_content_base_file_status(self, project_uuid: str, file_uuid: str) -> Dict:
-        """
-        Checks the processing status of a previously uploaded content base file.
-
-        Args:
-            project_uuid: The project's unique identifier.
-            file_uuid: The UUID returned by the upload endpoint.
-
-        Returns:
-            Dict with file status (e.g. "Processing", "success", "failed").
-        """
-        ...
-
-    def upload_content_base_file(
+    def upload_content_base_files_batch(
         self,
         project_uuid: str,
-        file: Tuple[str, bytes, str],
+        files: List[Tuple[str, bytes, str]],
         extension_file: str = "txt",
     ) -> Dict:
         """
-        Uploads a file to the project's inline content base in Nexus.
+        Uploads up to 25 files to the project's inline content base in Nexus.
 
         Args:
             project_uuid: The project's unique identifier.
-            file: Tuple of (filename, file_bytes, content_type).
+            files: List of (filename, file_bytes, content_type) tuples.
             extension_file: The file extension without dot (e.g. "txt").
 
         Returns:
-            Dict: Upload response data.
+            Dict with uploaded file metadata and optional errors.
+        """
+        ...
+
+    def get_content_base_batch_progress(
+        self,
+        project_uuid: str,
+        file_uuids: List[str],
+    ) -> Dict:
+        """
+        Returns aggregate ingestion progress for a batch of uploaded files.
+
+        Args:
+            project_uuid: The project's unique identifier.
+            file_uuids: UUIDs returned by the batch upload endpoint.
+
+        Returns:
+            Dict with aggregate progress fields (total, completed, status, etc.).
         """
         ...

--- a/retail/projects/tests/test_configure_agent_builder.py
+++ b/retail/projects/tests/test_configure_agent_builder.py
@@ -143,4 +143,4 @@ class TestConfigureAgentBuilderUseCase(TestCase):
 
         self.usecase.execute("mystore")
 
-        self.mock_nexus_service.upload_content_base_file.assert_not_called()
+        self.mock_nexus_service.upload_content_base_files_batch.assert_not_called()

--- a/retail/projects/tests/test_content_base_progress_helpers.py
+++ b/retail/projects/tests/test_content_base_progress_helpers.py
@@ -9,6 +9,7 @@ from retail.projects.usecases.content_base_progress_helpers import (
     STATUS_FAILED,
     STATUS_UPLOADING,
     compute_overall_percent,
+    compute_upload_percent,
     persist_content_base_progress,
 )
 
@@ -56,6 +57,20 @@ class TestComputeOverallPercent(TestCase):
             "status": STATUS_FAILED,
         }
         self.assertEqual(compute_overall_percent(snapshot), 20)
+
+
+class TestComputeUploadPercent(TestCase):
+    def test_single_batch_partial_progress(self):
+        self.assertEqual(compute_upload_percent(0, 25, 25, 40), 40)
+
+    def test_first_batch_complete_with_multiple_batches(self):
+        self.assertEqual(compute_upload_percent(0, 25, 30, 100), 83)
+
+    def test_second_batch_complete(self):
+        self.assertEqual(compute_upload_percent(1, 5, 30, 100), 100)
+
+    def test_returns_zero_when_no_files(self):
+        self.assertEqual(compute_upload_percent(0, 25, 0, 50), 0)
 
 
 class TestPersistContentBaseProgress(TestCase):

--- a/retail/projects/tests/test_onboarding_full_flow.py
+++ b/retail/projects/tests/test_onboarding_full_flow.py
@@ -172,7 +172,7 @@ class TestFullOnboardingFlow(TestCase):
         self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
         self.assertEqual(onboarding.progress, MANAGER_DONE_PROGRESS)
         mock_nexus_service.configure_agent_attributes.assert_called_once()
-        mock_nexus_service.upload_content_base_file.assert_not_called()
+        mock_nexus_service.upload_content_base_files_batch.assert_not_called()
 
         # -- Step 7: Agent integration completes the wizard --
         mock_nexus_service_agents = MagicMock()
@@ -260,11 +260,19 @@ class TestFullOnboardingFlow(TestCase):
         background_nexus.check_agent_builder_exists.return_value = {
             "data": {"has_agent": True}
         }
-        background_nexus.upload_content_base_file.return_value = {
-            "uuid": str(uuid4()),
-            "extension_file": "txt",
+        background_nexus.upload_content_base_files_batch.return_value = {
+            "files": [
+                {"uuid": str(uuid4()), "extension_file": "txt", "filename": "a.txt"},
+                {"uuid": str(uuid4()), "extension_file": "txt", "filename": "b.txt"},
+            ]
         }
-        background_nexus.get_content_base_file_status.return_value = {
+        background_nexus.get_content_base_batch_progress.return_value = {
+            "total": 2,
+            "completed": 2,
+            "failed": 0,
+            "remaining": 0,
+            "progress_percentage": 100,
+            "is_complete": True,
             "status": "success",
         }
 
@@ -277,7 +285,7 @@ class TestFullOnboardingFlow(TestCase):
         onboarding.refresh_from_db()
         self.assertEqual(onboarding.current_step, "NEXUS_CONFIG")
         self.assertEqual(onboarding.progress, 100)
-        self.assertEqual(background_nexus.upload_content_base_file.call_count, 2)
+        self.assertEqual(background_nexus.upload_content_base_files_batch.call_count, 1)
         self.assertEqual(
             GetContentBaseProgressUseCase().execute(self.vtex_account), 100
         )

--- a/retail/projects/tests/test_upload_nexus_contents.py
+++ b/retail/projects/tests/test_upload_nexus_contents.py
@@ -262,6 +262,70 @@ class TestUploadNexusContentsUseCase(TestCase):
             self.mock_nexus_service.get_content_base_batch_progress.call_count, 2
         )
 
+    @patch("retail.projects.usecases.upload_nexus_contents.persist_content_base_progress")
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_persists_progress_during_batch_polling(
+        self, _mock_sleep, mock_persist
+    ):
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(upload_uuid)
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.side_effect = [
+            _batch_progress_response(
+                is_complete=False, status="processing", progress_percentage=0
+            ),
+            _batch_progress_response(
+                is_complete=False, status="processing", progress_percentage=50
+            ),
+            _batch_progress_response(),
+        ]
+
+        contents = [{"link": "https://a.com", "title": "A", "content": "a"}]
+
+        self.usecase.execute("mystore", contents)
+
+        upload_percents = [
+            call.kwargs["upload_percent"]
+            for call in mock_persist.call_args_list
+            if call.kwargs.get("status") == "uploading"
+        ]
+        self.assertEqual(upload_percents, [0, 50, 100])
+
+    @patch("retail.projects.usecases.upload_nexus_contents.persist_content_base_progress")
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_multi_batch_persists_mid_batch_before_second_batch_starts(
+        self, _mock_sleep, mock_persist
+    ):
+        first_batch_uuids = [str(uuid4()) for _ in range(BATCH_MAX_FILES)]
+        second_batch_uuid = str(uuid4())
+
+        self.mock_nexus_service.upload_content_base_files_batch.side_effect = [
+            _batch_upload_response(*first_batch_uuids),
+            _batch_upload_response(second_batch_uuid),
+        ]
+        self.mock_nexus_service.get_content_base_batch_progress.side_effect = [
+            _batch_progress_response(
+                is_complete=False, status="processing", progress_percentage=50
+            ),
+            _batch_progress_response(),
+            _batch_progress_response(),
+        ]
+
+        contents = [
+            {"link": f"https://a{i}.com", "title": f"Page {i}", "content": f"c{i}"}
+            for i in range(BATCH_MAX_FILES + 1)
+        ]
+
+        self.usecase.execute("mystore", contents)
+
+        uploading_percents = [
+            call.kwargs["upload_percent"]
+            for call in mock_persist.call_args_list
+            if call.kwargs.get("status") == "uploading"
+        ]
+        self.assertEqual(uploading_percents[0], 48)
+
     @patch(
         "retail.projects.usecases.upload_nexus_contents.BATCH_STATUS_MAX_ATTEMPTS", 2
     )

--- a/retail/projects/tests/test_upload_nexus_contents.py
+++ b/retail/projects/tests/test_upload_nexus_contents.py
@@ -6,11 +6,39 @@ from django.test import TestCase
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.usecases.agent_builder_helpers import ProjectNotLinkedError
 from retail.projects.usecases.upload_nexus_contents import (
-    FileProcessingError,
+    BATCH_MAX_FILES,
     FileUploadError,
     UploadNexusContentsUseCase,
     _sanitize_filename,
 )
+
+
+def _batch_upload_response(*file_uuids):
+    return {
+        "files": [
+            {"uuid": uuid, "extension_file": "txt", "filename": f"file-{i}.txt"}
+            for i, uuid in enumerate(file_uuids)
+        ]
+    }
+
+
+def _batch_progress_response(
+    *,
+    is_complete=True,
+    status="success",
+    progress_percentage=100,
+    failed_files=None,
+):
+    return {
+        "total": 1,
+        "completed": 1 if status == "success" else 0,
+        "failed": 0,
+        "remaining": 0 if is_complete else 1,
+        "progress_percentage": progress_percentage,
+        "is_complete": is_complete,
+        "status": status,
+        "failed_files": failed_files or [],
+    }
 
 
 class TestUploadNexusContentsUseCase(TestCase):
@@ -47,7 +75,7 @@ class TestUploadNexusContentsUseCase(TestCase):
 
         self.onboarding.refresh_from_db()
         self.assertEqual(self.onboarding.progress, 100)
-        self.mock_nexus_service.upload_content_base_file.assert_not_called()
+        self.mock_nexus_service.upload_content_base_files_batch.assert_not_called()
 
     def test_ensures_agent_configured_before_upload(self):
         """
@@ -68,16 +96,14 @@ class TestUploadNexusContentsUseCase(TestCase):
         self.mock_nexus_service.configure_agent_attributes.assert_called_once()
 
     @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
-    def test_uploads_files_for_each_content(self, _mock_sleep):
-        upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "success",
-        }
+    def test_uploads_files_in_single_batch(self, _mock_sleep):
+        uuid_1, uuid_2 = str(uuid4()), str(uuid4())
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(uuid_1, uuid_2)
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.return_value = (
+            _batch_progress_response()
+        )
 
         contents = [
             {
@@ -94,22 +120,18 @@ class TestUploadNexusContentsUseCase(TestCase):
 
         self.usecase.execute("mystore", contents)
 
-        self.assertEqual(self.mock_nexus_service.upload_content_base_file.call_count, 2)
-        self.assertEqual(
-            self.mock_nexus_service.get_content_base_file_status.call_count, 2
-        )
+        self.mock_nexus_service.upload_content_base_files_batch.assert_called_once()
+        self.mock_nexus_service.get_content_base_batch_progress.assert_called_once()
 
     @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
     def test_file_contains_only_content(self, _mock_sleep):
         upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "success",
-        }
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(upload_uuid)
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.return_value = (
+            _batch_progress_response()
+        )
 
         contents = [
             {
@@ -121,8 +143,11 @@ class TestUploadNexusContentsUseCase(TestCase):
 
         self.usecase.execute("mystore", contents)
 
-        call_kwargs = self.mock_nexus_service.upload_content_base_file.call_args[1]
-        _, file_bytes, _ = call_kwargs["file"]
+        call_kwargs = self.mock_nexus_service.upload_content_base_files_batch.call_args[
+            1
+        ]
+        batch_files = call_kwargs["files"]
+        _, file_bytes, _ = batch_files[0]
 
         text = file_bytes.decode("utf-8")
         self.assertEqual(text, "Some content here.")
@@ -133,14 +158,12 @@ class TestUploadNexusContentsUseCase(TestCase):
     def test_does_not_update_progress(self, _mock_sleep):
         """Background path must never touch ``onboarding.progress``."""
         upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "success",
-        }
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(upload_uuid, str(uuid4()))
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.return_value = (
+            _batch_progress_response()
+        )
 
         contents = [
             {"link": "https://a.com", "title": "A", "content": "a"},
@@ -156,10 +179,7 @@ class TestUploadNexusContentsUseCase(TestCase):
         self.assertEqual(snapshot["status"], "complete")
 
     def test_stops_on_upload_failure(self):
-        self.mock_nexus_service.upload_content_base_file.side_effect = [
-            None,
-            {"uuid": str(uuid4()), "extension_file": "txt"},
-        ]
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = None
 
         contents = [
             {"link": "https://a.com", "title": "A", "content": "a"},
@@ -169,19 +189,17 @@ class TestUploadNexusContentsUseCase(TestCase):
         with self.assertRaises(FileUploadError):
             self.usecase.execute("mystore", contents)
 
-        self.assertEqual(self.mock_nexus_service.upload_content_base_file.call_count, 1)
+        self.mock_nexus_service.upload_content_base_files_batch.assert_called_once()
 
     @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
     def test_passes_project_uuid_to_nexus(self, _mock_sleep):
         upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "success",
-        }
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(upload_uuid)
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.return_value = (
+            _batch_progress_response()
+        )
 
         contents = [
             {"link": "https://a.com", "title": "A", "content": "a"},
@@ -189,45 +207,51 @@ class TestUploadNexusContentsUseCase(TestCase):
 
         self.usecase.execute("mystore", contents)
 
-        call_kwargs = self.mock_nexus_service.upload_content_base_file.call_args[1]
+        call_kwargs = self.mock_nexus_service.upload_content_base_files_batch.call_args[
+            1
+        ]
         self.assertEqual(call_kwargs["project_uuid"], str(self.project.uuid))
 
     @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
-    def test_waits_for_processing_before_next_upload(self, _mock_sleep):
-        """Ensures polling occurs between consecutive uploads."""
+    def test_waits_for_batch_processing_before_next_batch(self, _mock_sleep):
+        """Ensures polling occurs until the batch is complete."""
         uuid_1, uuid_2 = str(uuid4()), str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.side_effect = [
-            {"uuid": uuid_1, "extension_file": "txt"},
-            {"uuid": uuid_2, "extension_file": "txt"},
+        self.mock_nexus_service.upload_content_base_files_batch.side_effect = [
+            _batch_upload_response(uuid_1),
+            _batch_upload_response(uuid_2),
         ]
-        self.mock_nexus_service.get_content_base_file_status.side_effect = [
-            {"uuid": uuid_1, "status": "Processing"},
-            {"uuid": uuid_1, "status": "success"},
-            {"uuid": uuid_2, "status": "success"},
+        self.mock_nexus_service.get_content_base_batch_progress.side_effect = [
+            _batch_progress_response(
+                is_complete=False, status="processing", progress_percentage=0
+            ),
+            _batch_progress_response(),
+            _batch_progress_response(),
         ]
 
         contents = [
-            {"link": "https://a.com", "title": "A", "content": "a"},
-            {"link": "https://b.com", "title": "B", "content": "b"},
+            {"link": f"https://a{i}.com", "title": f"A{i}", "content": f"a{i}"}
+            for i in range(BATCH_MAX_FILES + 1)
         ]
 
         self.usecase.execute("mystore", contents)
 
         self.assertEqual(
-            self.mock_nexus_service.get_content_base_file_status.call_count, 3
+            self.mock_nexus_service.upload_content_base_files_batch.call_count, 2
+        )
+        self.assertEqual(
+            self.mock_nexus_service.get_content_base_batch_progress.call_count, 3
         )
 
     @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
     def test_retries_status_poll_when_status_unavailable(self, _mock_sleep):
-        """A transient ``None`` status response must not abort polling."""
+        """A transient ``None`` progress response must not abort polling."""
         upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.side_effect = [
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(upload_uuid)
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.side_effect = [
             None,
-            {"uuid": upload_uuid, "status": "success"},
+            _batch_progress_response(),
         ]
 
         contents = [{"link": "https://a.com", "title": "A", "content": "a"}]
@@ -235,49 +259,111 @@ class TestUploadNexusContentsUseCase(TestCase):
         self.usecase.execute("mystore", contents)
 
         self.assertEqual(
-            self.mock_nexus_service.get_content_base_file_status.call_count, 2
+            self.mock_nexus_service.get_content_base_batch_progress.call_count, 2
         )
 
-    @patch("retail.projects.usecases.upload_nexus_contents.FILE_STATUS_MAX_ATTEMPTS", 2)
+    @patch(
+        "retail.projects.usecases.upload_nexus_contents.BATCH_STATUS_MAX_ATTEMPTS", 2
+    )
     @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
     def test_gives_up_after_max_attempts_without_terminal_status(self, _mock_sleep):
         """Polling stops (without raising) once the attempt budget runs out."""
         upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "processing",
-        }
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(upload_uuid)
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.return_value = (
+            _batch_progress_response(
+                is_complete=False, status="processing", progress_percentage=0
+            )
+        )
 
         contents = [{"link": "https://a.com", "title": "A", "content": "a"}]
 
         self.usecase.execute("mystore", contents)
 
         self.assertEqual(
-            self.mock_nexus_service.get_content_base_file_status.call_count, 2
+            self.mock_nexus_service.get_content_base_batch_progress.call_count, 2
         )
 
     @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
-    def test_raises_on_processing_failure(self, _mock_sleep):
+    def test_does_not_raise_on_processing_failure(self, _mock_sleep):
+        """Best-effort: a failed batch is logged but does not abort the upload."""
         upload_uuid = str(uuid4())
-        self.mock_nexus_service.upload_content_base_file.return_value = {
-            "uuid": upload_uuid,
-            "extension_file": "txt",
-        }
-        self.mock_nexus_service.get_content_base_file_status.return_value = {
-            "uuid": upload_uuid,
-            "status": "failed",
-        }
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(upload_uuid)
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.return_value = (
+            _batch_progress_response(status="failed", progress_percentage=0)
+        )
 
         contents = [
             {"link": "https://a.com", "title": "A", "content": "a"},
         ]
 
-        with self.assertRaises(FileProcessingError):
-            self.usecase.execute("mystore", contents)
+        self.usecase.execute("mystore", contents)
+
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["status"], "complete")
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_logs_partial_batch_failures_without_raising(self, _mock_sleep):
+        upload_uuid = str(uuid4())
+        self.mock_nexus_service.upload_content_base_files_batch.return_value = (
+            _batch_upload_response(upload_uuid)
+        )
+        self.mock_nexus_service.get_content_base_batch_progress.return_value = (
+            _batch_progress_response(
+                status="partial",
+                progress_percentage=50,
+                failed_files=[{"uuid": upload_uuid, "filename": "a.txt"}],
+            )
+        )
+
+        contents = [{"link": "https://a.com", "title": "A", "content": "a"}]
+
+        self.usecase.execute("mystore", contents)
+
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["status"], "complete")
+
+    @patch("retail.projects.usecases.upload_nexus_contents.time.sleep")
+    def test_chunks_more_than_25_files(self, _mock_sleep):
+        first_batch_uuids = [str(uuid4()) for _ in range(BATCH_MAX_FILES)]
+        second_batch_uuid = str(uuid4())
+
+        self.mock_nexus_service.upload_content_base_files_batch.side_effect = [
+            _batch_upload_response(*first_batch_uuids),
+            _batch_upload_response(second_batch_uuid),
+        ]
+        self.mock_nexus_service.get_content_base_batch_progress.return_value = (
+            _batch_progress_response()
+        )
+
+        contents = [
+            {"link": f"https://a{i}.com", "title": f"Page {i}", "content": f"c{i}"}
+            for i in range(BATCH_MAX_FILES + 1)
+        ]
+
+        self.usecase.execute("mystore", contents)
+
+        self.assertEqual(
+            self.mock_nexus_service.upload_content_base_files_batch.call_count, 2
+        )
+        first_call_files = (
+            self.mock_nexus_service.upload_content_base_files_batch.call_args_list[0][
+                1
+            ]["files"]
+        )
+        second_call_files = (
+            self.mock_nexus_service.upload_content_base_files_batch.call_args_list[1][
+                1
+            ]["files"]
+        )
+        self.assertEqual(len(first_call_files), BATCH_MAX_FILES)
+        self.assertEqual(len(second_call_files), 1)
 
 
 class TestBuildFilesFromContents(TestCase):

--- a/retail/projects/usecases/content_base_progress_helpers.py
+++ b/retail/projects/usecases/content_base_progress_helpers.py
@@ -28,6 +28,27 @@ def compute_overall_percent(snapshot: dict) -> int:
     return min(100, round(crawl * CRAWL_WEIGHT / 100 + upload * UPLOAD_WEIGHT / 100))
 
 
+def compute_upload_percent(
+    batch_index: int,
+    batch_size: int,
+    total_files: int,
+    batch_progress_pct: int,
+    *,
+    batch_max_files: int = 25,
+) -> int:
+    if total_files <= 0:
+        return 0
+    files_before_batch = batch_index * batch_max_files
+    return min(
+        100,
+        round(
+            (files_before_batch + batch_progress_pct * batch_size / 100)
+            / total_files
+            * 100
+        ),
+    )
+
+
 def persist_content_base_progress(onboarding: ProjectOnboarding, **updates) -> None:
     config = onboarding.config or {}
     snapshot = dict(config.get("content_base_progress") or {})

--- a/retail/projects/usecases/upload_nexus_contents.py
+++ b/retail/projects/usecases/upload_nexus_contents.py
@@ -15,6 +15,7 @@ from retail.projects.usecases.agent_builder_helpers import (
 from retail.projects.usecases.content_base_progress_helpers import (
     STATUS_COMPLETE,
     STATUS_UPLOADING,
+    compute_upload_percent,
     persist_content_base_progress,
 )
 from retail.services.nexus.service import NexusService
@@ -135,20 +136,13 @@ class UploadNexusContentsUseCase:
                 f"project={project_uuid}: file_uuids={batch_file_uuids}"
             )
 
-            batch_progress_pct = self._wait_for_batch_processing(
-                project_uuid, batch_file_uuids, batch_index
-            )
-
-            files_before_batch = batch_index * BATCH_MAX_FILES
-            overall_upload_percent = round(
-                (files_before_batch + batch_progress_pct * len(batch) / 100)
-                / total
-                * 100
-            )
-            persist_content_base_progress(
+            self._wait_for_batch_processing(
                 onboarding,
-                upload_percent=min(overall_upload_percent, 100),
-                status=STATUS_UPLOADING,
+                project_uuid,
+                batch_file_uuids,
+                batch_index=batch_index,
+                batch_size=len(batch),
+                total_files=total,
             )
 
         if not uploaded_file_uuids:
@@ -168,15 +162,20 @@ class UploadNexusContentsUseCase:
 
     def _wait_for_batch_processing(
         self,
+        onboarding: ProjectOnboarding,
         project_uuid: str,
         file_uuids: List[str],
+        *,
         batch_index: int,
+        batch_size: int,
+        total_files: int,
     ) -> int:
         """
         Polls Nexus until the batch reaches a terminal state.
 
-        Returns the final ``progress_percentage`` from Nexus.
-        Partial and failed batches are logged but do not raise.
+        Persists ``upload_percent`` on every successful poll so clients
+        see real-time progress. Returns the final ``progress_percentage``
+        from Nexus. Partial and failed batches are logged but do not raise.
         """
         for attempt in range(1, BATCH_STATUS_MAX_ATTEMPTS + 1):
             time.sleep(BATCH_STATUS_POLL_INTERVAL)
@@ -197,9 +196,19 @@ class UploadNexusContentsUseCase:
             progress_pct = progress_response.get("progress_percentage", 0)
             is_complete = progress_response.get("is_complete", False)
 
+            upload_percent = compute_upload_percent(
+                batch_index, batch_size, total_files, progress_pct
+            )
+            persist_content_base_progress(
+                onboarding,
+                upload_percent=upload_percent,
+                status=STATUS_UPLOADING,
+            )
+
             logger.info(
                 f"Batch {batch_index + 1} progress for project={project_uuid}: "
                 f"status={status} progress={progress_pct}% "
+                f"upload_percent={upload_percent}% "
                 f"(attempt {attempt}/{BATCH_STATUS_MAX_ATTEMPTS})"
             )
 

--- a/retail/projects/usecases/upload_nexus_contents.py
+++ b/retail/projects/usecases/upload_nexus_contents.py
@@ -22,28 +22,28 @@ from retail.services.nexus.service import NexusService
 logger = logging.getLogger(__name__)
 
 
-class FileProcessingError(Exception):
-    """Raised when Nexus reports a file processing failure."""
-
-
 class FileUploadError(Exception):
     """Raised when a file upload to Nexus fails."""
 
 
-FILE_STATUS_POLL_INTERVAL = 3  # seconds between status checks
-FILE_STATUS_MAX_ATTEMPTS = 60  # ~3 minutes max wait per file
+BATCH_MAX_FILES = 25
+BATCH_STATUS_POLL_INTERVAL = 3  # seconds between status checks
+BATCH_STATUS_MAX_ATTEMPTS = 300  # ~15 minutes max wait per batch
 
 
 class UploadNexusContentsUseCase:
     """
     Background-only upload of crawled content files to the Nexus
-    content base.
+    content base via the inline batch direct-ingest API.
 
     Invoked by ``task_upload_nexus_contents`` when the crawl webhook
     arrives with ``crawl.completed``. Calls ``ensure_agent_manager_configured``
     first so the upload is safe to run even if the inline manager step
     (``ConfigureAgentBuilderUseCase``) has not yet completed -- e.g.
     the webhook arrived early.
+
+    Partial ingestion failures within a batch are logged but do not
+    abort the upload when at least one file succeeds (best-effort).
 
     Background path: does NOT touch ``onboarding.progress`` -- the main
     wizard is decoupled from the crawl outcome.
@@ -80,7 +80,8 @@ class UploadNexusContentsUseCase:
         contents: list,
     ) -> None:
         """
-        Converts crawled content to .txt files and uploads them to Nexus.
+        Converts crawled content to .txt files and uploads them to Nexus
+        in batches of up to 25 files.
 
         Background-only: does NOT update ``onboarding.progress``. The
         ``onboarding`` argument is kept for log context.
@@ -93,36 +94,66 @@ class UploadNexusContentsUseCase:
 
         files = self._build_files_from_contents(contents)
         total = len(files)
+        batches = _chunk_files(files, BATCH_MAX_FILES)
+        uploaded_file_uuids: List[str] = []
 
         logger.info(
-            f"Uploading {total} content files to Nexus for project={project_uuid}"
+            f"Uploading {total} content files to Nexus for project={project_uuid} "
+            f"in {len(batches)} batch(es)"
         )
 
-        for index, (filename, file_bytes, content_type) in enumerate(files):
-            response = self.nexus_service.upload_content_base_file(
+        for batch_index, batch in enumerate(batches):
+            response = self.nexus_service.upload_content_base_files_batch(
                 project_uuid=project_uuid,
-                file=(filename, file_bytes, content_type),
+                files=batch,
             )
 
             if response is None:
                 raise FileUploadError(
-                    f"Failed to upload {filename} to Nexus for project={project_uuid}"
+                    f"Failed to batch upload files to Nexus for project={project_uuid}"
                 )
 
-            file_uuid = response.get("uuid")
+            uploaded_files = response.get("files") or []
+            if not uploaded_files:
+                raise FileUploadError(
+                    f"No files were uploaded to Nexus for project={project_uuid}"
+                )
+
+            for error in response.get("errors") or []:
+                logger.warning(
+                    f"Batch upload error for project={project_uuid}: "
+                    f"filename={error.get('filename')} message={error.get('message')}"
+                )
+
+            batch_file_uuids = [
+                entry["uuid"] for entry in uploaded_files if entry.get("uuid")
+            ]
+            uploaded_file_uuids.extend(batch_file_uuids)
+
             logger.info(
-                f"Uploaded {filename} to Nexus for project={project_uuid}: "
-                f"file_uuid={file_uuid}, response={response}"
+                f"Batch {batch_index + 1}/{len(batches)} uploaded for "
+                f"project={project_uuid}: file_uuids={batch_file_uuids}"
             )
 
-            if file_uuid:
-                self._wait_for_processing(project_uuid, file_uuid, filename)
+            batch_progress_pct = self._wait_for_batch_processing(
+                project_uuid, batch_file_uuids, batch_index
+            )
 
-            upload_percent = round((index + 1) / total * 100)
+            files_before_batch = batch_index * BATCH_MAX_FILES
+            overall_upload_percent = round(
+                (files_before_batch + batch_progress_pct * len(batch) / 100)
+                / total
+                * 100
+            )
             persist_content_base_progress(
                 onboarding,
-                upload_percent=upload_percent,
+                upload_percent=min(overall_upload_percent, 100),
                 status=STATUS_UPLOADING,
+            )
+
+        if not uploaded_file_uuids:
+            raise FileUploadError(
+                f"No file UUIDs returned from Nexus for project={project_uuid}"
             )
 
         persist_content_base_progress(
@@ -132,50 +163,68 @@ class UploadNexusContentsUseCase:
         )
         logger.info(
             f"Content base upload completed for project={project_uuid} "
-            f"({total} files uploaded)"
+            f"({len(uploaded_file_uuids)} files uploaded)"
         )
 
-    def _wait_for_processing(
-        self, project_uuid: str, file_uuid: str, filename: str
-    ) -> None:
+    def _wait_for_batch_processing(
+        self,
+        project_uuid: str,
+        file_uuids: List[str],
+        batch_index: int,
+    ) -> int:
         """
-        Polls Nexus until the uploaded file reaches a terminal status
-        (``success`` or ``failed``) before allowing the next upload.
-        """
-        for attempt in range(1, FILE_STATUS_MAX_ATTEMPTS + 1):
-            time.sleep(FILE_STATUS_POLL_INTERVAL)
+        Polls Nexus until the batch reaches a terminal state.
 
-            status_response = self.nexus_service.get_content_base_file_status(
-                project_uuid, file_uuid
+        Returns the final ``progress_percentage`` from Nexus.
+        Partial and failed batches are logged but do not raise.
+        """
+        for attempt in range(1, BATCH_STATUS_MAX_ATTEMPTS + 1):
+            time.sleep(BATCH_STATUS_POLL_INTERVAL)
+
+            progress_response = self.nexus_service.get_content_base_batch_progress(
+                project_uuid, file_uuids
             )
 
-            if status_response is None:
+            if progress_response is None:
                 logger.warning(
-                    f"Could not fetch status for file_uuid={file_uuid} "
-                    f"(attempt {attempt}/{FILE_STATUS_MAX_ATTEMPTS})"
+                    f"Could not fetch batch progress for project={project_uuid} "
+                    f"batch={batch_index + 1} "
+                    f"(attempt {attempt}/{BATCH_STATUS_MAX_ATTEMPTS})"
                 )
                 continue
 
-            status = status_response.get("status", "").lower()
+            status = progress_response.get("status", "").lower()
+            progress_pct = progress_response.get("progress_percentage", 0)
+            is_complete = progress_response.get("is_complete", False)
 
             logger.info(
-                f"File {filename} (uuid={file_uuid}) status={status} "
-                f"(attempt {attempt}/{FILE_STATUS_MAX_ATTEMPTS})"
+                f"Batch {batch_index + 1} progress for project={project_uuid}: "
+                f"status={status} progress={progress_pct}% "
+                f"(attempt {attempt}/{BATCH_STATUS_MAX_ATTEMPTS})"
             )
 
-            if status == "success":
-                return
+            if not is_complete:
+                continue
 
-            if status == "failed":
-                raise FileProcessingError(
-                    f"Nexus reported processing failure for "
-                    f"file_uuid={file_uuid} ({filename})"
+            if status == "partial":
+                failed_files = progress_response.get("failed_files") or []
+                logger.warning(
+                    f"Batch {batch_index + 1} completed with partial failures "
+                    f"for project={project_uuid}: failed_files={failed_files}"
+                )
+            elif status == "failed":
+                logger.error(
+                    f"Batch {batch_index + 1} ingestion failed for "
+                    f"project={project_uuid}: file_uuids={file_uuids}"
                 )
 
+            return progress_pct
+
         logger.error(
-            f"Timed out waiting for file_uuid={file_uuid} ({filename}) "
-            f"after {FILE_STATUS_MAX_ATTEMPTS} attempts"
+            f"Timed out waiting for batch {batch_index + 1} "
+            f"project={project_uuid} after {BATCH_STATUS_MAX_ATTEMPTS} attempts"
         )
+        return 0
 
     @staticmethod
     def _build_files_from_contents(
@@ -204,6 +253,12 @@ class UploadNexusContentsUseCase:
             files.append((filename, file_bytes, "text/plain"))
 
         return files
+
+
+def _chunk_files(
+    files: List[Tuple[str, bytes, str]], chunk_size: int
+) -> List[List[Tuple[str, bytes, str]]]:
+    return [files[i : i + chunk_size] for i in range(0, len(files), chunk_size)]  # noqa: E203
 
 
 def _sanitize_filename(title: str, index: int) -> str:

--- a/retail/services/nexus/service.py
+++ b/retail/services/nexus/service.py
@@ -117,47 +117,49 @@ class NexusService:
             )
             return None
 
-    def get_content_base_file_status(
-        self, project_uuid: str, file_uuid: str
-    ) -> Optional[Dict]:
-        """
-        Checks the processing status of a previously uploaded content base file.
-        """
-        try:
-            return self.nexus_client.get_content_base_file_status(
-                project_uuid, file_uuid
-            )
-        except CustomAPIException as e:
-            logger.error(
-                f"Error {e.status_code} checking file status "
-                f"file_uuid={file_uuid} project={project_uuid}: {e}"
-            )
-            return None
-
-    def upload_content_base_file(
+    def upload_content_base_files_batch(
         self,
         project_uuid: str,
-        file: Tuple[str, bytes, str],
+        files: List[Tuple[str, bytes, str]],
         extension_file: str = "txt",
     ) -> Optional[Dict]:
         """
-        Uploads a file to the project's inline content base in Nexus.
+        Uploads up to 25 files to the project's inline content base in Nexus.
 
         Args:
             project_uuid: The project's unique identifier.
-            file: Tuple of (filename, file_bytes, content_type).
+            files: List of (filename, file_bytes, content_type) tuples.
             extension_file: The file extension without dot (e.g. "txt").
 
         Returns:
-            Dict with upload response or None on failure.
+            Dict with uploaded file metadata or None on failure.
         """
         try:
-            return self.nexus_client.upload_content_base_file(
-                project_uuid, file, extension_file
+            return self.nexus_client.upload_content_base_files_batch(
+                project_uuid, files, extension_file
             )
         except CustomAPIException as e:
             logger.error(
-                f"Error {e.status_code} when uploading content base file "
+                f"Error {e.status_code} when batch uploading content base files "
                 f"for project {project_uuid}: {e}"
+            )
+            return None
+
+    def get_content_base_batch_progress(
+        self,
+        project_uuid: str,
+        file_uuids: List[str],
+    ) -> Optional[Dict]:
+        """
+        Returns aggregate ingestion progress for a batch of uploaded files.
+        """
+        try:
+            return self.nexus_client.get_content_base_batch_progress(
+                project_uuid, file_uuids
+            )
+        except CustomAPIException as e:
+            logger.error(
+                f"Error {e.status_code} checking batch progress "
+                f"project={project_uuid} file_uuids={file_uuids}: {e}"
             )
             return None

--- a/retail/services/tests/test_nexus.py
+++ b/retail/services/tests/test_nexus.py
@@ -184,3 +184,67 @@ class TestNexusService(TestCase):
         )
 
         self.assertIsNone(result)
+
+    def test_upload_content_base_files_batch_success(self):
+        files = [("page.txt", b"content", "text/plain")]
+        expected = {
+            "files": [
+                {
+                    "uuid": "file-uuid-1",
+                    "extension_file": "txt",
+                    "filename": "page.txt",
+                }
+            ]
+        }
+        self.mock_nexus_client.upload_content_base_files_batch.return_value = expected
+
+        result = self.service.upload_content_base_files_batch(self.project_uuid, files)
+
+        self.mock_nexus_client.upload_content_base_files_batch.assert_called_once_with(
+            self.project_uuid, files, "txt"
+        )
+        self.assertEqual(result, expected)
+
+    def test_upload_content_base_files_batch_api_exception(self):
+        files = [("page.txt", b"content", "text/plain")]
+        self.mock_nexus_client.upload_content_base_files_batch.side_effect = (
+            CustomAPIException(status_code=400, detail="Bad request")
+        )
+
+        result = self.service.upload_content_base_files_batch(self.project_uuid, files)
+
+        self.assertIsNone(result)
+
+    def test_get_content_base_batch_progress_success(self):
+        file_uuids = ["uuid-1", "uuid-2"]
+        expected = {
+            "total": 2,
+            "completed": 1,
+            "failed": 0,
+            "remaining": 1,
+            "progress_percentage": 50,
+            "is_complete": False,
+            "status": "processing",
+        }
+        self.mock_nexus_client.get_content_base_batch_progress.return_value = expected
+
+        result = self.service.get_content_base_batch_progress(
+            self.project_uuid, file_uuids
+        )
+
+        self.mock_nexus_client.get_content_base_batch_progress.assert_called_once_with(
+            self.project_uuid, file_uuids
+        )
+        self.assertEqual(result, expected)
+
+    def test_get_content_base_batch_progress_api_exception(self):
+        file_uuids = ["uuid-1"]
+        self.mock_nexus_client.get_content_base_batch_progress.side_effect = (
+            CustomAPIException(status_code=500, detail="Error")
+        )
+
+        result = self.service.get_content_base_batch_progress(
+            self.project_uuid, file_uuids
+        )
+
+        self.assertIsNone(result)


### PR DESCRIPTION
## What

Refactors the background crawl upload path (`UploadNexusContentsUseCase`) from
sequential single-file uploads to Nexus's inline batch direct-ingest API
(up to 25 files per request).

- Adds `upload_content_base_files_batch` and `get_content_base_batch_progress`
to the Nexus client interface, client, and service.
- Chunks crawled `.txt` files into batches, uploads each batch, polls aggregate
ingestion progress until `is_complete`, and persists upload percent under
`config["content_base_progress"]`.
- Partial and failed ingestion batches are logged but do not abort the flow
(best-effort); HTTP upload failures still raise `FileUploadError`.
- Updates onboarding integration tests and adds unit tests for the new service
methods and batch polling behavior.

## Why

The single-file upload + per-file status poll was slow for large crawls and
does not align with Nexus's Bedrock DIRECT ingestion batch API. Batching
reduces round-trips.