### PR TITLE
fix: Skip agent webhooks when integrated agent is inactive

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/delivered_order_tracking.py
+++ b/retail/agents/domains/agent_integration/usecases/delivered_order_tracking.py
@@ -256,11 +256,16 @@ class DeliveredOrderTrackingWebhookUseCase:
     """Use case for processing delivered order tracking webhook notifications."""
 
     def get_integrated_agent(self, integrated_agent_uuid: str) -> IntegratedAgent:
-        """Get integrated agent by integrated agent UUID."""
+        """Retrieve an active integrated agent by UUID."""
         try:
-            return IntegratedAgent.objects.get(uuid=integrated_agent_uuid)
+            return IntegratedAgent.objects.select_related("project").get(
+                uuid=integrated_agent_uuid,
+                is_active=True,
+            )
         except IntegratedAgent.DoesNotExist:
-            raise NotFound(f"Integrated agent not found: {integrated_agent_uuid}")
+            raise NotFound(
+                f"Active integrated agent not found: {integrated_agent_uuid}"
+            )
 
     def validate_tracking_enabled(self, integrated_agent: IntegratedAgent) -> bool:
         """

--- a/retail/agents/domains/agent_integration/usecases/payment_recovery.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery.py
@@ -31,44 +31,54 @@ class PaymentRecoveryWebhookUseCase:
         self.vtex_io_service = vtex_io_service or VtexIOService()
 
     def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
-        """Retrieve an integrated agent by UUID.
+        """Retrieve an active integrated agent by UUID.
 
         Args:
             integrated_agent_uuid: UUID of the integrated agent.
 
         Returns:
-            IntegratedAgent: The matching integrated agent instance.
+            IntegratedAgent: The matching active integrated agent instance.
 
         Raises:
-            NotFound: If no integrated agent exists with the given UUID.
+            NotFound: If no active integrated agent exists with the given UUID.
         """
         try:
-            return IntegratedAgent.objects.get(uuid=integrated_agent_uuid)
+            return IntegratedAgent.objects.select_related("project").get(
+                uuid=integrated_agent_uuid,
+                is_active=True,
+            )
         except IntegratedAgent.DoesNotExist:
-            raise NotFound(f"Integrated agent not found: {integrated_agent_uuid}")
+            raise NotFound(
+                f"Active integrated agent not found: {integrated_agent_uuid}"
+            )
 
-    def get_delay_seconds(self, integrated_agent_uuid: UUID) -> int:
+    def get_delay_seconds(
+        self,
+        integrated_agent_uuid: UUID,
+        integrated_agent: Optional[IntegratedAgent] = None,
+    ) -> int:
         """Get the configured delay in seconds for scheduling the processing task.
 
         Reads ``delay_minutes`` from ``integrated_agent.config["payment_recovery"]``
-        and falls back to ``DEFAULT_DELAY_MINUTES`` when the agent or config
-        is not found.
+        and falls back to ``DEFAULT_DELAY_MINUTES`` when the agent is inactive,
+        missing, or the config is absent.
 
         Args:
             integrated_agent_uuid: UUID of the integrated agent.
+            integrated_agent: Optional pre-resolved active integrated agent.
 
         Returns:
             int: The delay in seconds before processing the webhook.
         """
