### PR TITLE
fix: Resolve geo_country for contract acceptance notifications

### DIFF
--- a/retail/contracts/tests/test_register_contract_acceptance.py
+++ b/retail/contracts/tests/test_register_contract_acceptance.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone as dt_timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.test import TestCase
@@ -33,7 +33,11 @@ class RegisterContractAcceptanceUseCaseTests(TestCase):
         self.template = ContractTemplate.objects.create(
             version="v2.1", template_name="contract/pdf/v1.html"
         )
-        self.usecase = RegisterContractAcceptanceUseCase()
+        self.tenant_locale_service = MagicMock()
+        self.tenant_locale_service.resolve_geo_country.return_value = "BR"
+        self.usecase = RegisterContractAcceptanceUseCase(
+            tenant_locale_service=self.tenant_locale_service
+        )
 
     def _build_dto(self, **overrides) -> RegisterContractAcceptanceDTO:
         defaults = dict(
@@ -118,6 +122,29 @@ class RegisterContractAcceptanceUseCaseTests(TestCase):
         )
 
         self.assertEqual(acceptance.company_name, "Magazine Luiza S.A.")
+
+    @patch(NOTIFY_TASK_PATH)
+    @patch(TASK_PATH)
+    def test_execute_persists_geo_country_from_tenant_locale(
+        self, _mock_task, _mock_notify
+    ):
+        acceptance = self.usecase.execute(self._build_dto())
+
+        self.tenant_locale_service.resolve_geo_country.assert_called_once_with(
+            "teststore",
+            fallback_language=self.project.language,
+        )
+        self.assertEqual(acceptance.geo_country, "BR")
+
+    @patch(NOTIFY_TASK_PATH)
+    @patch(TASK_PATH)
+    def test_execute_keeps_explicit_geo_country_from_dto(
+        self, _mock_task, _mock_notify
+    ):
+        acceptance = self.usecase.execute(self._build_dto(geo_country="US"))
+
+        self.tenant_locale_service.resolve_geo_country.assert_not_called()
+        self.assertEqual(acceptance.geo_country, "US")
 
     @patch(NOTIFY_TASK_PATH)
     @patch(TASK_PATH)

--- a/retail/contracts/usecases/register_contract_acceptance.py
+++ b/retail/contracts/usecases/register_contract_acceptance.py
@@ -18,6 +18,7 @@ from retail.contracts.tasks import (
     task_process_contract_acceptance_document,
 )
 from retail.projects.models import Project
+from retail.services.vtex_io.tenant_locale_service import VtexTenantLocaleService
 
 logger = logging.getLogger(__name__)
 
