### PR TITLE
fix: Persist store URL locally before abandoned cart template creation

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -811,9 +811,16 @@ class AssignAgentUseCase:
             vtex_host_store = project.config.get("vtex_host_store")
             if vtex_host_store:
                 domain = urlparse(vtex_host_store).netloc
+                url_source = "vtex_host_store"
             else:
                 domain = f"{project.vtex_account}.vtexcommercestable.com.br"
+                url_source = "fallback_vtexcommercestable"
             button_base_url = f"https://{domain}/checkout?orderFormId="
+            logger.info(
+                f"[AssignAgent] abandoned_cart_button_url_resolved: "
+                f"project={project.uuid} vtex_account={project.vtex_account} "
+                f"source={url_source} button_base_url={button_base_url!r}"
+            )
             button_url_example = f"{button_base_url}92421d4a70224658acaab0c172f6b6d7"
 
             # Placeholder image URL for template approval (configurable via env)

--- a/retail/agents/tests/usecases/test_assign_abandoned_cart_button_url.py
+++ b/retail/agents/tests/usecases/test_assign_abandoned_cart_button_url.py
@@ -1,0 +1,104 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.assign import AssignAgentUseCase
+from retail.agents.domains.agent_integration.usecases.fetch_country_phone_code import (
+    FetchCountryPhoneCodeUseCase,
+    VtexLocaleInfo,
+)
+from retail.projects.models import Project
+
+ABANDONED_CART_AGENT_UUID = str(uuid.uuid4())
+
+
+@override_settings(ABANDONED_CART_AGENT_UUID=ABANDONED_CART_AGENT_UUID)
+class AssignAbandonedCartButtonUrlTest(TestCase):
+    def setUp(self):
+        self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
+        self.mock_fetch_phone_code.fetch_locale_info.return_value = VtexLocaleInfo(
+            country_phone_code="55",
+            meta_language="pt_BR",
+            vtex_locale="pt-BR",
+        )
+        self.use_case = AssignAgentUseCase(
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(),
+            name="Test Project",
+            vtex_account="teststore",
+            config={"vtex_host_store": "https://www.realstore.com.br/"},
+        )
+        self.integrated_agent = MagicMock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid.uuid4()
+        self.integrated_agent.config = {"initial_template_language": "pt_BR"}
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateCustomTemplateUseCase"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.ImageUrlToBase64Converter"
+    )
+    @override_settings(
+        ABANDONED_CART_DEFAULT_IMAGE_URL="https://placehold.co/1200x628/png?text=Test"
+    )
+    def test_uses_vtex_host_store_for_button_base_url(
+        self, mock_converter_cls, mock_custom_template_cls
+    ):
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = "data:image/png;base64,abc"
+        mock_converter_cls.return_value = mock_converter
+        mock_template_usecase = MagicMock()
+        mock_custom_template_cls.return_value = mock_template_usecase
+
+        self.use_case._create_default_abandoned_cart_template(
+            integrated_agent=self.integrated_agent,
+            project=self.project,
+            project_uuid=self.project.uuid,
+            app_uuid=uuid.uuid4(),
+        )
+
+        payload = mock_template_usecase.execute.call_args[0][0]
+        button = payload["template_translation"]["template_button"][0]
+        self.assertEqual(
+            button["url"]["base_url"],
+            "https://www.realstore.com.br/checkout?orderFormId=",
+        )
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateCustomTemplateUseCase"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.ImageUrlToBase64Converter"
+    )
+    @override_settings(
+        ABANDONED_CART_DEFAULT_IMAGE_URL="https://placehold.co/1200x628/png?text=Test"
+    )
+    def test_falls_back_to_vtexcommercestable_when_host_store_missing(
+        self, mock_converter_cls, mock_custom_template_cls
+    ):
+        self.project.config = {}
+        self.project.save(update_fields=["config"])
+
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = "data:image/png;base64,abc"
+        mock_converter_cls.return_value = mock_converter
+        mock_template_usecase = MagicMock()
+        mock_custom_template_cls.return_value = mock_template_usecase
+
+        self.use_case._create_default_abandoned_cart_template(
+            integrated_agent=self.integrated_agent,
+            project=self.project,
+            project_uuid=self.project.uuid,
+            app_uuid=uuid.uuid4(),
+        )
+
+        payload = mock_template_usecase.execute.call_args[0][0]
+        button = payload["template_translation"]["template_button"][0]
+        self.assertEqual(
+            button["url"]["base_url"],
+            "https://teststore.vtexcommercestable.com.br/checkout?orderFormId=",
+        )