-        try:
-            integrated_agent = IntegratedAgent.objects.get(
-                uuid=integrated_agent_uuid, is_active=True
-            )
-            payment_config = integrated_agent.config.get("payment_recovery", {})
-            delay_minutes = payment_config.get("delay_minutes", DEFAULT_DELAY_MINUTES)
-            return int(delay_minutes) * 60
-        except IntegratedAgent.DoesNotExist:
-            return DEFAULT_DELAY_MINUTES * 60
+        if integrated_agent is None:
+            try:
+                integrated_agent = self.get_integrated_agent(integrated_agent_uuid)
+            except NotFound:
+                return DEFAULT_DELAY_MINUTES * 60
+
+        payment_config = integrated_agent.config.get("payment_recovery", {})
+        delay_minutes = payment_config.get("delay_minutes", DEFAULT_DELAY_MINUTES)
+        return int(delay_minutes) * 60
 
     def validate_payment_recovery_enabled(
         self, integrated_agent: IntegratedAgent

--- a/retail/agents/domains/agent_integration/views.py
+++ b/retail/agents/domains/agent_integration/views.py
@@ -39,6 +39,7 @@ from retail.agents.domains.agent_integration.usecases.update import (
 )
 from retail.agents.domains.agent_integration.usecases.delivered_order_tracking import (
     DeliveredOrderTrackingConfigUseCase,
+    DeliveredOrderTrackingWebhookUseCase,
 )
 from retail.agents.tasks import (
     task_delivered_order_tracking_webhook,
@@ -328,7 +329,18 @@ class DeliveredOrderTrackingWebhookView(APIView):
 
         # For actual webhook notifications, process asynchronously
         try:
-            # Queue the webhook processing task
+            webhook_use_case = DeliveredOrderTrackingWebhookUseCase()
+            try:
+                webhook_use_case.get_integrated_agent(str(pk))
+            except NotFound:
+                logger.warning(
+                    f"[DELIVERED_TRACKING] Integrated agent not found or inactive - "
+                    f"agent={pk}"
+                )
+                return Response(
+                    {"message": "Webhook received"}, status=status.HTTP_200_OK
+                )
+
             task_delivered_order_tracking_webhook.apply_async(
                 args=[pk, request.data],
                 queue="vtex-io-orders-update-events",
@@ -363,7 +375,20 @@ class PaymentRecoveryWebhookView(APIView):
 
         try:
             use_case = PaymentRecoveryWebhookUseCase()
-            countdown = use_case.get_delay_seconds(pk)
+            try:
+                integrated_agent = use_case.get_integrated_agent(pk)
+            except NotFound:
+                logger.warning(
+                    f"[PaymentRecovery] Integrated agent not found or inactive - "
+                    f"agent={pk}"
+                )
+                return Response(
+                    {"message": "Webhook received"}, status=status.HTTP_200_OK
+                )
+
+            countdown = use_case.get_delay_seconds(
+                pk, integrated_agent=integrated_agent
+            )
 
             task_payment_recovery_webhook.apply_async(
                 args=[pk, request.data],

--- a/retail/agents/tests/tasks/test_delivered_order_tracking_task.py
+++ b/retail/agents/tests/tasks/test_delivered_order_tracking_task.py
@@ -10,6 +10,8 @@ from django.test import TestCase
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+from rest_framework.exceptions import NotFound
+
 from retail.agents.domains.agent_execution.context import clear_execution_context
 from retail.agents.tasks import task_delivered_order_tracking_webhook
 
@@ -45,6 +47,23 @@ class TaskDeliveredOrderTrackingWebhookTest(TestCase):
         mock_usecase.process_webhook_notification.assert_called_once_with(
             mock_agent, self.webhook_data
         )
+        mock_logger.log_execution_error.assert_not_called()
+
+    @patch("retail.agents.tasks.DeliveredOrderTrackingWebhookUseCase")
+    @patch("retail.agents.domains.agent_execution.task_helpers.ExecutionLoggerService")
+    def test_task_skips_processing_when_agent_is_inactive(
+        self, mock_logger_factory, mock_usecase_cls
+    ):
+        mock_logger = MagicMock()
+        mock_logger_factory.return_value = mock_logger
+
+        mock_usecase = MagicMock()
+        mock_usecase_cls.return_value = mock_usecase
+        mock_usecase.get_integrated_agent.side_effect = NotFound("Inactive agent")
+
+        task_delivered_order_tracking_webhook(self.agent_uuid, self.webhook_data)
+
+        mock_usecase.process_webhook_notification.assert_not_called()
         mock_logger.log_execution_error.assert_not_called()
 
     @patch("retail.agents.tasks.DeliveredOrderTrackingWebhookUseCase")

--- a/retail/agents/tests/tasks/test_payment_recovery_task.py
+++ b/retail/agents/tests/tasks/test_payment_recovery_task.py
@@ -10,6 +10,8 @@ from django.test import TestCase
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+from rest_framework.exceptions import NotFound
+
 from retail.agents.domains.agent_execution.context import clear_execution_context
 from retail.agents.tasks import task_payment_recovery_webhook
 
@@ -86,7 +88,7 @@ class TaskPaymentRecoveryWebhookTest(TestCase):
 
         mock_usecase = MagicMock()
         mock_usecase_cls.return_value = mock_usecase
-        mock_usecase.get_integrated_agent.side_effect = Exception("Agent not found")
+        mock_usecase.get_integrated_agent.side_effect = NotFound("Inactive agent")
 
         # Must not raise.
         task_payment_recovery_webhook(self.agent_uuid, self.webhook_data)
@@ -109,9 +111,10 @@ class TaskPaymentRecoveryWebhookTest(TestCase):
 
         execution_uuid = uuid4()
         mock_logger = MagicMock()
-        mock_logger.log_webhook_received.side_effect = (
-            lambda *a, **kw: (set_current_execution_uuid(execution_uuid), execution_uuid)[1]
-        )
+        mock_logger.log_webhook_received.side_effect = lambda *a, **kw: (
+            set_current_execution_uuid(execution_uuid),
+            execution_uuid,
+        )[1]
         mock_logger_factory.return_value = mock_logger
 
         mock_usecase = MagicMock()

--- a/retail/agents/tests/usecases/test_delivered_order_tracking_webhook.py
+++ b/retail/agents/tests/usecases/test_delivered_order_tracking_webhook.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+from rest_framework.exceptions import NotFound
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.delivered_order_tracking import (
+    DeliveredOrderTrackingWebhookUseCase,
+)
+
+
+class DeliveredOrderTrackingWebhookUseCaseTest(TestCase):
+    def setUp(self):
+        self.use_case = DeliveredOrderTrackingWebhookUseCase()
+        self.agent_uuid = str(uuid4())
+        self.mock_integrated_agent = MagicMock(spec=IntegratedAgent)
+        self.mock_integrated_agent.uuid = self.agent_uuid
+        self.mock_integrated_agent.project.vtex_account = "testaccount"
+        self.mock_integrated_agent.config = {
+            "delivered_order_tracking": {"is_enabled": True}
+        }
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.delivered_order_tracking.IntegratedAgent"
+    )
+    def test_get_integrated_agent_found(self, mock_model):
+        mock_model.objects.select_related.return_value.get.return_value = (
+            self.mock_integrated_agent
+        )
+
+        result = self.use_case.get_integrated_agent(self.agent_uuid)
+
+        self.assertEqual(result, self.mock_integrated_agent)
+        mock_model.objects.select_related.assert_called_once_with("project")
+        mock_model.objects.select_related.return_value.get.assert_called_once_with(
+            uuid=self.agent_uuid,
+            is_active=True,
+        )
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.delivered_order_tracking.IntegratedAgent"
+    )
+    def test_get_integrated_agent_not_found(self, mock_model):
+        mock_model.DoesNotExist = IntegratedAgent.DoesNotExist
+        mock_model.objects.select_related.return_value.get.side_effect = (
+            IntegratedAgent.DoesNotExist
+        )
+
+        with self.assertRaises(NotFound):
+            self.use_case.get_integrated_agent(self.agent_uuid)

--- a/retail/agents/tests/usecases/test_payment_recovery_webhook.py
+++ b/retail/agents/tests/usecases/test_payment_recovery_webhook.py
@@ -35,17 +35,25 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
         "retail.agents.domains.agent_integration.usecases.payment_recovery.IntegratedAgent"
     )
     def test_get_integrated_agent_found(self, mock_model):
-        mock_model.objects.get.return_value = self.mock_integrated_agent
+        mock_model.objects.select_related.return_value.get.return_value = (
+            self.mock_integrated_agent
+        )
         result = self.use_case.get_integrated_agent(self.agent_uuid)
         self.assertEqual(result, self.mock_integrated_agent)
-        mock_model.objects.get.assert_called_once_with(uuid=self.agent_uuid)
+        mock_model.objects.select_related.assert_called_once_with("project")
+        mock_model.objects.select_related.return_value.get.assert_called_once_with(
+            uuid=self.agent_uuid,
+            is_active=True,
+        )
 
     @patch(
         "retail.agents.domains.agent_integration.usecases.payment_recovery.IntegratedAgent"
     )
     def test_get_integrated_agent_not_found(self, mock_model):
         mock_model.DoesNotExist = IntegratedAgent.DoesNotExist
-        mock_model.objects.get.side_effect = IntegratedAgent.DoesNotExist
+        mock_model.objects.select_related.return_value.get.side_effect = (
+            IntegratedAgent.DoesNotExist
+        )
         with self.assertRaises(NotFound):
             self.use_case.get_integrated_agent(self.agent_uuid)
 
@@ -186,7 +194,9 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
     )
     def test_get_delay_seconds_from_config(self, mock_model):
         self.mock_integrated_agent.config = {"payment_recovery": {"delay_minutes": 15}}
