### PR TITLE
fix: Propagate VTEX order amount to agent execution logs

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/payment_recovery.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery.py
@@ -5,9 +5,17 @@ from uuid import UUID
 
 from rest_framework.exceptions import NotFound, ValidationError
 
+from retail.agents.domains.agent_execution.services.logger import ExecutionLoggerService
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.domains.agent_webhook.usecases.order_status import (
     AgentOrderStatusUpdateUsecase,
+)
+from retail.agents.shared.vtex_order_value import (
+    fetch_order_amount_details,
+    propagate_order_amount_to_execution_log,
+)
+from retail.interfaces.services.execution_logger import (
+    ExecutionLoggerServiceInterface,
 )
 from retail.services.vtex_io.service import VtexIOService
 from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
@@ -21,14 +29,24 @@ DEFAULT_DELAY_MINUTES = 5
 class PaymentRecoveryWebhookUseCase:
     """Use case for processing payment recovery webhook notifications from VTEX."""
 
-    def __init__(self, vtex_io_service: Optional[VtexIOService] = None):
+    def __init__(
+        self,
+        vtex_io_service: Optional[VtexIOService] = None,
+        exec_logger: Optional[ExecutionLoggerServiceInterface] = None,
+    ):
         """Initialize the use case with its VTEX IO dependency.
 
         Args:
             vtex_io_service: Service used to fetch order details from VTEX.
                 Defaults to a concrete ``VtexIOService`` instance.
+            exec_logger: Optional execution logger for agent-logs tracing.
+                When omitted, a default ``ExecutionLoggerService`` is used
+                (relies on the active execution contextvar when present).
         """
         self.vtex_io_service = vtex_io_service or VtexIOService()
+        self.exec_logger: ExecutionLoggerServiceInterface = (
+            exec_logger or ExecutionLoggerService()
+        )
 
     def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
         """Retrieve an active integrated agent by UUID.
@@ -151,7 +169,38 @@ class PaymentRecoveryWebhookUseCase:
         agent_uuid = integrated_agent.uuid
         order_id = webhook_data.get("OrderId")
 
-        if self._is_below_minimum_order_value(integrated_agent, order_id, vtex_account):
+        order_details = propagate_order_amount_to_execution_log(
+            self.exec_logger,
+            self.vtex_io_service,
+            order_id=order_id,
+            vtex_account=vtex_account,
+            log_prefix="[PAYMENT_RECOVERY]",
+        )
+
+        if self._is_below_minimum_order_value(
+            integrated_agent,
+            order_id,
+            vtex_account,
+            order_value=order_details.amount,
+            minimum_value=integrated_agent.config.get("payment_recovery", {}).get(
+                "minimum_order_value"
+            ),
+        ):
+            self.exec_logger.log_execution_skip(
+                reason="order_value_below_minimum",
+                skip_data={
+                    "order_id": order_id,
+                    "order_value": (
+                        str(order_details.amount)
+                        if order_details.amount is not None
+                        else None
+                    ),
+                    "minimum_order_value": integrated_agent.config.get(
+                        "payment_recovery", {}
+                    ).get("minimum_order_value"),
+                    "vtex_account": vtex_account,
+                },
+            )
             return {
                 "status": "skipped",
                 "message": "Order value below configured minimum",
@@ -174,8 +223,15 @@ class PaymentRecoveryWebhookUseCase:
             vtexAccount=vtex_account,
         )
 
-        order_status_usecase = AgentOrderStatusUpdateUsecase()
-        order_status_usecase.execute(integrated_agent, order_status_dto)
+        order_status_usecase = AgentOrderStatusUpdateUsecase(
+            exec_logger=self.exec_logger,
+            vtex_io_service=self.vtex_io_service,
+        )
+        order_status_usecase.execute(
+            integrated_agent,
+            order_status_dto,
+            order_amount_details=order_details,
+        )
 
         logger.info(
             f"[PAYMENT_RECOVERY] completed: "
@@ -193,6 +249,10 @@ class PaymentRecoveryWebhookUseCase:
         integrated_agent: IntegratedAgent,
         order_id: Optional[str],
         vtex_account: str,
+        # Keyword-only from here: order_value/minimum_value must be passed by name.
+        *,
+        order_value: Optional[Decimal] = None,
+        minimum_value: Optional[float] = None,
     ) -> bool:
         """Decide whether the recovery dispatch must be skipped by minimum value.
 
@@ -205,18 +265,19 @@ class PaymentRecoveryWebhookUseCase:
             integrated_agent: The integrated agent that owns the webhook.
             order_id: VTEX order identifier from the webhook payload.
             vtex_account: The VTEX account identifier for the project.
