### PR TITLE
feat: Add payment recovery sales channel hook config endpoint

### DIFF
--- a/retail/agents/api/urls.py
+++ b/retail/agents/api/urls.py
@@ -18,6 +18,7 @@ from retail.agents.domains.agent_integration.views import (
     DeliveredOrderTrackingEnableView,
     DeliveredOrderTrackingDisableView,
     DeliveredOrderTrackingWebhookView,
+    PaymentRecoveryHookConfigView,
     PaymentRecoveryWebhookView,
     TemplateLanguagesView,
 )
@@ -64,6 +65,11 @@ urlpatterns = [
         "delivered-order-tracking/<uuid:pk>/",
         DeliveredOrderTrackingWebhookView.as_view(),
         name="delivered-order-tracking-webhook",
+    ),
+    path(
+        "assigneds/<uuid:pk>/payment-recovery/hook-config/",
+        PaymentRecoveryHookConfigView.as_view(),
+        name="payment-recovery-hook-config",
     ),
     path(
         "payment-recovery-webhook/<uuid:pk>/",

--- a/retail/agents/domains/agent_integration/serializers.py
+++ b/retail/agents/domains/agent_integration/serializers.py
@@ -2,6 +2,9 @@ from rest_framework import serializers
 
 from retail.templates.serializers import ReadTemplateSerializer
 from retail.agents.domains.agent_management.usecases.push import PushAgentUseCase
+from retail.agents.domains.agent_integration.services.payment_recovery_hook import (
+    DEFAULT_SALES_CHANNELS,
+)
 from retail.agents.domains.agent_integration.usecases.payment_recovery import (
     DEFAULT_DELAY_MINUTES,
 )
@@ -88,6 +91,26 @@ class PaymentRecoveryConfigSerializer(PartialUpdateSerializer):
         required=False,
         min_value=1,
     )
+
+
+class PaymentRecoveryHookConfigSerializer(serializers.Serializer):
+    """Serializer for payment recovery VTEX hook filter configuration."""
+
+    sales_channels = serializers.ListField(
+        child=serializers.CharField(
+            max_length=50,
+            allow_blank=False,
+            trim_whitespace=True,
+        ),
+        allow_empty=True,
+    )
+
+
+class PaymentRecoveryHookConfigReadSerializer(serializers.Serializer):
+    """Read serializer for payment recovery VTEX hook filter configuration."""
+
+    sales_channels = serializers.ListField(child=serializers.CharField())
+    hook_created = serializers.BooleanField()
 
 
 class UpdateIntegratedAgentSerializer(PartialUpdateSerializer):
@@ -196,6 +219,9 @@ class ReadIntegratedAgentSerializer(serializers.Serializer):
             "minimum_order_value": payment_recovery_config.get("minimum_order_value"),
             "delay_minutes": payment_recovery_config.get(
                 "delay_minutes", DEFAULT_DELAY_MINUTES
+            ),
+            "sales_channels": payment_recovery_config.get(
+                "sales_channels", list(DEFAULT_SALES_CHANNELS)
             ),
         }
 

--- a/retail/agents/domains/agent_integration/services/payment_recovery_hook.py
+++ b/retail/agents/domains/agent_integration/services/payment_recovery_hook.py
@@ -28,20 +28,23 @@ def build_sales_channel_clause(sales_channels: List[str]) -> Optional[str]:
 def build_payment_recovery_hook_expression(sales_channels: List[str]) -> str:
     """Build the VTEX ``FromOrders`` hook filter expression for PIX recovery.
 
-    An empty ``sales_channels`` list means no sales-channel constraint: only
-    the PIX payment-system filter is applied, matching VTEX accounts that do
-    not segment orders by sales channel.
+    ``isCompleted = false`` is always applied so the hook targets open orders
+    only. An empty ``sales_channels`` list omits the sales-channel constraint
+    (all channels) without relaxing the incomplete-order guard.
     """
     payment_clause = (
         "paymentData.transactions.payments"
         f'[paymentSystem = "{PIX_PAYMENT_SYSTEM_ID}"]'
     )
 
-    if not sales_channels:
-        return payment_clause
+    expression_parts = ["isCompleted = false"]
 
     sales_channel_clause = build_sales_channel_clause(sales_channels)