--- a/retail/projects/tests/test_initiate_crawl.py
+++ b/retail/projects/tests/test_initiate_crawl.py
@@ -28,9 +28,7 @@ class TestInitiateCrawlUseCase(TestCase):
         self.usecase.detect_storefront_usecase = self.mock_detect_storefront
 
     def test_runs_full_sequence(self):
-        self.usecase.execute(
-            self.project, "mystore", "https://www.mystore.com.br/"
-        )
+        self.usecase.execute(self.project, "mystore", "https://www.mystore.com.br/")
 
         self.mock_connect.update_project_config.assert_called_once()
         self.mock_start_crawl.execute.assert_called_once_with(
@@ -41,23 +39,34 @@ class TestInitiateCrawlUseCase(TestCase):
         )
 
     def test_sends_vtex_host_store_with_correct_args(self):
-        self.usecase.execute(
-            self.project, "mystore", "https://www.mystore.com.br/"
-        )
+        self.usecase.execute(self.project, "mystore", "https://www.mystore.com.br/")
 
         self.mock_connect.update_project_config.assert_called_once_with(
             project_uuid=str(self.project.uuid),
             config={"vtex_host_store": "https://www.mystore.com.br/"},
         )
 
-    def test_crawl_proceeds_when_connect_fails(self):
-        self.mock_connect.update_project_config.side_effect = Exception(
-            "connect down"
-        )
+    def test_persists_vtex_host_store_locally_before_connect(self):
+        crawl_url = "https://www.mystore.com.br/"
 
-        self.usecase.execute(
-            self.project, "mystore", "https://www.mystore.com.br/"
-        )
+        self.usecase.execute(self.project, "mystore", crawl_url)
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.config["vtex_host_store"], crawl_url)
+
+    def test_persists_locally_even_when_connect_fails(self):
+        self.mock_connect.update_project_config.side_effect = Exception("connect down")
+        crawl_url = "https://www.mystore.com.br/"
+
+        self.usecase.execute(self.project, "mystore", crawl_url)
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.config["vtex_host_store"], crawl_url)
+
+    def test_crawl_proceeds_when_connect_fails(self):
+        self.mock_connect.update_project_config.side_effect = Exception("connect down")
+
+        self.usecase.execute(self.project, "mystore", "https://www.mystore.com.br/")
 
         self.mock_start_crawl.execute.assert_called_once()
         self.mock_detect_storefront.execute.assert_called_once()
@@ -72,8 +81,6 @@ class TestInitiateCrawlUseCase(TestCase):
         self.mock_start_crawl.execute.side_effect = RuntimeError("unexpected boom")
 
         with self.assertRaises(RuntimeError):
-            self.usecase.execute(
-                self.project, "mystore", "https://www.mystore.com.br/"
-            )
+            self.usecase.execute(self.project, "mystore", "https://www.mystore.com.br/")
 
         self.mock_detect_storefront.execute.assert_not_called()

