### PR TITLE
fix: Allow blank template footer to remove footer on edit

### DIFF
--- a/retail/templates/serializers.py
+++ b/retail/templates/serializers.py
@@ -155,16 +155,28 @@ class ParameterSerializer(serializers.Serializer):
     value = serializers.JSONField()
 
 
+def _normalize_blank_footer(value: str | None) -> str | None:
+    """Blank or whitespace-only footer means explicit removal."""
+    if value is None:
+        return None
+    if value.strip() == "":
+        return None
+    return value
+
+
 class UpdateTemplateContentSerializer(serializers.Serializer):
     template_body = serializers.CharField(required=False)
     template_header = serializers.CharField(required=False)
-    template_footer = serializers.CharField(required=False)
+    template_footer = serializers.CharField(required=False, allow_blank=True)
     template_button = serializers.ListField(required=False)
     template_body_params = serializers.ListField(required=False)
     app_uuid = serializers.CharField(required=True)
     project_uuid = serializers.CharField(required=True)
     parameters = ParameterSerializer(many=True, required=False, allow_null=True)
     language = serializers.CharField(required=False, allow_null=True)
+
+    def validate_template_footer(self, value: str | None) -> str | None:
+        return _normalize_blank_footer(value)
 
     def validate(self, attrs):
         if not any(
@@ -243,7 +255,8 @@ class ValidateTemplateSampleSerializer(UpdateTemplateContentSerializer):
                 )
         return value
 
-    def validate_template_footer(self, value: str) -> str:
+    def validate_template_footer(self, value: str | None) -> str | None:
+        value = _normalize_blank_footer(value)
         if value and len(value) > self._FOOTER_MAX_LENGTH:
             raise serializers.ValidationError(
                 f"Ensure this field has no more than {self._FOOTER_MAX_LENGTH} characters."

--- a/retail/templates/tests/handlers/test_template_metadata.py
+++ b/retail/templates/tests/handlers/test_template_metadata.py
@@ -154,6 +154,23 @@ class TestTemplateMetadataHandler(TestCase):
         }
         self.assertEqual(result, expected)
 
+    def test_build_metadata_without_footer_clears_footer(self):
+        translation = {"template_body": "Updated body"}
+
+        result = self.handler.build_metadata(translation)
+
+        self.assertIsNone(result["footer"])
+
+    def test_build_metadata_with_null_footer_clears_footer(self):
+        translation = {
+            "template_body": "Updated body",
+            "template_footer": None,
+        }
+
+        result = self.handler.build_metadata(translation)
+
+        self.assertIsNone(result["footer"])
+
     def test_post_process_translation_with_buttons(self):
         metadata = {"body": "Original", "buttons": "old_buttons"}
         translation_payload = {"buttons": [{"type": "URL", "text": "New Button"}]}

--- a/retail/templates/tests/serializers/test_template_serializers.py
+++ b/retail/templates/tests/serializers/test_template_serializers.py
@@ -378,6 +378,66 @@ class TestUpdateTemplateContentSerializer(TestCase):
         serializer = UpdateTemplateContentSerializer(data=data)
         self.assertTrue(serializer.is_valid())
 
+    def test_blank_footer_is_normalized_to_none(self):
+        data = {
+            "template_body": "Updated body",
+            "template_footer": "",
+            "app_uuid": str(uuid4()),
+            "project_uuid": str(uuid4()),
+        }
+
+        serializer = UpdateTemplateContentSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNone(serializer.validated_data["template_footer"])
+
+    def test_omitted_footer_is_not_present_in_validated_data(self):
+        data = {
+            "template_body": "Updated body",
+            "app_uuid": str(uuid4()),
+            "project_uuid": str(uuid4()),
+        }
+
+        serializer = UpdateTemplateContentSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertNotIn("template_footer", serializer.validated_data)
+
+    def test_blank_footer_with_other_content_fields_is_valid(self):
+        data = {
+            "template_body": "Olá, {{1}}! Identificamos que o pagamento do seu pedido ainda não foi finalizado.",
+            "template_header": "https://example.com/header.png",
+            "template_footer": "",
+            "template_button": [{"type": "URL", "text": "Copiar código Pix"}],
+            "app_uuid": str(uuid4()),
+            "project_uuid": str(uuid4()),
+        }
+
+        serializer = UpdateTemplateContentSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNone(serializer.validated_data["template_footer"])
+
+    def test_whitespace_only_footer_is_normalized_to_none(self):
+        data = {
+            "template_body": "Updated body",
+            "template_footer": "   ",
+            "app_uuid": str(uuid4()),
+            "project_uuid": str(uuid4()),
+        }
+
+        serializer = UpdateTemplateContentSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNone(serializer.validated_data["template_footer"])
+
+    def test_only_blank_footer_without_other_content_is_invalid(self):
+        data = {
+            "template_footer": "",
+            "app_uuid": str(uuid4()),
+            "project_uuid": str(uuid4()),
+        }
+
+        serializer = UpdateTemplateContentSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("non_field_errors", serializer.errors)
+
     def test_invalid_data_no_content_fields(self):
         data = {"app_uuid": str(uuid4()), "project_uuid": str(uuid4())}
 
@@ -568,6 +628,18 @@ class TestValidateTemplateSampleSerializer(TestCase):
         serializer = self._serializer(data)
         self.assertFalse(serializer.is_valid())
         self.assertIn("template_footer", serializer.errors)