-    return " and ".join(["isCompleted = false", sales_channel_clause, payment_clause])
+    if sales_channel_clause:
+        expression_parts.append(sales_channel_clause)
+
+    expression_parts.append(payment_clause)
+    return " and ".join(expression_parts)
 
 
 def build_payment_recovery_hook_payload(

--- a/retail/agents/domains/agent_integration/services/payment_recovery_hook.py
+++ b/retail/agents/domains/agent_integration/services/payment_recovery_hook.py
@@ -1,0 +1,63 @@
+"""Helpers for building VTEX payment recovery (PIX) order hooks."""
+
+from typing import Any, Dict, List, Optional
+
+DEFAULT_SALES_CHANNELS: List[str] = ["1"]
+PIX_PAYMENT_SYSTEM_ID = "125"
+VTEX_HOOK_USER_AGENT = "vtex-retail/0.0.0"
+
+
+def build_sales_channel_clause(sales_channels: List[str]) -> Optional[str]:
+    """Build the VTEX filter clause for one or more sales channels.
+
+    Returns ``None`` when ``sales_channels`` is empty so callers can omit
+    the sales-channel constraint from the hook expression.
+    """
+    if not sales_channels:
+        return None
+
+    if len(sales_channels) == 1:
+        return f'(salesChannel = "{sales_channels[0]}")'
+
+    channel_checks = " or ".join(
+        f'salesChannel = "{channel}"' for channel in sales_channels
+    )
+    return f"({channel_checks})"
+
+
+def build_payment_recovery_hook_expression(sales_channels: List[str]) -> str:
+    """Build the VTEX ``FromOrders`` hook filter expression for PIX recovery.
+
+    An empty ``sales_channels`` list means no sales-channel constraint: only
+    the PIX payment-system filter is applied, matching VTEX accounts that do
+    not segment orders by sales channel.
+    """
+    payment_clause = (
+        "paymentData.transactions.payments"
+        f'[paymentSystem = "{PIX_PAYMENT_SYSTEM_ID}"]'
+    )
+
+    if not sales_channels:
+        return payment_clause
+
+    sales_channel_clause = build_sales_channel_clause(sales_channels)
+    return " and ".join(["isCompleted = false", sales_channel_clause, payment_clause])
+
+
+def build_payment_recovery_hook_payload(
+    webhook_url: str,
+    sales_channels: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Build the VTEX hook configuration payload for payment recovery."""
+    channels = DEFAULT_SALES_CHANNELS if sales_channels is None else sales_channels
+    return {
+        "filter": {
+            "type": "FromOrders",
+            "expression": build_payment_recovery_hook_expression(channels),
+            "disableSingleFire": False,
+        },
+        "hook": {
+            "url": webhook_url,
+            "headers": {"User-Agent": VTEX_HOOK_USER_AGENT},
+        },
+    }

--- a/retail/agents/domains/agent_integration/tests/test_serializers.py
+++ b/retail/agents/domains/agent_integration/tests/test_serializers.py
@@ -384,6 +384,26 @@ class ReadIntegratedAgentSerializerTests(SimpleTestCase):
             },
         )
 
+    def test_payment_recovery_config_includes_sales_channels(self):
+        obj = _integrated_agent(
+            config={
+                "payment_recovery": {
+                    "hook_created": True,
+                    "delay_minutes": 5,
+                    "sales_channels": ["2", "3"],
+                }
+            }
+        )
+        data = ReadIntegratedAgentSerializer(obj).data
+        self.assertEqual(data["payment_recovery_config"]["sales_channels"], ["2", "3"])
+
+    def test_payment_recovery_config_defaults_sales_channels_when_absent(self):
+        obj = _integrated_agent(
+            config={"payment_recovery": {"hook_created": True, "delay_minutes": 5}}
+        )
+        data = ReadIntegratedAgentSerializer(obj).data
+        self.assertEqual(data["payment_recovery_config"]["sales_channels"], ["1"])
+
 
 class TemplateLanguageSerializerTests(SimpleTestCase):
     def test_valid_payload_round_trips(self):

--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -46,6 +46,10 @@ from retail.agents.domains.agent_integration.usecases.build_abandoned_cart_trans
 from retail.agents.domains.agent_integration.usecases.build_payment_recovery_translation import (
     BuildPaymentRecoveryTranslationUseCase,
 )
+from retail.agents.domains.agent_integration.services.payment_recovery_hook import (
+    DEFAULT_SALES_CHANNELS,
+    build_payment_recovery_hook_payload,
+)
 from retail.vtex.usecases.proxy_vtex import ProxyVtexUsecase
 from retail.services.vtex_io.service import VtexIOService
 
@@ -1017,21 +1021,9 @@ class AssignAgentUseCase:
                 f"agent={integrated_agent.uuid} webhook_url={webhook_url}"
             )
 
-            hook_data = {
-                "filter": {
-                    "type": "FromOrders",
-                    "expression": (
-                        'isCompleted = false and (salesChannel = "1") '
-                        "and (paymentData.transactions.payments"
-                        '[paymentSystem = "125"])'
-                    ),
-                    "disableSingleFire": False,
-                },
-                "hook": {
-                    "url": webhook_url,
-                    "headers": {"User-Agent": "vtex-retail/0.0.0"},
-                },
-            }
+            current_config = integrated_agent.config.copy()
+            payment_recovery_config = current_config.get("payment_recovery", {})
+            hook_data = build_payment_recovery_hook_payload(webhook_url)
 
             proxy_usecase = ProxyVtexUsecase(vtex_io_service=VtexIOService())
             proxy_usecase.execute(
@@ -1041,12 +1033,11 @@ class AssignAgentUseCase:
                 project_uuid=str(integrated_agent.project.uuid),
             )
 
-            current_config = integrated_agent.config.copy()
-            payment_recovery_config = current_config.get("payment_recovery", {})
             payment_recovery_config.update(
                 {
                     "webhook_url": webhook_url,
                     "hook_created": True,
+                    "sales_channels": list(DEFAULT_SALES_CHANNELS),
                 }
             )
             current_config["payment_recovery"] = payment_recovery_config

--- a/retail/agents/domains/agent_integration/usecases/payment_recovery_hook_config.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery_hook_config.py
@@ -1,0 +1,140 @@
+import logging
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from django.conf import settings
+from rest_framework.exceptions import NotFound, ValidationError
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.services.payment_recovery_hook import (
+    DEFAULT_SALES_CHANNELS,
+    build_payment_recovery_hook_payload,
+)
+from retail.agents.shared.cache import (
+    IntegratedAgentCacheHandler,
+    IntegratedAgentCacheHandlerRedis,
+)
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.usecases.proxy_vtex import ProxyVtexUsecase
+
+logger = logging.getLogger(__name__)
+
+
+class PaymentRecoveryHookConfigUseCase:
+    """Manage VTEX hook filter configuration for payment recovery agents."""
+
+    def __init__(
+        self,
+        proxy_vtex_usecase: Optional[ProxyVtexUsecase] = None,
+        vtex_io_service: Optional[VtexIOService] = None,
+        cache_handler: Optional[IntegratedAgentCacheHandler] = None,
+    ):
+        """Initialize the use case with optional VTEX proxy dependencies."""
+        self._proxy_vtex_usecase = proxy_vtex_usecase
+        self._vtex_io_service = vtex_io_service or VtexIOService()
+        self.cache_handler = cache_handler or IntegratedAgentCacheHandlerRedis()
+
+    def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
+        """Retrieve an active integrated agent by UUID."""
+        try:
+            return IntegratedAgent.objects.select_related("project").get(
+                uuid=integrated_agent_uuid,
+                is_active=True,
+            )
+        except IntegratedAgent.DoesNotExist:
+            raise NotFound(f"Integrated agent not found: {integrated_agent_uuid}")
+
+    def get_hook_config(self, integrated_agent: IntegratedAgent) -> Dict[str, Any]:
+        """Return the current payment recovery hook configuration."""
+        payment_recovery = integrated_agent.config.get("payment_recovery", {})
+        return {
+            "sales_channels": self._resolve_sales_channels(payment_recovery),
+            "hook_created": payment_recovery.get("hook_created", False),
+        }
+
+    def update_sales_channels(
+        self,
+        integrated_agent: IntegratedAgent,
+        sales_channels: List[str],
+    ) -> Dict[str, Any]:
+        """Persist sales channels and sync the VTEX hook filter expression."""
+        payment_recovery = integrated_agent.config.get("payment_recovery", {})
+        if not payment_recovery.get("hook_created", False):
+            raise ValidationError("Payment recovery hook is not configured")
+
+        normalized_channels = self._normalize_sales_channels(sales_channels)
+
+        current_config = integrated_agent.config.copy()
+        payment_recovery = current_config.get("payment_recovery", {})
+        payment_recovery["sales_channels"] = normalized_channels
+        current_config["payment_recovery"] = payment_recovery
+        integrated_agent.config = current_config
+
+        self._sync_vtex_hook(integrated_agent, normalized_channels)
+        integrated_agent.save(update_fields=["config"])
+        self.cache_handler.invalidate_all_for(integrated_agent)
+
+        logger.info(
+            f"[PaymentRecovery] Hook sales channels updated - "
+            f"agent={integrated_agent.uuid} sales_channels={normalized_channels}"
+        )
+        return self.get_hook_config(integrated_agent)
+
+    def _resolve_sales_channels(self, payment_recovery: Dict[str, Any]) -> List[str]:
+        stored_channels = payment_recovery.get("sales_channels")
+        if stored_channels is None:
+            return list(DEFAULT_SALES_CHANNELS)
+        return list(stored_channels)
+
+    def _normalize_sales_channels(self, sales_channels: List[str]) -> List[str]:
+        """Normalize channel ids; an empty list means all sales channels."""
+        normalized: List[str] = []
+        for channel in sales_channels:
+            stripped = str(channel).strip()
+            if not stripped:
+                raise ValidationError(
+                    {"sales_channels": "Sales channel values cannot be empty."}
+                )
+            if stripped not in normalized:
+                normalized.append(stripped)
+        return normalized
+
+    def _build_webhook_url(self, integrated_agent: IntegratedAgent) -> str:
+        payment_recovery = integrated_agent.config.get("payment_recovery", {})
+        webhook_url = payment_recovery.get("webhook_url")
+        if webhook_url:
+            return webhook_url
+
+        domain_url = settings.DOMAIN
+        return (
+            f"{domain_url}/api/v3/agents/"
+            f"payment-recovery-webhook/{integrated_agent.uuid}/"
+        )
+
+    def _get_proxy_usecase(self) -> ProxyVtexUsecase:
+        if self._proxy_vtex_usecase is None:
+            self._proxy_vtex_usecase = ProxyVtexUsecase(
+                vtex_io_service=self._vtex_io_service
+            )
+        return self._proxy_vtex_usecase
+
+    def _sync_vtex_hook(
+        self,
+        integrated_agent: IntegratedAgent,
+        sales_channels: List[str],
+    ) -> None:
+        webhook_url = self._build_webhook_url(integrated_agent)
+        hook_data = build_payment_recovery_hook_payload(webhook_url, sales_channels)
+
+        logger.info(
+            f"[PaymentRecovery] Syncing VTEX hook - "
+            f"agent={integrated_agent.uuid} expression={hook_data['filter']['expression']}"
+        )
+
+        proxy_usecase = self._get_proxy_usecase()
+        proxy_usecase.execute(
+            method="POST",
+            path="/api/orders/hook/config",
+            data=hook_data,
+            project_uuid=str(integrated_agent.project.uuid),
+        )

--- a/retail/agents/domains/agent_integration/views.py
+++ b/retail/agents/domains/agent_integration/views.py
@@ -20,6 +20,8 @@ from retail.agents.domains.agent_integration.serializers import (
     UpdateIntegratedAgentSerializer,
     RetrieveIntegratedAgentQueryParamsSerializer,
     DeliveredOrderTrackingEnableSerializer,
+    PaymentRecoveryHookConfigSerializer,
+    PaymentRecoveryHookConfigReadSerializer,
     TemplateLanguageSerializer,
 )
 from retail.agents.domains.agent_integration.utils import TEMPLATE_LANGUAGES
@@ -47,6 +49,9 @@ from retail.agents.tasks import (
 )
 from retail.agents.domains.agent_integration.usecases.payment_recovery import (
     PaymentRecoveryWebhookUseCase,
+)
+from retail.agents.domains.agent_integration.usecases.payment_recovery_hook_config import (
+    PaymentRecoveryHookConfigUseCase,
 )
 
 from retail.internal.permissions import HasProjectPermission
@@ -357,6 +362,42 @@ class DeliveredOrderTrackingWebhookView(APIView):
             )
 
             return Response({"message": "Webhook received"}, status=status.HTTP_200_OK)
+
+
+class PaymentRecoveryHookConfigView(APIView):
+    """View for managing payment recovery VTEX hook filter configuration."""
+
+    permission_classes = [
+        IsAuthenticated,
+        HasProjectPermission,
+        IsIntegratedAgentFromProject,
+    ]
+
+    def get(self, request: Request, pk: UUID) -> Response:
+        """Get payment recovery hook configuration for an integrated agent."""
+        use_case = PaymentRecoveryHookConfigUseCase()
+        integrated_agent = use_case.get_integrated_agent(pk)
+        self.check_object_permissions(request, integrated_agent)
+
+        config_data = use_case.get_hook_config(integrated_agent)
+        serializer = PaymentRecoveryHookConfigReadSerializer(config_data)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def patch(self, request: Request, pk: UUID) -> Response:
+        """Update payment recovery sales channel filter and sync VTEX hook."""
+        use_case = PaymentRecoveryHookConfigUseCase()
+        integrated_agent = use_case.get_integrated_agent(pk)
+        self.check_object_permissions(request, integrated_agent)
+
+        serializer = PaymentRecoveryHookConfigSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        config_data = use_case.update_sales_channels(
+            integrated_agent,
+            serializer.validated_data["sales_channels"],
+        )
+        response_serializer = PaymentRecoveryHookConfigReadSerializer(config_data)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 
 class PaymentRecoveryWebhookView(APIView):

--- a/retail/agents/tests/services/test_payment_recovery_hook.py
+++ b/retail/agents/tests/services/test_payment_recovery_hook.py
@@ -38,10 +38,11 @@ class BuildPaymentRecoveryHookExpressionTest(SimpleTestCase):
         expression = build_payment_recovery_hook_expression([])
         self.assertEqual(
             expression,
+            "isCompleted = false and "
             'paymentData.transactions.payments[paymentSystem = "125"]',
         )
         self.assertNotIn("salesChannel", expression)
-        self.assertNotIn("isCompleted", expression)
+        self.assertIn("isCompleted = false", expression)
 
     def test_multiple_sales_channels(self):
         expression = build_payment_recovery_hook_expression(["1", "2"])

--- a/retail/agents/tests/services/test_payment_recovery_hook.py
+++ b/retail/agents/tests/services/test_payment_recovery_hook.py
@@ -1,0 +1,78 @@
+from django.test import SimpleTestCase
+
+from retail.agents.domains.agent_integration.services.payment_recovery_hook import (
+    DEFAULT_SALES_CHANNELS,
+    build_payment_recovery_hook_expression,
+    build_payment_recovery_hook_payload,
+    build_sales_channel_clause,
+)
+
+
+class BuildSalesChannelClauseTest(SimpleTestCase):
+    def test_returns_none_for_empty_list(self):
+        self.assertIsNone(build_sales_channel_clause([]))
+
+    def test_single_channel(self):
+        self.assertEqual(
+            build_sales_channel_clause(["1"]),
+            '(salesChannel = "1")',
+        )
+
+    def test_multiple_channels(self):
+        self.assertEqual(
+            build_sales_channel_clause(["1", "2"]),
+            '(salesChannel = "1" or salesChannel = "2")',
+        )
+
+
+class BuildPaymentRecoveryHookExpressionTest(SimpleTestCase):
+    def test_default_sales_channel_expression(self):
+        expression = build_payment_recovery_hook_expression(DEFAULT_SALES_CHANNELS)
+        self.assertEqual(
+            expression,
+            'isCompleted = false and (salesChannel = "1") '
+            'and paymentData.transactions.payments[paymentSystem = "125"]',
+        )
+
+    def test_empty_sales_channels_matches_all_channels_expression(self):
+        expression = build_payment_recovery_hook_expression([])
+        self.assertEqual(
+            expression,
+            'paymentData.transactions.payments[paymentSystem = "125"]',
+        )
+        self.assertNotIn("salesChannel", expression)
+        self.assertNotIn("isCompleted", expression)
+
+    def test_multiple_sales_channels(self):
+        expression = build_payment_recovery_hook_expression(["1", "2"])
+        self.assertEqual(
+            expression,
+            "isCompleted = false and "
+            '(salesChannel = "1" or salesChannel = "2") and '
+            'paymentData.transactions.payments[paymentSystem = "125"]',
+        )
+
+
+class BuildPaymentRecoveryHookPayloadTest(SimpleTestCase):
+    def test_builds_complete_payload(self):
+        payload = build_payment_recovery_hook_payload(
+            "https://example.com/webhook/",
+            ["2"],
+        )
+
+        self.assertEqual(payload["filter"]["type"], "FromOrders")
+        self.assertEqual(
+            payload["filter"]["expression"],
+            'isCompleted = false and (salesChannel = "2") '
+            'and paymentData.transactions.payments[paymentSystem = "125"]',
+        )
+        self.assertFalse(payload["filter"]["disableSingleFire"])
+        self.assertEqual(payload["hook"]["url"], "https://example.com/webhook/")
+        self.assertEqual(
+            payload["hook"]["headers"],
+            {"User-Agent": "vtex-retail/0.0.0"},
+        )
+
+    def test_defaults_to_channel_one_when_sales_channels_omitted(self):
+        payload = build_payment_recovery_hook_payload("https://example.com/webhook/")
+        self.assertIn('salesChannel = "1"', payload["filter"]["expression"])

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -285,6 +285,10 @@ class AssignPaymentRecoveryHookTest(TestCase):
             call_kwargs["data"]["hook"]["headers"],
             {"User-Agent": "vtex-retail/0.0.0"},
         )
+        self.assertIn(
+            'salesChannel = "1"',
+            call_kwargs["data"]["filter"]["expression"],
+        )
 
         self.integrated_agent.save.assert_called()
         saved_config = self.integrated_agent.config
@@ -323,6 +327,7 @@ class AssignPaymentRecoveryHookTest(TestCase):
         self.assertEqual(saved_config["payment_recovery"]["delay_minutes"], 5)
         self.assertTrue(saved_config["payment_recovery"]["hook_created"])
         self.assertIn("webhook_url", saved_config["payment_recovery"])
+        self.assertEqual(saved_config["payment_recovery"]["sales_channels"], ["1"])
         self.assertEqual(saved_config["country_phone_code"], "55")
 
     @patch("retail.agents.domains.agent_integration.usecases.assign.ProxyVtexUsecase")

--- a/retail/agents/tests/usecases/test_payment_recovery_hook_config.py
+++ b/retail/agents/tests/usecases/test_payment_recovery_hook_config.py
@@ -1,0 +1,126 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase, override_settings
+from rest_framework.exceptions import NotFound, ValidationError
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.payment_recovery_hook_config import (
+    PaymentRecoveryHookConfigUseCase,
+)
+from retail.agents.shared.cache import IntegratedAgentCacheHandler
+from retail.projects.models import Project
+
+
+class PaymentRecoveryHookConfigUseCaseTest(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            uuid=uuid4(),
+            name="Test Project",
+            vtex_account="teststore",
+        )
+        self.integrated_agent = MagicMock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid4()
+        self.integrated_agent.project = self.project
+        self.integrated_agent.config = {
+            "payment_recovery": {
+                "hook_created": True,
+                "webhook_url": "https://retail.example.com/webhook/",
+                "sales_channels": ["1"],
+            }
+        }
+        self.mock_proxy = MagicMock()
+        self.mock_cache_handler = MagicMock(spec=IntegratedAgentCacheHandler)
+        self.use_case = PaymentRecoveryHookConfigUseCase(
+            proxy_vtex_usecase=self.mock_proxy,
+            cache_handler=self.mock_cache_handler,
+        )
+
+    def test_get_hook_config_returns_stored_sales_channels(self):
+        config = self.use_case.get_hook_config(self.integrated_agent)
+        self.assertEqual(config["sales_channels"], ["1"])
+        self.assertTrue(config["hook_created"])
+
+    def test_get_hook_config_defaults_sales_channels_when_absent(self):
+        self.integrated_agent.config = {"payment_recovery": {"hook_created": True}}
+        config = self.use_case.get_hook_config(self.integrated_agent)
+        self.assertEqual(config["sales_channels"], ["1"])
+
+    def test_get_integrated_agent_not_found(self):
+        with self.assertRaises(NotFound):
+            self.use_case.get_integrated_agent(uuid4())
+
+    def test_update_sales_channels_raises_when_hook_not_created(self):
+        self.integrated_agent.config = {"payment_recovery": {"hook_created": False}}
+        with self.assertRaises(ValidationError):
+            self.use_case.update_sales_channels(self.integrated_agent, ["2"])
+
+    def test_update_sales_channels_rejects_empty_channel_values(self):
+        with self.assertRaises(ValidationError):
+            self.use_case.update_sales_channels(self.integrated_agent, ["1", "  "])
+
+    def test_normalize_sales_channels_allows_empty_list_for_all_channels(self):
+        self.assertEqual(self.use_case._normalize_sales_channels([]), [])
+
+    @override_settings(DOMAIN="https://retail.example.com")
+    def test_update_sales_channels_syncs_vtex_hook_and_persists_config(self):
+        config = self.use_case.update_sales_channels(
+            self.integrated_agent, ["2", "3", "2"]
+        )
+
+        self.assertEqual(config["sales_channels"], ["2", "3"])
+        self.assertEqual(
+            self.integrated_agent.config["payment_recovery"]["sales_channels"],
+            ["2", "3"],
+        )
+        self.integrated_agent.save.assert_called_once_with(update_fields=["config"])
+        self.mock_cache_handler.invalidate_all_for.assert_called_once_with(
+            self.integrated_agent
+        )
+
+        self.mock_proxy.execute.assert_called_once()
+        call_kwargs = self.mock_proxy.execute.call_args[1]
+        self.assertEqual(call_kwargs["method"], "POST")
+        self.assertEqual(call_kwargs["path"], "/api/orders/hook/config")
+        self.assertEqual(call_kwargs["project_uuid"], str(self.project.uuid))
+        self.assertIn('salesChannel = "2"', call_kwargs["data"]["filter"]["expression"])
+        self.assertIn('salesChannel = "3"', call_kwargs["data"]["filter"]["expression"])
+
+    @override_settings(DOMAIN="https://retail.example.com")
+    def test_update_sales_channels_with_empty_list_matches_all_channels_hook(self):
+        self.use_case.update_sales_channels(self.integrated_agent, [])
+
+        call_kwargs = self.mock_proxy.execute.call_args[1]
+        self.assertEqual(
+            call_kwargs["data"]["filter"]["expression"],
+            'paymentData.transactions.payments[paymentSystem = "125"]',
+        )
+        self.assertEqual(
+            self.integrated_agent.config["payment_recovery"]["sales_channels"],
+            [],
+        )
+
+    def test_update_sales_channels_does_not_persist_when_vtex_sync_fails(self):
+        self.mock_proxy.execute.side_effect = Exception("VTEX unavailable")
+
+        with self.assertRaises(Exception):
+            self.use_case.update_sales_channels(self.integrated_agent, ["2"])
+
+        self.integrated_agent.save.assert_not_called()
+        self.mock_cache_handler.invalidate_all_for.assert_not_called()
+
+    @override_settings(DOMAIN="https://retail.example.com")
+    def test_build_webhook_url_falls_back_to_domain_when_config_missing(self):
+        self.integrated_agent.config["payment_recovery"].pop("webhook_url", None)
+
+        self.use_case.update_sales_channels(self.integrated_agent, ["2"])
+
+        call_kwargs = self.mock_proxy.execute.call_args[1]
+        self.assertIn(
+            f"payment-recovery-webhook/{self.integrated_agent.uuid}/",
+            call_kwargs["data"]["hook"]["url"],
+        )
+
+    def test_lazy_proxy_usecase_initialization(self):
+        use_case = PaymentRecoveryHookConfigUseCase()
+        self.assertIsNotNone(use_case._get_proxy_usecase())

--- a/retail/agents/tests/usecases/test_payment_recovery_hook_config.py
+++ b/retail/agents/tests/usecases/test_payment_recovery_hook_config.py
@@ -93,6 +93,7 @@ class PaymentRecoveryHookConfigUseCaseTest(TestCase):
         call_kwargs = self.mock_proxy.execute.call_args[1]
         self.assertEqual(
             call_kwargs["data"]["filter"]["expression"],
+            "isCompleted = false and "
             'paymentData.transactions.payments[paymentSystem = "125"]',
         )
         self.assertEqual(

--- a/retail/agents/tests/views/test_payment_recovery_hook_config_view.py
+++ b/retail/agents/tests/views/test_payment_recovery_hook_config_view.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.internal.test_mixins import (
+    BaseTestMixin,
+    ConnectServicePermissionScenarios,
+    with_test_settings,
+)
+from retail.projects.models import Project
+
+User = get_user_model()
+
+
+@with_test_settings
+class PaymentRecoveryHookConfigViewTest(BaseTestMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.project = Project.objects.create(name="Project 1", uuid=uuid4())
+        self.agent = Agent.objects.create(
+            uuid=uuid4(),
+            name="Payment Recovery",
+            slug="payment-recovery",
+            description="PIX recovery",
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.project,
+            config={
+                "payment_recovery": {
+                    "hook_created": True,
+                    "sales_channels": ["1"],
+                }
+            },
+        )
+        self.url = reverse(
+            "payment-recovery-hook-config",
+            args=[str(self.integrated_agent.uuid)],
+        )
+        self.user = User.objects.create_user(
+            username="testuser", password="12345", email="test@example.com"
+        )
+        self.client.force_authenticate(self.user)
+
+    def _request_headers(self):
+        return {"HTTP_PROJECT_UUID": str(self.project.uuid)}
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.PaymentRecoveryHookConfigUseCase"
+    )
+    def test_get_returns_hook_config(self, mock_use_case_cls):
+        self.setup_internal_user_permissions(self.user)
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions=ConnectServicePermissionScenarios.CONTRIBUTOR_PERMISSIONS,
+        )
+
+        mock_use_case = MagicMock()
+        mock_use_case.get_integrated_agent.return_value = self.integrated_agent
+        mock_use_case.get_hook_config.return_value = {
+            "sales_channels": ["1"],
+            "hook_created": True,
+        }
+        mock_use_case_cls.return_value = mock_use_case
+
+        response = self.client.get(
+            self.url,
+            **self._request_headers(),
+            QUERY_STRING="user_email=test@example.com",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {"sales_channels": ["1"], "hook_created": True},
+        )
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.PaymentRecoveryHookConfigUseCase"
+    )
+    def test_patch_updates_sales_channels(self, mock_use_case_cls):
+        self.setup_internal_user_permissions(self.user)
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions=ConnectServicePermissionScenarios.CONTRIBUTOR_PERMISSIONS,
+        )
+
+        mock_use_case = MagicMock()
+        mock_use_case.get_integrated_agent.return_value = self.integrated_agent
+        mock_use_case.update_sales_channels.return_value = {
+            "sales_channels": ["2"],
+            "hook_created": True,
+        }
+        mock_use_case_cls.return_value = mock_use_case
+
+        response = self.client.patch(
+            self.url,
+            data={"sales_channels": ["2"]},
+            format="json",
+            **self._request_headers(),
+            QUERY_STRING="user_email=test@example.com",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_use_case.update_sales_channels.assert_called_once_with(
+            self.integrated_agent,
+            ["2"],
+        )
+        self.assertEqual(
+            response.json(),
+            {"sales_channels": ["2"], "hook_created": True},
+        )
+
+    def test_patch_requires_sales_channels_field(self):
+        self.setup_internal_user_permissions(self.user)
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions=ConnectServicePermissionScenarios.CONTRIBUTOR_PERMISSIONS,
+        )
+
+        response = self.client.patch(
+            self.url,
+            data={},
+            format="json",
+            **self._request_headers(),
+            QUERY_STRING="user_email=test@example.com",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("sales_channels", response.json())


### PR DESCRIPTION
## What

Adds GET/PATCH endpoint at
`/api/v3/agents/assigneds/<uuid>/payment-recovery/hook-config/` so the IO
frontend can configure which VTEX sales channels trigger the PIX payment
recovery hook.

A shared pure service (`payment_recovery_hook.py`) builds the VTEX hook
filter expression and payload. On first assign the default remains channel
`"1"`. An empty `sales_channels` list removes all channel constraints and
syncs only the PIX payment-system filter (`125`), matching accounts that
do not segment by sales channel.

Updates are persisted in
`integrated_agent.config["payment_recovery"]["sales_channels"]`, synced to
VTEX via the existing IO proxy (`POST /api/orders/hook/config`), and the
integrated-agent cache is invalidated after each update.

## Why

Some VTEX accounts do not use sales channel `1`, remove it entirely, or
require multiple channels. The hook was hardcoded to `salesChannel = "1"`
during integration, causing missed or incorrect PIX recovery events.