--- a/retail/projects/usecases/initiate_crawl.py
+++ b/retail/projects/usecases/initiate_crawl.py
@@ -14,9 +14,10 @@ logger = logging.getLogger(__name__)
 class InitiateCrawlUseCase:
     """
     Runs the full crawl initiation sequence once a project is linked:
-      1. Sends the store URL to Connect (non-blocking).
-      2. Starts the crawl via the Crawler MS (critical).
-      3. Detects the storefront type (non-blocking).
+      1. Persists the store URL locally (for synchronous onboarding steps).
+      2. Sends the store URL to Connect (non-blocking).
+      3. Starts the crawl via the Crawler MS (critical).
+      4. Detects the storefront type (non-blocking).
 
     Invoked by ``OnboardingOrchestrator`` as the first sub-phase of
     ``NEXUS_CONFIG``, after pre-crawl channel setup completes.
@@ -28,23 +29,36 @@ class InitiateCrawlUseCase:
         self.detect_storefront_usecase = DetectStorefrontTypeUseCase()
 
     def execute(self, project: Project, vtex_account: str, crawl_url: str) -> None:
-        self._send_vtex_host_store(project, crawl_url)
+        self._persist_vtex_host_store(project, crawl_url)
+        self._send_vtex_host_store_to_connect(project, crawl_url)
         self.start_crawl_usecase.execute(vtex_account, crawl_url)
         self.detect_storefront_usecase.execute(project, crawl_url)
 
-    def _send_vtex_host_store(self, project: Project, crawl_url: str) -> None:
-        """Propagates the store host to Connect.
+    def _persist_vtex_host_store(self, project: Project, crawl_url: str) -> None:
+        """Persist the store URL locally so downstream onboarding steps can use it.
 
-        The host value is the ``crawl_url`` received from the storefront at
-        start-setup; it is NOT fetched from VTEX here. The local
-        ``Project.config["vtex_host_store"]`` is only persisted once Connect
-        echoes it back via EDA, so this log trail is the source of truth for
-        whether the outbound propagation happened.
+        Agent assignment (abandoned cart template) runs in the same synchronous
+        NEXUS_CONFIG pipeline and must not depend on the async Connect → EDA
+        round-trip. The EDA echo later confirms or updates this value.
         """
+        config = project.config or {}
+        config["vtex_host_store"] = crawl_url
+        project.config = config
+        project.save(update_fields=["config"])
+
         logger.info(
-            f"[vtex_host_store] Resolved store host for project={project.uuid} "
-            f"vtex_account={project.vtex_account}: host={crawl_url!r}. "
-            f"Sending to Connect."
+            f"[vtex_host_store] Persisted locally for project={project.uuid} "
+            f"vtex_account={project.vtex_account}: host={crawl_url!r}"
+        )
+
+    def _send_vtex_host_store_to_connect(
+        self, project: Project, crawl_url: str
+    ) -> None:
+        """Propagates the store host to Connect for cross-service sync."""
+        logger.info(
+            f"[vtex_host_store] Sending store host to Connect for "
+            f"project={project.uuid} vtex_account={project.vtex_account}: "
+            f"host={crawl_url!r}"
         )
         try:
             self.connect_service.update_project_config(
@@ -62,5 +76,5 @@ class InitiateCrawlUseCase:
         logger.info(
             f"[vtex_host_store] Sent to Connect for project={project.uuid} "
             f"vtex_account={project.vtex_account} host={crawl_url!r}. "
-            f"Awaiting EDA echo to persist locally."
+            f"EDA echo will confirm or update the local value."
         )


### PR DESCRIPTION
## What
Eliminates the race condition where the abandoned cart template was created
before `vtex_host_store` was available in `project.config`. The store URL
from `start-setup` (`crawl_url`) is now persisted locally in
`InitiateCrawlUseCase` before agent integration runs, so
`AssignAgentUseCase` can build the checkout button with the real store
domain instead of falling back to `{account}.vtexcommercestable.com.br`.
The Connect → EDA round-trip is unchanged and continues to confirm or
update the value asynchronously. Diagnostic logging was added when the
abandoned cart button URL is resolved.

## Why
Agent integration runs synchronously in the NEXUS_CONFIG orchestrator
immediately after crawl kickoff, but `vtex_host_store` was only persisted
locally after the async Connect → EDA echo. When EDA arrived late, templates
were created with the VTEX default domain instead of the customer's store URL.