### PR TITLE
feat: Enhance NexusClient to support instructions in agent payload

### DIFF
--- a/retail/clients/nexus/client.py
+++ b/retail/clients/nexus/client.py
@@ -155,7 +155,8 @@ class NexusClient(RequestClient, NexusClientInterface):
 
         Args:
             project_uuid: The project's unique identifier.
-            agent_payload: Dict with "agent" and optional "links" keys.
+            agent_payload: Dict with "agent", optional "links", and optional
+                "instructions" keys.
 
         Returns:
             Dict with the Nexus response.

--- a/retail/interfaces/clients/nexus/client.py
+++ b/retail/interfaces/clients/nexus/client.py
@@ -100,7 +100,8 @@ class NexusClientInterface(Protocol):
 
         Args:
             project_uuid: The project's unique identifier.
-            agent_payload: Dict with "agent" and optional "links" keys.
+            agent_payload: Dict with "agent", optional "links", and optional
+                "instructions" keys.
 
         Returns:
             Dict with the Nexus response.

--- a/retail/projects/tests/test_agent_builder_helpers.py
+++ b/retail/projects/tests/test_agent_builder_helpers.py
@@ -10,6 +10,7 @@ from retail.projects.usecases.agent_builder_helpers import (
     load_onboarding_with_linked_project,
 )
 from retail.projects.usecases.manager_defaults import MANAGER_DEFAULTS
+from retail.projects.usecases.onboarding_defaults import INSTRUCTIONS_BY_LANGUAGE
 
 
 class TestLoadOnboardingWithLinkedProject(TestCase):
@@ -71,6 +72,20 @@ class TestEnsureAgentManagerConfigured(TestCase):
         payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
         self.assertEqual(payload["agent"]["name"], "Mystore Manager")
         self.assertEqual(payload["agent"]["goal"], MANAGER_DEFAULTS["pt"]["goal"])
+        self.assertEqual(payload["instructions"], INSTRUCTIONS_BY_LANGUAGE["pt"])
+
+    def test_configures_with_english_fallback_instructions(self):
+        self.mock_nexus_service.check_agent_builder_exists.return_value = {
+            "data": {"has_agent": False}
+        }
+        self.mock_nexus_service.configure_agent_attributes.return_value = {"ok": True}
+
+        ensure_agent_manager_configured(
+            self.project_uuid, "mystore", "ja-jp", self.mock_nexus_service
+        )
+
+        payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
+        self.assertEqual(payload["instructions"], INSTRUCTIONS_BY_LANGUAGE["en"])
 
     def test_configures_when_check_returns_none(self):
         self.mock_nexus_service.check_agent_builder_exists.return_value = None

--- a/retail/projects/tests/test_configure_agent_builder.py
+++ b/retail/projects/tests/test_configure_agent_builder.py
@@ -13,6 +13,7 @@ from retail.projects.usecases.manager_defaults import (
     MANAGER_DEFAULTS,
     MANAGER_PERSONALITY,
 )
+from retail.projects.usecases.onboarding_defaults import INSTRUCTIONS_BY_LANGUAGE
 
 
 class TestConfigureAgentBuilderUseCase(TestCase):
@@ -82,6 +83,7 @@ class TestConfigureAgentBuilderUseCase(TestCase):
         self.assertEqual(payload["agent"]["role"], MANAGER_DEFAULTS["pt"]["role"])
         self.assertEqual(payload["agent"]["goal"], MANAGER_DEFAULTS["pt"]["goal"])
         self.assertEqual(payload["links"], [])
+        self.assertEqual(payload["instructions"], INSTRUCTIONS_BY_LANGUAGE["pt"])
 
     def test_configures_agent_with_english_fallback(self):
         self.project.language = "ja-jp"
@@ -97,6 +99,7 @@ class TestConfigureAgentBuilderUseCase(TestCase):
         payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
         self.assertEqual(payload["agent"]["role"], MANAGER_DEFAULTS["en"]["role"])
         self.assertEqual(payload["agent"]["goal"], MANAGER_DEFAULTS["en"]["goal"])
+        self.assertEqual(payload["instructions"], INSTRUCTIONS_BY_LANGUAGE["en"])
 
     def test_configures_agent_with_spanish(self):
         self.project.language = "es"
@@ -111,6 +114,7 @@ class TestConfigureAgentBuilderUseCase(TestCase):
 
         payload = self.mock_nexus_service.configure_agent_attributes.call_args[0][1]
         self.assertEqual(payload["agent"]["role"], MANAGER_DEFAULTS["es"]["role"])
+        self.assertEqual(payload["instructions"], INSTRUCTIONS_BY_LANGUAGE["es"])
 
     def test_configures_agent_when_check_returns_none(self):
         """If the check endpoint fails, we still attempt to configure."""

--- a/retail/projects/usecases/agent_builder_helpers.py
+++ b/retail/projects/usecases/agent_builder_helpers.py
@@ -18,6 +18,7 @@ from retail.projects.usecases.manager_defaults import (
     MANAGER_PERSONALITY,
     get_manager_defaults,
 )
+from retail.projects.usecases.onboarding_defaults import get_instructions
 from retail.services.nexus.service import NexusService
 
 logger = logging.getLogger(__name__)
@@ -75,6 +76,7 @@ def ensure_agent_manager_configured(
             "personality": MANAGER_PERSONALITY,
         },
         "links": [],
+        "instructions": get_instructions(language),
     }
 
     result = nexus_service.configure_agent_attributes(project_uuid, payload)


### PR DESCRIPTION
### What
- Updated NexusClient and NexusClientInterface to include "instructions" as an optional key in the agent_payload dictionary.
- Modified tests to validate the inclusion of instructions based on language settings, ensuring fallback to English when necessary.
- Integrated instructions retrieval in the ensure_agent_manager_configured function to support multilingual onboarding.

### Why
Nexus now supports the instructions configuration to enable us to use the correct localization