+            order_value: Pre-resolved order total in major units, when available.
+            minimum_value: Configured minimum order value threshold.
 
         Returns:
             bool: ``True`` when the dispatch must be skipped because the order
             value is below the configured minimum, ``False`` otherwise.
         """
-        payment_config = integrated_agent.config.get("payment_recovery", {})
-        minimum_value = payment_config.get("minimum_order_value")
-
         if minimum_value is None:
             return False
 
-        order_value = self._get_order_value(order_id, vtex_account)
+        if order_value is None:
+            order_value = self._get_order_value(order_id, vtex_account)
+
         if order_value is None:
             logger.warning(
                 f"[PAYMENT_RECOVERY] minimum_value_unresolved: "
@@ -257,31 +318,10 @@ class PaymentRecoveryWebhookUseCase:
             A VTEX ``value`` of ``2047`` (cents) resolves to
             ``Decimal("20.47")`` (R$ 20.47).
         """
-        if not order_id:
-            return None
-
-        account_domain = f"{vtex_account}.myvtex.com"
-        try:
-            order_details = self.vtex_io_service.get_order_details_by_id(
-                account_domain=account_domain,
-                vtex_account=vtex_account,
-                order_id=order_id,
-            )
-        except Exception as exc:
-            logger.warning(
-                f"[PAYMENT_RECOVERY] order_lookup_failed: "
-                f"vtex_account={vtex_account} order_id={order_id} error={exc}"
-            )
-            return None
-
-        if not order_details:
-            return None
-
-        raw_value = order_details.get("value")
-        if raw_value in (None, ""):
-            return None
-
-        try:
-            return (Decimal(raw_value) / Decimal(100)).quantize(Decimal("0.01"))
-        except (TypeError, ValueError, ArithmeticError):
-            return None
+        details = fetch_order_amount_details(
+            self.vtex_io_service,
+            order_id=order_id,
+            vtex_account=vtex_account,
+            log_prefix="[PAYMENT_RECOVERY]",
+        )
+        return details.amount

--- a/retail/agents/domains/agent_webhook/usecases/order_status.py
+++ b/retail/agents/domains/agent_webhook/usecases/order_status.py
@@ -16,11 +16,17 @@ from retail.agents.shared.cache import (
     IntegratedAgentCacheHandler,
     IntegratedAgentCacheHandlerRedis,
 )
+from retail.agents.shared.vtex_order_value import (
+    OrderAmountDetails,
+    apply_order_amount_details,
+    propagate_order_amount_to_execution_log,
+)
 from retail.interfaces.clients.aws_lambda.client import RequestData
 from retail.interfaces.services.execution_logger import (
     ExecutionLoggerServiceInterface,
 )
 from retail.projects.models import Project
+from retail.services.vtex_io.service import VtexIOService
 from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 
 
@@ -60,11 +66,13 @@ class AgentOrderStatusUpdateUsecase:
         self,
         cache_handler: Optional[IntegratedAgentCacheHandler] = None,
         exec_logger: Optional[ExecutionLoggerServiceInterface] = None,
+        vtex_io_service: Optional[VtexIOService] = None,
     ) -> None:
         self.cache_handler = cache_handler or IntegratedAgentCacheHandlerRedis()
         self.exec_logger: ExecutionLoggerServiceInterface = (
             exec_logger or ExecutionLoggerService()
         )
+        self.vtex_io_service = vtex_io_service or VtexIOService()
 
     def get_integrated_agent_if_exists(
         self, project: Project
@@ -241,6 +249,8 @@ class AgentOrderStatusUpdateUsecase:
         self,
         integrated_agent: IntegratedAgent,
         order_status_dto: OrderStatusDTO,
+        *,
+        order_amount_details: Optional[OrderAmountDetails] = None,
     ) -> None:
         vtex_account = order_status_dto.vtexAccount
         current_state = order_status_dto.currentState
@@ -284,6 +294,17 @@ class AgentOrderStatusUpdateUsecase:
             f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
             f"current_state={current_state} order_id={order_id}"
         )