-        mock_model.objects.get.return_value = self.mock_integrated_agent
+        mock_model.objects.select_related.return_value.get.return_value = (
+            self.mock_integrated_agent
+        )
 
         result = self.use_case.get_delay_seconds(self.agent_uuid)
 
@@ -197,7 +207,9 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
     )
     def test_get_delay_seconds_uses_default_when_not_configured(self, mock_model):
         self.mock_integrated_agent.config = {"payment_recovery": {}}
-        mock_model.objects.get.return_value = self.mock_integrated_agent
+        mock_model.objects.select_related.return_value.get.return_value = (
+            self.mock_integrated_agent
+        )
 
         result = self.use_case.get_delay_seconds(self.agent_uuid)
 
@@ -208,7 +220,9 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
     )
     def test_get_delay_seconds_uses_default_when_agent_not_found(self, mock_model):
         mock_model.DoesNotExist = IntegratedAgent.DoesNotExist
-        mock_model.objects.get.side_effect = IntegratedAgent.DoesNotExist
+        mock_model.objects.select_related.return_value.get.side_effect = (
+            IntegratedAgent.DoesNotExist
+        )
 
         result = self.use_case.get_delay_seconds(self.agent_uuid)
 

--- a/retail/agents/tests/views/test_delivered_order_tracking_webhook_view.py
+++ b/retail/agents/tests/views/test_delivered_order_tracking_webhook_view.py
@@ -1,0 +1,57 @@
+"""Tests for ``DeliveredOrderTrackingWebhookView``."""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.test import APITestCase
+
+
+class DeliveredOrderTrackingWebhookViewTest(APITestCase):
+    def setUp(self):
+        self.agent_uuid = uuid4()
+        self.url = reverse(
+            "delivered-order-tracking-webhook",
+            kwargs={"pk": self.agent_uuid},
+        )
+        self.webhook_payload = {
+            "OrderId": "v1234567-01",
+            "State": "delivered",
+        }
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.task_delivered_order_tracking_webhook"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.views.DeliveredOrderTrackingWebhookUseCase"
+    )
+    def test_post_schedules_task_for_active_agent(self, mock_usecase_cls, mock_task):
+        mock_usecase = mock_usecase_cls.return_value
+        mock_usecase.get_integrated_agent.return_value = object()
+
+        response = self.client.post(self.url, self.webhook_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_usecase.get_integrated_agent.assert_called_once_with(str(self.agent_uuid))
+        mock_task.apply_async.assert_called_once_with(
+            args=[self.agent_uuid, self.webhook_payload],
+            queue="vtex-io-orders-update-events",
+        )
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.task_delivered_order_tracking_webhook"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.views.DeliveredOrderTrackingWebhookUseCase"
+    )
+    def test_post_skips_task_when_agent_is_inactive(self, mock_usecase_cls, mock_task):
+        mock_usecase = mock_usecase_cls.return_value
+        mock_usecase.get_integrated_agent.side_effect = NotFound()
+
+        response = self.client.post(self.url, self.webhook_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["message"], "Webhook received")
+        mock_task.apply_async.assert_not_called()