@@ -50,9 +51,19 @@ class RegisterContractAcceptanceUseCase:
     ``task_process_contract_acceptance_document``.
     """
 
+    def __init__(
+        self,
+        tenant_locale_service: Optional[VtexTenantLocaleService] = None,
+    ):
+        self.tenant_locale_service = tenant_locale_service or VtexTenantLocaleService()
+
     def execute(self, dto: RegisterContractAcceptanceDTO) -> ContractAcceptance:
         project = self._get_project(dto.vtex_account)
         template = self._get_active_template()
+        geo_country = dto.geo_country or self.tenant_locale_service.resolve_geo_country(
+            dto.vtex_account,
+            fallback_language=project.language,
+        )
 
         acceptance_uuid = uuid4()
         accepted_at = timezone.now()
@@ -78,7 +89,7 @@ class RegisterContractAcceptanceUseCase:
             acceptance_method=dto.acceptance_method,
             checkbox_label_text=dto.checkbox_label_text,
             request_id=dto.request_id,
-            geo_country=dto.geo_country,
+            geo_country=geo_country,
         )
 
         logger.info(

--- a/retail/services/tests/test_vtex_io_tenant_locale_service.py
+++ b/retail/services/tests/test_vtex_io_tenant_locale_service.py
@@ -1,0 +1,95 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from retail.services.vtex_io.tenant_locale_service import (
+    VtexTenantLocaleService,
+    extract_default_locale,
+    language_to_geo_country,
+    locale_to_geo_country,
+)
+
+
+class TenantLocaleParsingTests(TestCase):
+    def test_extract_default_locale_from_list_response(self):
+        result = extract_default_locale([{"defaultLocale": "en-US"}])
+        self.assertEqual(result, "en-US")
+
+    def test_extract_default_locale_from_dict_response(self):
+        result = extract_default_locale({"defaultLocale": "es-AR"})
+        self.assertEqual(result, "es-AR")
+
+    def test_extract_default_locale_returns_none_for_empty(self):
+        self.assertIsNone(extract_default_locale(None))
+        self.assertIsNone(extract_default_locale([]))
+        self.assertIsNone(extract_default_locale({}))
+
+    def test_locale_to_geo_country_from_vtex_locale(self):
+        self.assertEqual(locale_to_geo_country("en-US"), "US")
+        self.assertEqual(locale_to_geo_country("pt-BR"), "BR")
+
+    def test_locale_to_geo_country_returns_none_when_missing_region(self):
+        self.assertIsNone(locale_to_geo_country(""))
+        self.assertIsNone(locale_to_geo_country("pt"))
+
+    def test_language_to_geo_country_normalizes_underscores(self):
+        self.assertEqual(language_to_geo_country("pt-br"), "BR")
+        self.assertEqual(language_to_geo_country("en-us"), "US")
+
+    def test_language_to_geo_country_returns_none_when_empty(self):
+        self.assertIsNone(language_to_geo_country(None))
+        self.assertIsNone(language_to_geo_country(""))
+
+
+class VtexTenantLocaleServiceTests(TestCase):
+    def setUp(self):
+        self.vtex_io_service = MagicMock()
+        self.service = VtexTenantLocaleService(vtex_io_service=self.vtex_io_service)
+
+    def _mock_tenant_response(self, locale):
+        self.vtex_io_service.proxy_vtex.return_value = [{"defaultLocale": locale}]
+
+    def test_fetch_default_locale_returns_locale(self):
+        self._mock_tenant_response("es-MX")
+
+        locale = self.service.fetch_default_locale("teststore")
+
+        self.vtex_io_service.proxy_vtex.assert_called_once_with(
+            account_domain="teststore.myvtex.com",
+            vtex_account="teststore",
+            method="GET",
+            path="/api/tenant/tenants?q=teststore",
+        )
+        self.assertEqual(locale, "es-MX")
+
+    def test_fetch_default_locale_returns_empty_when_proxy_fails(self):
+        self.vtex_io_service.proxy_vtex.side_effect = Exception("timeout")
+
+        self.assertEqual(self.service.fetch_default_locale("teststore"), "")
+
+    def test_fetch_default_locale_returns_empty_when_no_locale_in_response(self):
+        self.vtex_io_service.proxy_vtex.return_value = [{}]
+
+        self.assertEqual(self.service.fetch_default_locale("teststore"), "")
+
+    def test_resolve_geo_country_from_tenant_locale(self):
+        self._mock_tenant_response("en-US")
+
+        self.assertEqual(self.service.resolve_geo_country("teststore"), "US")
+
+    def test_resolve_geo_country_falls_back_to_project_language(self):
+        self.vtex_io_service.proxy_vtex.side_effect = Exception("timeout")
+
+        geo_country = self.service.resolve_geo_country(
+            "teststore",
+            fallback_language="pt-br",
+        )
+
+        self.assertEqual(geo_country, "BR")
+
+    def test_resolve_geo_country_returns_none_when_unresolvable(self):
+        self.vtex_io_service.proxy_vtex.return_value = [{}]
+
+        self.assertIsNone(
+            self.service.resolve_geo_country("teststore", fallback_language="")
+        )

--- a/retail/services/vtex_io/tenant_locale_service.py
+++ b/retail/services/vtex_io/tenant_locale_service.py
@@ -1,0 +1,85 @@
+"""Resolve VTEX tenant locale and country from the IO tenants API."""
+
+import logging
+from typing import Any, Optional
+
+from retail.services.vtex_io.service import VtexIOService
+
+logger = logging.getLogger(__name__)
+
+TENANT_LOCALE_PATH_TEMPLATE = "/api/tenant/tenants?q={vtex_account}"
+
+
+def extract_default_locale(response: Any) -> Optional[str]:
+    """Extract ``defaultLocale`` from a VTEX tenant API response."""
+    if not response:
+        return None
+
+    tenant = response if isinstance(response, dict) else None
+    if isinstance(response, list) and response:
+        tenant = response[0]
+
+    if not tenant:
+        return None
+
+    locale = tenant.get("defaultLocale", "")
+    return locale or None
+
+
+def locale_to_geo_country(locale: Optional[str]) -> Optional[str]:
+    """Convert a VTEX locale (e.g. ``en-US``) to ISO 3166-1 alpha-2."""
+    if not locale or "-" not in locale:
+        return None
+
+    region = locale.rsplit("-", 1)[-1].strip()
+    return region.upper() if region else None
+
+
+def language_to_geo_country(language: Optional[str]) -> Optional[str]:
+    """Convert a Connect project language (e.g. ``pt-br``) to ISO country code."""
+    if not language:
+        return None
+
+    return locale_to_geo_country(language.replace("_", "-"))
+
+
+class VtexTenantLocaleService:
+    """Fetches tenant locale via the VTEX IO proxy."""
+
+    def __init__(self, vtex_io_service: Optional[VtexIOService] = None):
+        self.vtex_io_service = vtex_io_service or VtexIOService()
+
+    def fetch_default_locale(self, vtex_account: str) -> str:
+        """Return the tenant ``defaultLocale`` (e.g. ``pt-BR``) or an empty string."""
+        account_domain = f"{vtex_account}.myvtex.com"
+
+        try:
+            response = self.vtex_io_service.proxy_vtex(
+                account_domain=account_domain,
+                vtex_account=vtex_account,
+                method="GET",
+                path=TENANT_LOCALE_PATH_TEMPLATE.format(vtex_account=vtex_account),
+            )
+            locale = extract_default_locale(response)
+            if locale:
+                return locale
+        except Exception as exc:
+            logger.warning(
+                f"Failed to fetch tenant locale for vtex_account={vtex_account}: {exc}"
+            )
+
+        return ""
+
+    def resolve_geo_country(
+        self,
+        vtex_account: str,
+        *,
+        fallback_language: Optional[str] = None,
+    ) -> Optional[str]:
+        """Resolve ISO country code from tenant locale, with optional project fallback."""
+        locale = self.fetch_default_locale(vtex_account)
+        geo_country = locale_to_geo_country(locale)
+        if geo_country:
+            return geo_country
+
+        return language_to_geo_country(fallback_language)

--- a/retail/vtex/tests/usecases/test_register_lead.py
+++ b/retail/vtex/tests/usecases/test_register_lead.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from retail.projects.models import Project
 from retail.vtex.models import Lead
+from retail.services.vtex_io.tenant_locale_service import extract_default_locale
 from retail.vtex.usecases.register_lead import RegisterLeadDTO, RegisterLeadUseCase
 
 
@@ -98,13 +99,13 @@ class TestRegisterLeadUseCase(TestCase):
         self.assertIn("nonexistent", str(ctx.exception))
 
     def test_extract_locale_from_list_response(self):
-        result = RegisterLeadUseCase._extract_locale([{"defaultLocale": "en-US"}])
+        result = extract_default_locale([{"defaultLocale": "en-US"}])
         self.assertEqual(result, "en-US")
 
     def test_extract_locale_from_dict_response(self):
-        result = RegisterLeadUseCase._extract_locale({"defaultLocale": "es-AR"})
+        result = extract_default_locale({"defaultLocale": "es-AR"})
         self.assertEqual(result, "es-AR")
 
     def test_extract_locale_returns_none_for_empty(self):
-        self.assertIsNone(RegisterLeadUseCase._extract_locale(None))
-        self.assertIsNone(RegisterLeadUseCase._extract_locale([]))
+        self.assertIsNone(extract_default_locale(None))
+        self.assertIsNone(extract_default_locale([]))

--- a/retail/vtex/usecases/register_lead.py
+++ b/retail/vtex/usecases/register_lead.py
@@ -10,8 +10,9 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from retail.projects.models import Project
-from retail.vtex.models import Lead
 from retail.services.vtex_io.service import VtexIOService
+from retail.services.vtex_io.tenant_locale_service import VtexTenantLocaleService
+from retail.vtex.models import Lead
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +34,15 @@ class RegisterLeadUseCase:
     def __init__(
         self,
         vtex_io_service: Optional[VtexIOService] = None,
+        tenant_locale_service: Optional[VtexTenantLocaleService] = None,
     ):
-        self.vtex_io_service = vtex_io_service or VtexIOService()
+        self.tenant_locale_service = tenant_locale_service or VtexTenantLocaleService(
+            vtex_io_service=vtex_io_service
+        )
 
     def execute(self, dto: RegisterLeadDTO) -> Lead:
         project = self._get_project(dto.vtex_account)
-        region = self._resolve_region(dto.vtex_account)
+        region = self.tenant_locale_service.fetch_default_locale(dto.vtex_account)
 
         lead, created = Lead.objects.update_or_create(
             vtex_account=dto.vtex_account,
@@ -65,34 +69,3 @@ class RegisterLeadUseCase:
             return Project.objects.get(vtex_account=vtex_account)
         except Project.DoesNotExist:
             raise ValueError(f"Project not found for vtex_account: {vtex_account}")
-
-    def _resolve_region(self, vtex_account: str) -> str:
-        """Fetch the full VTEX tenant locale (e.g. 'es-MX', 'pt-BR')."""
-        account_domain = f"{vtex_account}.myvtex.com"
-        try:
-            response = self.vtex_io_service.proxy_vtex(
-                account_domain=account_domain,
-                vtex_account=vtex_account,
-                method="GET",
-                path=f"/api/tenant/tenants?q={vtex_account}",
-            )
-            locale = self._extract_locale(response)
-            if locale:
-                return locale
-        except Exception as e:
-            logger.warning(
-                f"Failed to fetch tenant locale for "
-                f"vtex_account={vtex_account}: {e}"
-            )
-        return ""
-
-    @staticmethod
-    def _extract_locale(response) -> Optional[str]:
-        if not response:
-            return None
-        tenant = response if isinstance(response, dict) else None
-        if isinstance(response, list) and response:
-            tenant = response[0]
-        if not tenant:
-            return None
-        return tenant.get("defaultLocale", "")


### PR DESCRIPTION
## What

Contract acceptance Slack notifications were showing `Country: N/A` because
`geo_country` was hardcoded to `None` in the view and never resolved server-side.

This change introduces `VtexTenantLocaleService` (`retail/services/vtex_io/tenant_locale_service.py`)
as a shared module for resolving VTEX tenant locale and ISO country codes via the
IO proxy (`GET /api/tenant/tenants?q={vtex_account}`), matching the legacy lead
flow. `RegisterContractAcceptanceUseCase` now resolves `geo_country` from the
tenant `defaultLocale` (e.g. `en-US` → `US`), with `project.language` as fallback
when the proxy call fails.

`RegisterLeadUseCase` was refactored to use the same service, removing duplicated
locale-fetch logic without creating a dependency between contracts and the Lead
module.

## Why

Sales and ops teams rely on Slack notifications to identify the customer's country
when a plan is accepted. The legacy lead endpoint already surfaced this information;
the new contract acceptance flow lost it, blocking regional follow-up.