+
+    def test_blank_footer_is_normalized_to_none(self):
+        data = {**self.base_data, "template_footer": ""}
+        serializer = self._serializer(data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNone(serializer.validated_data["template_footer"])
+
+    def test_whitespace_only_footer_is_normalized_to_none(self):
+        data = {**self.base_data, "template_footer": "  \t  "}
+        serializer = self._serializer(data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNone(serializer.validated_data["template_footer"])
 
     def test_button_text_at_20_chars_passes(self):
         data = {

--- a/retail/templates/tests/strategies/test_update_template_strategies.py
+++ b/retail/templates/tests/strategies/test_update_template_strategies.py
@@ -14,6 +14,8 @@ from retail.templates.strategies.update_template_strategies import (
 from retail.templates.adapters.template_library_to_custom_adapter import (
     TemplateTranslationAdapter,
 )
+from retail.templates.handlers.template_metadata import TemplateMetadataHandler
+from retail.templates.serializers import UpdateTemplateContentSerializer
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_management.models import Agent, PreApprovedTemplate
 from retail.projects.models import Project
@@ -556,6 +558,102 @@ class UpdateNormalTemplateStrategyTest(TestCase):
             assert self.template.metadata["body"] == "Only body updated"
             assert self.template.metadata["header"] == "Original header"
             assert self.template.metadata["footer"] == "Original footer"
+
+
+class UpdateNormalTemplateFooterRemovalIntegrationTest(TestCase):
+    """Footer removal through serializer → metadata handler → translation adapter."""
+
+    def setUp(self):
+        self.project = Project.objects.create(
+            uuid=uuid4(),
+            name="Test Project",
+            organization_uuid=uuid4(),
+        )
+        self.template = Template.objects.create(
+            name="payment_recovery_template",
+            metadata={
+                "category": "UTILITY",
+                "body": "Original body",
+                "header": "Original header",
+                "footer": "VTEX CX Platform",
+                "buttons": [{"type": "QUICK_REPLY", "text": "Original Button"}],
+                "language": "pt_BR",
+            },
+        )
+        self.strategy = UpdateNormalTemplateStrategy(
+            template_metadata_handler=TemplateMetadataHandler(),
+            template_adapter=TemplateTranslationAdapter(),
+        )
+        self.app_uuid = str(uuid4())
+        self.project_uuid = str(self.project.uuid)
+
+    def _build_payload_from_request(self, request_data: dict) -> dict:
+        serializer = UpdateTemplateContentSerializer(data=request_data)
+        serializer.is_valid(raise_exception=True)
+        return {
+            **serializer.validated_data,
+            "app_uuid": self.app_uuid,
+            "project_uuid": self.project_uuid,
+        }
+
+    def _assert_footer_removed(self, translation_payload: dict) -> None:
+        self.template.refresh_from_db()
+        self.assertIsNone(self.template.metadata["footer"])
+        self.assertNotIn("footer", translation_payload)
+
+    def test_blank_footer_removes_footer_end_to_end(self):
+        payload = self._build_payload_from_request(
+            {
+                "template_body": "Updated body",
+                "template_header": "Order update",
+                "template_footer": "",
+                "template_button": [{"type": "QUICK_REPLY", "text": "Pay now"}],
+                "app_uuid": self.app_uuid,
+                "project_uuid": self.project_uuid,
+            }
+        )
+
+        translation_payload = self.strategy._build_and_persist_metadata(
+            self.template, payload
+        )
+
+        self._assert_footer_removed(translation_payload)
+        self.assertEqual(self.template.metadata["body"], "Updated body")
+
+    def test_omitted_footer_removes_footer_end_to_end(self):
+        payload = self._build_payload_from_request(
+            {
+                "template_body": "Updated body",
+                "template_header": "Order update",
+                "template_button": [{"type": "QUICK_REPLY", "text": "Pay now"}],
+                "app_uuid": self.app_uuid,
+                "project_uuid": self.project_uuid,
+            }
+        )
+
+        translation_payload = self.strategy._build_and_persist_metadata(
+            self.template, payload
+        )
+
+        self._assert_footer_removed(translation_payload)
+
+    def test_whitespace_footer_removes_footer_end_to_end(self):
+        payload = self._build_payload_from_request(
+            {
+                "template_body": "Updated body",
+                "template_header": "Order update",
+                "template_footer": "   ",
+                "template_button": [{"type": "QUICK_REPLY", "text": "Pay now"}],
+                "app_uuid": self.app_uuid,
+                "project_uuid": self.project_uuid,
+            }
+        )
+
+        translation_payload = self.strategy._build_and_persist_metadata(
+            self.template, payload
+        )
+
+        self._assert_footer_removed(translation_payload)
 
 
 class UpdateCustomTemplateStrategyTest(TestCase):


### PR DESCRIPTION
## What

Allow `template_footer: ""` on template content updates without triggering DRF's
"This field may not be blank." error. Blank footer values are normalized to
`None`, which clears footer in persisted metadata and excludes it from the
Integrations/Meta translation payload. Body and header validation remain unchanged.

Touched files:
- `retail/templates/serializers.py` — `allow_blank=True` + `_normalize_blank_footer`
- Serializer, handler, and sample-validation tests

## Why

Operators editing the Pix payment recovery template could not remove the footer
because the frontend sends an empty string when the field is cleared, and the
backend rejected it before persistence.