--- a/retail/agents/tests/views/test_payment_recovery_webhook_view.py
+++ b/retail/agents/tests/views/test_payment_recovery_webhook_view.py
@@ -1,0 +1,59 @@
+"""Tests for ``PaymentRecoveryWebhookView``."""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.test import APITestCase
+
+
+class PaymentRecoveryWebhookViewTest(APITestCase):
+    def setUp(self):
+        self.agent_uuid = uuid4()
+        self.url = reverse(
+            "payment-recovery-webhook",
+            kwargs={"pk": self.agent_uuid},
+        )
+        self.webhook_payload = {
+            "OrderId": "v1234567-01",
+            "State": "payment-pending",
+        }
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.task_payment_recovery_webhook"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.views.PaymentRecoveryWebhookUseCase"
+    )
+    def test_post_schedules_task_for_active_agent(self, mock_usecase_cls, mock_task):
+        mock_usecase = mock_usecase_cls.return_value
+        mock_usecase.get_integrated_agent.return_value = object()
+        mock_usecase.get_delay_seconds.return_value = 300
+
+        response = self.client.post(self.url, self.webhook_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_usecase.get_integrated_agent.assert_called_once_with(self.agent_uuid)
+        mock_task.apply_async.assert_called_once_with(
+            args=[self.agent_uuid, self.webhook_payload],
+            countdown=300,
+            queue="vtex-io-orders-update-events",
+        )
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.task_payment_recovery_webhook"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.views.PaymentRecoveryWebhookUseCase"
+    )
+    def test_post_skips_task_when_agent_is_inactive(self, mock_usecase_cls, mock_task):
+        mock_usecase = mock_usecase_cls.return_value
+        mock_usecase.get_integrated_agent.side_effect = NotFound()
+
+        response = self.client.post(self.url, self.webhook_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["message"], "Webhook received")
+        mock_task.apply_async.assert_not_called()