+
+        if order_amount_details is not None:
+            apply_order_amount_details(self.exec_logger, order_amount_details)
+        else:
+            propagate_order_amount_to_execution_log(
+                self.exec_logger,
+                self.vtex_io_service,
+                order_id=order_id,
+                vtex_account=vtex_account,
+                log_prefix="[ORDER_STATUS]",
+            )
 
         webhook_payload: Dict[str, Any] = adapt_order_status_to_webhook_payload(
             order_status_dto

--- a/retail/agents/shared/vtex_order_value.py
+++ b/retail/agents/shared/vtex_order_value.py
@@ -1,0 +1,106 @@
+"""VTEX order total and currency helpers for agent execution logging."""
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Dict, Optional
+
+from retail.interfaces.services.execution_logger import ExecutionLoggerServiceInterface
+from retail.services.vtex_io.service import VtexIOService
+
+logger = logging.getLogger(__name__)
+
+_AMOUNT_QUANTUM = Decimal("0.01")
+
+
+@dataclass(frozen=True)
+class OrderAmountDetails:
+    """Order total and store currency resolved from a VTEX order payload."""
+
+    amount: Optional[Decimal]
+    currency: Optional[str]
+
+
+def parse_order_amount_details(
+    order_details: Optional[Dict[str, Any]],
+) -> OrderAmountDetails:
+    """Extract the order total (major units) and currency from VTEX order JSON.
+
+    VTEX returns ``order.value`` in minor units (cents). The amount is
+    divided by 100 and quantized to two decimal places.
+    """
+    if not order_details:
+        return OrderAmountDetails(amount=None, currency=None)
+
+    store_preferences = order_details.get("storePreferencesData") or {}
+    currency = store_preferences.get("currencyCode") or None
+
+    raw_value = order_details.get("value")
+    if raw_value in (None, ""):
+        return OrderAmountDetails(amount=None, currency=currency)
+
+    try:
+        amount = (Decimal(raw_value) / Decimal(100)).quantize(_AMOUNT_QUANTUM)
+    except (TypeError, ValueError, ArithmeticError):
+        return OrderAmountDetails(amount=None, currency=currency)
+
+    return OrderAmountDetails(amount=amount, currency=currency)
+
+
+def apply_order_amount_details(
+    exec_logger: ExecutionLoggerServiceInterface,
+    details: OrderAmountDetails,
+) -> None:
+    """Push parsed order totals onto the active execution log when present."""
+    if details.amount is not None or details.currency:
+        exec_logger.update_order_info(
+            amount=details.amount,
+            currency=details.currency,
+        )
+
+
+def fetch_order_amount_details(
+    vtex_io_service: VtexIOService,
+    *,
+    order_id: Optional[str],
+    vtex_account: str,
+    log_prefix: str = "[VTEX_ORDER]",
+) -> OrderAmountDetails:
+    """Load order details from VTEX and parse amount/currency for logging."""
+    if not order_id:
+        return OrderAmountDetails(amount=None, currency=None)
+
+    account_domain = f"{vtex_account}.myvtex.com"
+    try:
+        order_details = vtex_io_service.get_order_details_by_id(
+            account_domain=account_domain,
+            vtex_account=vtex_account,
+            order_id=order_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            f"{log_prefix} order_lookup_failed: "
+            f"vtex_account={vtex_account} order_id={order_id} error={exc}"
+        )
+        return OrderAmountDetails(amount=None, currency=None)
+
+    return parse_order_amount_details(order_details)
+
+
+def propagate_order_amount_to_execution_log(
+    exec_logger: ExecutionLoggerServiceInterface,
+    vtex_io_service: VtexIOService,
+    *,
+    order_id: Optional[str],
+    vtex_account: str,
+    log_prefix: str = "[VTEX_ORDER]",
+) -> OrderAmountDetails:
+    """Fetch VTEX order totals and push them onto the active execution log."""
+    details = fetch_order_amount_details(
+        vtex_io_service,
+        order_id=order_id,
+        vtex_account=vtex_account,
+        log_prefix=log_prefix,
+    )
+    apply_order_amount_details(exec_logger, details)
+    return details

--- a/retail/agents/tasks.py
+++ b/retail/agents/tasks.py
@@ -220,7 +220,7 @@ def task_payment_recovery_webhook(
             f"agent_uuid={integrated_agent_uuid} data={webhook_data}"
         )
 
-        use_case = PaymentRecoveryWebhookUseCase()
+        use_case = PaymentRecoveryWebhookUseCase(exec_logger=exec_logger)
         # Resolve the agent BEFORE opening any execution log so a missing
         # agent raises NotFound and is handled by execution_log_scope
         # without leaving an agentless row behind.

--- a/retail/agents/tests/shared/test_vtex_order_value.py
+++ b/retail/agents/tests/shared/test_vtex_order_value.py
@@ -1,0 +1,145 @@
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from retail.agents.shared.vtex_order_value import (
+    OrderAmountDetails,
+    apply_order_amount_details,
+    fetch_order_amount_details,
+    parse_order_amount_details,
+    propagate_order_amount_to_execution_log,
+)
+
+
+class ParseOrderAmountDetailsTest(TestCase):
+    def test_returns_none_when_order_details_missing(self):
+        self.assertEqual(
+            parse_order_amount_details(None),
+            OrderAmountDetails(amount=None, currency=None),
+        )
+
+    def test_converts_cents_to_major_units(self):
+        details = parse_order_amount_details(
+            {
+                "value": 2047,
+                "storePreferencesData": {"currencyCode": "BRL"},
+            }
+        )
+        self.assertEqual(details.amount, Decimal("20.47"))
+        self.assertEqual(details.currency, "BRL")
+
+    def test_returns_currency_without_amount_when_value_missing(self):
+        details = parse_order_amount_details(
+            {"storePreferencesData": {"currencyCode": "MXN"}}
+        )
+        self.assertIsNone(details.amount)
+        self.assertEqual(details.currency, "MXN")
+
+    def test_returns_none_amount_for_invalid_value(self):
+        details = parse_order_amount_details({"value": "not-a-number"})
+        self.assertIsNone(details.amount)
+
+
+class FetchOrderAmountDetailsTest(TestCase):
+    def test_returns_empty_details_when_order_id_missing(self):
+        service = MagicMock()
+        details = fetch_order_amount_details(
+            service, order_id=None, vtex_account="store"
+        )
+        self.assertEqual(details, OrderAmountDetails(amount=None, currency=None))
+        service.get_order_details_by_id.assert_not_called()
+
+    def test_fetches_and_parses_order_details(self):
+        service = MagicMock()
+        service.get_order_details_by_id.return_value = {
+            "value": 15000,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+        details = fetch_order_amount_details(
+            service, order_id="order-1", vtex_account="store"
+        )
+        self.assertEqual(details.amount, Decimal("150.00"))
+        self.assertEqual(details.currency, "BRL")
+        service.get_order_details_by_id.assert_called_once_with(
+            account_domain="store.myvtex.com",
+            vtex_account="store",
+            order_id="order-1",
+        )
+
+    def test_returns_empty_details_when_lookup_raises(self):
+        service = MagicMock()
+        service.get_order_details_by_id.side_effect = Exception("boom")
+        details = fetch_order_amount_details(
+            service, order_id="order-1", vtex_account="store"
+        )
+        self.assertEqual(details, OrderAmountDetails(amount=None, currency=None))
+
+
+class ApplyOrderAmountDetailsTest(TestCase):
+    def test_updates_execution_log_when_amount_or_currency_present(self):
+        exec_logger = MagicMock()
+        apply_order_amount_details(
+            exec_logger,
+            OrderAmountDetails(amount=Decimal("75.50"), currency="BRL"),
+        )
+        exec_logger.update_order_info.assert_called_once_with(
+            amount=Decimal("75.50"),
+            currency="BRL",
+        )
+
+    def test_updates_execution_log_with_currency_only(self):
+        exec_logger = MagicMock()
+        apply_order_amount_details(
+            exec_logger,
+            OrderAmountDetails(amount=None, currency="MXN"),
+        )
+        exec_logger.update_order_info.assert_called_once_with(
+            amount=None,
+            currency="MXN",
+        )
+
+    def test_skips_update_when_details_are_empty(self):
+        exec_logger = MagicMock()
+        apply_order_amount_details(
+            exec_logger,
+            OrderAmountDetails(amount=None, currency=None),
+        )
+        exec_logger.update_order_info.assert_not_called()
+
+
+class PropagateOrderAmountToExecutionLogTest(TestCase):
+    def test_updates_execution_log_when_amount_present(self):
+        exec_logger = MagicMock()
+        service = MagicMock()
+        service.get_order_details_by_id.return_value = {
+            "value": 3598,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+
+        details = propagate_order_amount_to_execution_log(
+            exec_logger,
+            service,
+            order_id="order-1",
+            vtex_account="store",
+        )
+
+        self.assertEqual(details.amount, Decimal("35.98"))
+        exec_logger.update_order_info.assert_called_once_with(
+            amount=Decimal("35.98"),
+            currency="BRL",
+        )
+
+    def test_skips_update_when_lookup_returns_no_data(self):
+        exec_logger = MagicMock()
+        service = MagicMock()
+        service.get_order_details_by_id.return_value = {}
+
+        propagate_order_amount_to_execution_log(
+            exec_logger,
+            service,
+            order_id="order-1",
+            vtex_account="store",
+        )
+
+        exec_logger.update_order_info.assert_not_called()

--- a/retail/agents/tests/tasks/test_payment_recovery_task.py
+++ b/retail/agents/tests/tasks/test_payment_recovery_task.py
@@ -44,6 +44,7 @@ class TaskPaymentRecoveryWebhookTest(TestCase):
 
         task_payment_recovery_webhook(self.agent_uuid, self.webhook_data)
 
+        mock_usecase_cls.assert_called_once_with(exec_logger=mock_logger)
         mock_usecase.get_integrated_agent.assert_called_once_with(self.agent_uuid)
         mock_usecase.process_webhook_notification.assert_called_once_with(
             mock_agent, self.webhook_data

--- a/retail/agents/tests/test_order_amount_execution_log_flow.py
+++ b/retail/agents/tests/test_order_amount_execution_log_flow.py
@@ -1,0 +1,280 @@
+"""End-to-end flow tests for VTEX order amount propagation into agent logs.
+
+Unit tests mock ``ExecutionLoggerService``; these wire the real logger,
+buffer, and flush pipeline so ``AgentExecution.amount`` / ``currency``
+survive to Postgres and surface through the public list-API serializer.
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.agents.domains.agent_execution.context import clear_execution_context
+from retail.agents.domains.agent_execution.models import (
+    AgentExecution,
+    AgentExecutionStatus,
+)
+from retail.agents.domains.agent_execution.serializers import AgentLogRowSerializer
+from retail.agents.domains.agent_execution.services.buffer import (
+    ExecutionBufferService,
+)
+from retail.agents.domains.agent_execution.services.logger import (
+    ExecutionLoggerService,
+)
+from retail.agents.domains.agent_execution.services.traces_storage import (
+    ExecutionTracesStorageService,
+)
+from retail.agents.domains.agent_execution.tests._fakes import (
+    FakeRedisConnection,
+    FakeS3Client,
+)
+from retail.agents.domains.agent_execution.usecases.flush_executions import (
+    FlushExecutionsUseCase,
+)
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.payment_recovery import (
+    PaymentRecoveryWebhookUseCase,
+)
+from retail.agents.domains.agent_management.models import Agent
+from retail.agents.domains.agent_webhook.usecases.order_status import (
+    AgentOrderStatusUpdateUsecase,
+)
+from retail.projects.models import Project
+from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
+
+
+@override_settings(
+    EXECUTION_TRACES_BUCKET="test-traces-bucket",
+    ORDER_STATUS_DUPLICATE_WINDOW_SECONDS=60,
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "order-amount-flow-tests",
+        }
+    },
+)
+class OrderAmountExecutionLogFlowTests(TestCase):
+    """Logger → use case → buffer → flush → DB + API serializer."""
+
+    def setUp(self):
+        super().setUp()
+        clear_execution_context()
+        self.addCleanup(clear_execution_context)
+        cache.clear()
+
+        self.fake_redis = FakeRedisConnection()
+        self.fake_s3 = FakeS3Client(bucket_name="test-traces-bucket")
+        self.traces_storage = ExecutionTracesStorageService(s3_service=self.fake_s3)
+
+        patcher = patch(
+            "retail.agents.domains.agent_execution.services.buffer."
+            "get_redis_connection",
+            return_value=self.fake_redis,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.buffer = ExecutionBufferService(traces_storage=self.traces_storage)
+        self.exec_logger = ExecutionLoggerService(buffer_service=self.buffer)
+
+        self.project = Project.objects.create(
+            name="Flow Project", uuid=uuid4(), vtex_account="flowstore"
+        )
+        self.agent = Agent.objects.create(
+            uuid=uuid4(),
+            name="Order Status",
+            slug="order-status",
+            description="",
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.project,
+            config={
+                "payment_recovery": {
+                    "hook_created": True,
+                    "minimum_order_value": 100.0,
+                }
+            },
+        )
+        self.mock_vtex_io = MagicMock()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def _flush(self) -> None:
+        FlushExecutionsUseCase(
+            buffer=self.buffer, traces_storage=self.traces_storage
+        ).execute()
+
+    def _order_status_dto(self) -> OrderStatusDTO:
+        return OrderStatusDTO(
+            recorder={},
+            domain="Marketplace",
+            orderId="1646748157477-01",
+            currentState="payment-approved",
+            lastState="payment-pending",
+            currentChangeDate="2026-07-14T17:47:35.779879+00:00",
+            lastChangeDate="2026-07-14T17:47:30.000000+00:00",
+            vtexAccount=self.project.vtex_account,
+        )
+
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    def test_order_status_flow_persists_amount_through_flush_and_api(
+        self, mock_webhook_use_case_cls
+    ):
+        mock_webhook = MagicMock()
+        mock_webhook_use_case_cls.return_value = mock_webhook
+        mock_webhook._addapt_credentials.return_value = {}
+        mock_webhook.execute.return_value = None
+
+        self.mock_vtex_io.get_order_details_by_id.return_value = {
+            "value": 3598,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+
+        use_case = AgentOrderStatusUpdateUsecase(
+            exec_logger=self.exec_logger,
+            vtex_io_service=self.mock_vtex_io,
+        )
+
+        self.exec_logger.log_webhook_received(
+            integrated_agent=self.integrated_agent,
+            payload={"OrderId": "1646748157477-01"},
+            order_id="1646748157477-01",
+        )
+        use_case.execute(self.integrated_agent, self._order_status_dto())
+        self.exec_logger.log_execution_skip(reason="test_terminal_for_flush")
+
+        self._flush()
+
+        row = AgentExecution.objects.get(integrated_agent=self.integrated_agent)
+        self.assertEqual(row.amount, Decimal("35.98"))
+        self.assertEqual(row.currency, "BRL")
+        self.assertEqual(row.status, AgentExecutionStatus.SKIP)
+
+        api_row = AgentLogRowSerializer(row).data
+        self.assertEqual(api_row["amount"], {"value": "35.98", "currency": "BRL"})
+        mock_webhook.execute.assert_called_once()
+
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    def test_payment_recovery_success_reuses_single_vtex_lookup(
+        self, mock_webhook_use_case_cls
+    ):
+        mock_webhook = MagicMock()
+        mock_webhook_use_case_cls.return_value = mock_webhook
+        mock_webhook._addapt_credentials.return_value = {}
+        mock_webhook.execute.return_value = None
+
+        self.mock_vtex_io.get_order_details_by_id.return_value = {
+            "value": 15000,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+
+        self.exec_logger.log_webhook_received(
+            integrated_agent=self.integrated_agent,
+            payload={"OrderId": "1646748157477-01"},
+            order_id="1646748157477-01",
+        )
+
+        use_case = PaymentRecoveryWebhookUseCase(
+            vtex_io_service=self.mock_vtex_io,
+            exec_logger=self.exec_logger,
+        )
+        webhook_data = {
+            "OrderId": "1646748157477-01",
+            "State": "payment-pending",
+            "CurrentChange": "2026-07-14T17:47:35.779879+00:00",
+            "LastChange": "2026-07-14T17:47:30.000000+00:00",
+        }
+        result = use_case.process_webhook_notification(
+            self.integrated_agent, webhook_data
+        )
+
+        self.assertEqual(result["status"], "success")
+        self.mock_vtex_io.get_order_details_by_id.assert_called_once()
+        self.exec_logger.log_execution_skip(reason="test_terminal_for_flush")
+        self._flush()
+
+        row = AgentExecution.objects.get(integrated_agent=self.integrated_agent)
+        self.assertEqual(row.amount, Decimal("150.00"))
+        self.assertEqual(row.currency, "BRL")
+
+    def test_payment_recovery_minimum_skip_persists_amount_on_execution_row(self):
+        self.mock_vtex_io.get_order_details_by_id.return_value = {
+            "value": 5000,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+
+        self.exec_logger.log_webhook_received(
+            integrated_agent=self.integrated_agent,
+            payload={"OrderId": "1646748157435-01"},
+            order_id="1646748157435-01",
+        )
+
+        use_case = PaymentRecoveryWebhookUseCase(
+            vtex_io_service=self.mock_vtex_io,
+            exec_logger=self.exec_logger,
+        )
+        result = use_case.process_webhook_notification(
+            self.integrated_agent,
+            {
+                "OrderId": "1646748157435-01",
+                "State": "payment-pending",
+            },
+        )
+
+        self.assertEqual(result["status"], "skipped")
+        self._flush()
+
+        row = AgentExecution.objects.get(integrated_agent=self.integrated_agent)
+        self.assertEqual(row.amount, Decimal("50.00"))
+        self.assertEqual(row.currency, "BRL")
+        self.assertEqual(row.status, AgentExecutionStatus.SKIP)
+
+        api_row = AgentLogRowSerializer(row).data
+        self.assertEqual(api_row["amount"], {"value": "50.00", "currency": "BRL"})
+        self.assertEqual(api_row["status"], "skipped")
+
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    def test_duplicate_skip_does_not_issue_second_vtex_lookup(
+        self, mock_webhook_use_case_cls
+    ):
+        """First event fetches VTEX once; the duplicate short-circuit must not."""
+        use_case = AgentOrderStatusUpdateUsecase(
+            exec_logger=self.exec_logger,
+            vtex_io_service=self.mock_vtex_io,
+        )
+
+        self.exec_logger.log_webhook_received(
+            integrated_agent=self.integrated_agent,
+            payload={"OrderId": "order-id"},
+            order_id="order-id",
+        )
+
+        dto = OrderStatusDTO(
+            recorder={},
+            domain="Marketplace",
+            orderId="order-id",
+            currentState="invoiced",
+            lastState="payment-approved",
+            currentChangeDate="2026-07-14T00:00:00+00:00",
+            lastChangeDate="2026-07-14T00:00:00+00:00",
+            vtexAccount=self.project.vtex_account,
+        )
+        use_case.execute(self.integrated_agent, dto)
+        use_case.execute(self.integrated_agent, dto)
+
+        self.mock_vtex_io.get_order_details_by_id.assert_called_once()
+        mock_webhook_use_case_cls.return_value.execute.assert_called_once()

--- a/retail/agents/tests/usecases/test_order_status_update.py
+++ b/retail/agents/tests/usecases/test_order_status_update.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.test import TestCase
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -10,6 +12,7 @@ from retail.agents.domains.agent_webhook.usecases.order_status import (
 )
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.agents.shared.cache import AgentRole
+from retail.agents.shared.vtex_order_value import OrderAmountDetails
 from retail.projects.models import Project
 from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 
@@ -20,9 +23,11 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
     def setUp(self):
         self.exec_logger = MagicMock()
         self.mock_cache_handler = MagicMock()
+        self.mock_vtex_io_service = MagicMock()
         self.usecase = AgentOrderStatusUpdateUsecase(
             cache_handler=self.mock_cache_handler,
-            exec_logger=self.exec_logger
+            exec_logger=self.exec_logger,
+            vtex_io_service=self.mock_vtex_io_service,
         )
         self.mock_project = MagicMock(spec=Project)
         self.mock_project.uuid = uuid4()
@@ -290,6 +295,72 @@ class AgentOrderStatusUpdateUsecaseTest(TestCase):
         mock_agent_webhook_use_case.execute.assert_called_once_with(
             self.mock_integrated_agent, mock_request_data
         )
+
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    def test_execute_propagates_order_amount_to_execution_log(
+        self,
+        mock_agent_webhook_use_case_cls,
+        mock_cache,
+        mock_settings,
+    ):
+        mock_settings.ORDER_STATUS_DUPLICATE_WINDOW_SECONDS = 60
+        mock_cache.add.return_value = True
+        self.mock_vtex_io_service.get_order_details_by_id.return_value = {
+            "value": 10000,
+            "storePreferencesData": {"currencyCode": "MXN"},
+        }
+
+        mock_order_status_dto = MagicMock(spec=OrderStatusDTO)
+        mock_order_status_dto.orderId = "order-id"
+        mock_order_status_dto.domain = "Marketplace"
+        mock_order_status_dto.currentState = "invoiced"
+        mock_order_status_dto.lastState = "payment-approved"
+        mock_order_status_dto.vtexAccount = "test-account"
+
+        self.usecase.execute(self.mock_integrated_agent, mock_order_status_dto)
+
+        self.exec_logger.update_order_info.assert_called_once_with(
+            amount=Decimal("100.00"),
+            currency="MXN",
+        )
+
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
+    @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")
+    @patch(
+        "retail.agents.domains.agent_webhook.usecases.order_status.AgentWebhookUseCase"
+    )
+    def test_execute_reuses_prefetched_order_amount_details(
+        self,
+        mock_agent_webhook_use_case_cls,
+        mock_cache,
+        mock_settings,
+    ):
+        mock_settings.ORDER_STATUS_DUPLICATE_WINDOW_SECONDS = 60
+        mock_cache.add.return_value = True
+
+        mock_order_status_dto = MagicMock(spec=OrderStatusDTO)
+        mock_order_status_dto.orderId = "order-id"
+        mock_order_status_dto.domain = "Marketplace"
+        mock_order_status_dto.currentState = "payment-pending"
+        mock_order_status_dto.lastState = "unknow"
+        mock_order_status_dto.vtexAccount = "test-account"
+
+        prefetched = OrderAmountDetails(amount=Decimal("75.50"), currency="BRL")
+        self.usecase.execute(
+            self.mock_integrated_agent,
+            mock_order_status_dto,
+            order_amount_details=prefetched,
+        )
+
+        self.exec_logger.update_order_info.assert_called_once_with(
+            amount=Decimal("75.50"),
+            currency="BRL",
+        )
+        self.mock_vtex_io_service.get_order_details_by_id.assert_not_called()
 
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.settings")
     @patch("retail.agents.domains.agent_webhook.usecases.order_status.cache")

--- a/retail/agents/tests/usecases/test_payment_recovery_webhook.py
+++ b/retail/agents/tests/usecases/test_payment_recovery_webhook.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.test import TestCase
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -78,36 +80,69 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
     def test_process_webhook_notification_success(self, mock_order_usecase_cls):
         mock_order_usecase = MagicMock()
         mock_order_usecase_cls.return_value = mock_order_usecase
-
-        result = self.use_case.process_webhook_notification(
-            self.mock_integrated_agent, self.webhook_data
-        )
-
-        self.assertEqual(result["status"], "success")
-        mock_order_usecase.execute.assert_called_once()
-
-        call_args = mock_order_usecase.execute.call_args
-        dto = call_args[0][1]
-        self.assertEqual(dto.orderId, "v1234567-01")
-        self.assertEqual(dto.currentState, "payment-pending")
-        self.assertEqual(dto.vtexAccount, "testaccount")
-
-    @patch(
-        "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
-    )
-    def test_process_webhook_notification_without_minimum_skips_value_lookup(
-        self, mock_order_usecase_cls
-    ):
-        """No minimum configured: dispatch happens without querying VTEX."""
         mock_vtex_io = MagicMock()
-        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+        mock_vtex_io.get_order_details_by_id.return_value = {
+            "value": 15000,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+        exec_logger = MagicMock()
+        use_case = PaymentRecoveryWebhookUseCase(
+            vtex_io_service=mock_vtex_io,
+            exec_logger=exec_logger,
+        )
 
         result = use_case.process_webhook_notification(
             self.mock_integrated_agent, self.webhook_data
         )
 
         self.assertEqual(result["status"], "success")
-        mock_vtex_io.get_order_details_by_id.assert_not_called()
+        mock_order_usecase.execute.assert_called_once()
+        mock_order_usecase_cls.assert_called_once_with(
+            exec_logger=exec_logger,
+            vtex_io_service=mock_vtex_io,
+        )
+        exec_logger.update_order_info.assert_called_once_with(
+            amount=Decimal("150.00"),
+            currency="BRL",
+        )
+
+        call_args = mock_order_usecase.execute.call_args
+        dto = call_args[0][1]
+        self.assertEqual(dto.orderId, "v1234567-01")
+        self.assertEqual(dto.currentState, "payment-pending")
+        self.assertEqual(dto.vtexAccount, "testaccount")
+        self.assertEqual(
+            call_args.kwargs["order_amount_details"].amount, Decimal("150.00")
+        )
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
+    )
+    def test_process_webhook_notification_propagates_amount_without_minimum(
+        self, mock_order_usecase_cls
+    ):
+        """Every recovery execution surfaces order amount in agent logs."""
+        mock_vtex_io = MagicMock()
+        mock_vtex_io.get_order_details_by_id.return_value = {
+            "value": 9999,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+        exec_logger = MagicMock()
+        use_case = PaymentRecoveryWebhookUseCase(
+            vtex_io_service=mock_vtex_io,
+            exec_logger=exec_logger,
+        )
+
+        result = use_case.process_webhook_notification(
+            self.mock_integrated_agent, self.webhook_data
+        )
+
+        self.assertEqual(result["status"], "success")
+        mock_vtex_io.get_order_details_by_id.assert_called_once()
+        exec_logger.update_order_info.assert_called_once_with(
+            amount=Decimal("99.99"),
+            currency="BRL",
+        )
         mock_order_usecase_cls.return_value.execute.assert_called_once()
 
     @patch(
@@ -122,8 +157,15 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
         ] = 100.0
         mock_vtex_io = MagicMock()
         # VTEX returns value in cents: 5000 = R$ 50,00 < R$ 100,00
-        mock_vtex_io.get_order_details_by_id.return_value = {"value": 5000}
-        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+        mock_vtex_io.get_order_details_by_id.return_value = {
+            "value": 5000,
+            "storePreferencesData": {"currencyCode": "BRL"},
+        }
+        exec_logger = MagicMock()
+        use_case = PaymentRecoveryWebhookUseCase(
+            vtex_io_service=mock_vtex_io,
+            exec_logger=exec_logger,
+        )
 
         result = use_case.process_webhook_notification(
             self.mock_integrated_agent, self.webhook_data
@@ -132,6 +174,15 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
         self.assertEqual(result["status"], "skipped")
         mock_order_usecase_cls.return_value.execute.assert_not_called()
         mock_vtex_io.get_order_details_by_id.assert_called_once()
+        exec_logger.update_order_info.assert_called_once_with(
+            amount=Decimal("50.00"),
+            currency="BRL",
+        )
+        exec_logger.log_execution_skip.assert_called_once()
+        self.assertEqual(
+            exec_logger.log_execution_skip.call_args.kwargs["reason"],
+            "order_value_below_minimum",
+        )
 
     @patch(
         "retail.agents.domains.agent_integration.usecases.payment_recovery.AgentOrderStatusUpdateUsecase"
@@ -146,7 +197,10 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
         mock_vtex_io = MagicMock()
         # 15000 cents = R$ 150,00 >= R$ 100,00
         mock_vtex_io.get_order_details_by_id.return_value = {"value": 15000}
-        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+        use_case = PaymentRecoveryWebhookUseCase(
+            vtex_io_service=mock_vtex_io,
+            exec_logger=MagicMock(),
+        )
 
         result = use_case.process_webhook_notification(
             self.mock_integrated_agent, self.webhook_data
@@ -167,7 +221,10 @@ class PaymentRecoveryWebhookUseCaseTest(TestCase):
         ] = 100.0
         mock_vtex_io = MagicMock()
         mock_vtex_io.get_order_details_by_id.side_effect = Exception("boom")
-        use_case = PaymentRecoveryWebhookUseCase(vtex_io_service=mock_vtex_io)
+        use_case = PaymentRecoveryWebhookUseCase(
+            vtex_io_service=mock_vtex_io,
+            exec_logger=MagicMock(),
+        )
 
         result = use_case.process_webhook_notification(
             self.mock_integrated_agent, self.webhook_data


### PR DESCRIPTION
## What

Adds `retail/agents/shared/vtex_order_value.py` to fetch VTEX order details,
convert `value` from cents to major units, extract `currencyCode`, and push
both onto the active `AgentExecution` row via `update_order_info`.

Wires the helper into `AgentOrderStatusUpdateUsecase` and
`PaymentRecoveryWebhookUseCase` (with explicit `exec_logger` injection from
`task_payment_recovery_webhook`). Payment recovery reuses fetched details to
avoid a second VTEX call and closes minimum-value skips via `log_execution_skip`.

Includes unit tests (mocked logger) and flow tests
(`test_order_amount_execution_log_flow.py`) that exercise logger → buffer →
flush → DB → public API serializer.

## Why

Successful order-status and payment-recovery agent logs showed `amount: 0.00`
and default `currency: BRL` even when contact, template, and delivery status
were correct. Only abandoned-cart had ever called `update_order_info`.