--- a/retail/broadcasts/tests/test_broadcast_report_views.py
+++ b/retail/broadcasts/tests/test_broadcast_report_views.py
@@ -76,7 +76,12 @@ class BroadcastReportViewsTest(BaseTestMixin, APITestCase):
             "broadcast-agent-summary",
             kwargs={"agent_uuid": str(self.integrated_agent.uuid)},
         )
-        self.query = "start_date=2026-06-01&end_date=2026-06-30"
+        today = timezone.now().date()
+        self.start_date = today.replace(day=1)
+        self.end_date = today
+        self.query = (
+            f"start_date={self.start_date:%Y-%m-%d}&end_date={self.end_date:%Y-%m-%d}"
+        )
 
     def _get(self, url, *, project_uuid=None, query=None):
         headers = {"HTTP_AUTHORIZATION": "Bearer token"}

--- a/retail/broadcasts/tests/test_get_broadcast_summary.py
+++ b/retail/broadcasts/tests/test_get_broadcast_summary.py
@@ -1,9 +1,10 @@
 """Tests for ``GetBroadcastSummaryUseCase``."""
 
-from datetime import date, datetime, timezone as dt_timezone
+from datetime import datetime, time, timedelta, timezone as dt_timezone
 from uuid import uuid4
 
 from django.test import TestCase
+from django.utils import timezone
 
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_management.models import Agent
@@ -17,6 +18,11 @@ from retail.broadcasts.usecases.get_broadcast_summary import (
     GetBroadcastSummaryUseCase,
 )
 from retail.projects.models import Project
+
+
+def _current_month_date_range():
+    today = timezone.now().date()
+    return today.replace(day=1), today
 
 
 class GetBroadcastSummaryUseCaseTest(TestCase):
@@ -35,8 +41,7 @@ class GetBroadcastSummaryUseCaseTest(TestCase):
             channel_uuid=uuid4(),
         )
         self.use_case = GetBroadcastSummaryUseCase()
-        self.start_date = date(2026, 6, 1)
-        self.end_date = date(2026, 6, 30)
+        self.start_date, self.end_date = _current_month_date_range()
 
     def _create_broadcast(
         self, *, integrated_agent=None, status=BroadcastStatus.DELIVERED, **overrides
@@ -103,7 +108,11 @@ class GetBroadcastSummaryUseCaseTest(TestCase):
             order_id="old-order",
         )
         BroadcastMessage.objects.filter(pk=out_of_range.pk).update(
-            created_at=datetime(2026, 5, 1, 12, 0, tzinfo=dt_timezone.utc)
+            created_at=datetime.combine(
+                self.start_date - timedelta(days=10),
+                time(12, 0),
+                tzinfo=dt_timezone.utc,
+            )
         )
         conversion = BroadcastConversion.objects.create(
             project=self.project,
@@ -111,7 +120,11 @@ class GetBroadcastSummaryUseCaseTest(TestCase):
             order_id="order-conv",
         )
         BroadcastConversion.objects.filter(pk=conversion.pk).update(
-            converted_at=datetime(2026, 5, 2, 12, 0, tzinfo=dt_timezone.utc)
+            converted_at=datetime.combine(
+                self.start_date - timedelta(days=5),
+                time(12, 0),
+                tzinfo=dt_timezone.utc,
+            )
         )
 
         result = self._execute()

--- a/retail/broadcasts/tests/test_list_broadcast_dispatches.py
+++ b/retail/broadcasts/tests/test_list_broadcast_dispatches.py
@@ -1,6 +1,6 @@
 """Tests for ``ListBroadcastDispatchesUseCase``."""
 
-from datetime import date, datetime, timedelta, timezone as dt_timezone
+from datetime import datetime, time, timedelta, timezone as dt_timezone
 from uuid import uuid4
 
 from django.test import TestCase
@@ -36,8 +36,9 @@ class ListBroadcastDispatchesUseCaseTest(TestCase):
             channel_uuid=uuid4(),
         )
         self.use_case = ListBroadcastDispatchesUseCase()
-        self.start_date = date(2026, 6, 1)
-        self.end_date = date(2026, 6, 30)
+        today = timezone.now().date()
+        self.start_date = today.replace(day=1)
+        self.end_date = today
 
     def _create_broadcast(self, *, project=None, **overrides):
         defaults = {
@@ -98,7 +99,11 @@ class ListBroadcastDispatchesUseCaseTest(TestCase):
         in_range = self._create_broadcast(order_id="in-range")
         out_of_range = self._create_broadcast(order_id="out-range")
         BroadcastMessage.objects.filter(pk=out_of_range.pk).update(
-            created_at=datetime(2026, 5, 1, 12, 0, tzinfo=dt_timezone.utc)
+            created_at=datetime.combine(
+                self.start_date - timedelta(days=10),
+                time(12, 0),
+                tzinfo=dt_timezone.utc,
+            )
         )
         other_project_agent = IntegratedAgent.objects.create(
             agent=self.agent,


### PR DESCRIPTION
## What

Inactive integrated agents (`is_active=False`) were still processing VTEX
webhook notifications for payment recovery (PIX) and delivered order tracking.
Both dedicated webhook use cases now resolve agents with `is_active=True`, and
their views short-circuit before enqueueing Celery tasks when the agent is
missing or inactive. Tasks re-validate on execution so a deactivation between
enqueue and run is also blocked.

Order status and abandoned cart already filtered active agents via
`get_integrated_agent_if_exists`; the generic agent webhook task already used
`is_active=True` on DB lookup. This PR closes the gap on the two dedicated VTEX
hook endpoints that were missing the guard.

## Why

Clients disabling integrated agents expect notifications to stop immediately.
Payment recovery was reported still sending messages after unassign because
`get_integrated_agent` did not filter by `is_active`, while VTEX hooks remained
registered.
