### PR TITLE
feat: Add payment recovery conversion metrics API

### DIFF
--- a/retail/broadcasts/api/serializers.py
+++ b/retail/broadcasts/api/serializers.py
@@ -56,3 +56,30 @@ class BroadcastSummarySerializer(serializers.Serializer):
             "delivered": instance.delivered,
             "converted": instance.converted,
         }
+
+
+class GetPaymentRecoveryConversionMetricsQuerySerializer(_DateRangeQuerySerializer):
+    """Query params for payment recovery conversion metrics."""
+
+
+class PaymentRecoveryConversionMetricsSerializer(serializers.Serializer):
+    total_dispatches = serializers.IntegerField()
+    converted_payments = serializers.IntegerField()
+    conversion_rate = serializers.DecimalField(max_digits=7, decimal_places=2)
+    recovered_revenue = serializers.DecimalField(max_digits=14, decimal_places=2)
+    average_ticket = serializers.DecimalField(
+        max_digits=14, decimal_places=2, allow_null=True
+    )
+    first_conversion_at = serializers.DateTimeField(allow_null=True)
+    last_conversion_at = serializers.DateTimeField(allow_null=True)
+
+    def to_representation(self, instance) -> dict:
+        return {
+            "total_dispatches": instance.total_dispatches,
+            "converted_payments": instance.converted_payments,
+            "conversion_rate": instance.conversion_rate,
+            "recovered_revenue": instance.recovered_revenue,
+            "average_ticket": instance.average_ticket,
+            "first_conversion_at": instance.first_conversion_at,
+            "last_conversion_at": instance.last_conversion_at,
+        }

--- a/retail/broadcasts/api/urls.py
+++ b/retail/broadcasts/api/urls.py
@@ -2,8 +2,10 @@ from django.urls import path
 
 from retail.broadcasts.api.views import (
     BroadcastAgentDispatchesView,
+    BroadcastAgentPaymentRecoveryConversionView,
     BroadcastAgentSummaryView,
     BroadcastProjectDispatchesView,
+    BroadcastProjectPaymentRecoveryConversionView,
     BroadcastProjectSummaryView,
 )
 
@@ -28,5 +30,15 @@ urlpatterns = [
         "assigneds/<uuid:agent_uuid>/summary/",
         BroadcastAgentSummaryView.as_view(),
         name="broadcast-agent-summary",
+    ),
+    path(
+        "projects/payment-recovery/conversion/",
+        BroadcastProjectPaymentRecoveryConversionView.as_view(),
+        name="broadcast-project-payment-recovery-conversion",
+    ),
+    path(
+        "assigneds/<uuid:agent_uuid>/payment-recovery/conversion/",
+        BroadcastAgentPaymentRecoveryConversionView.as_view(),
+        name="broadcast-agent-payment-recovery-conversion",
     ),
 ]

--- a/retail/broadcasts/api/views.py
+++ b/retail/broadcasts/api/views.py
@@ -15,11 +15,17 @@ from retail.broadcasts.api.serializers import (
     BroadcastDispatchRowSerializer,
     BroadcastSummarySerializer,
     GetBroadcastSummaryQuerySerializer,
+    GetPaymentRecoveryConversionMetricsQuerySerializer,
     ListBroadcastDispatchesQuerySerializer,
+    PaymentRecoveryConversionMetricsSerializer,
 )
 from retail.broadcasts.usecases.get_broadcast_summary import (
     GetBroadcastSummaryDTO,
     GetBroadcastSummaryUseCase,
+)
+from retail.broadcasts.usecases.get_payment_recovery_conversion_metrics import (
+    GetPaymentRecoveryConversionMetricsDTO,
+    GetPaymentRecoveryConversionMetricsUseCase,
 )
 from retail.broadcasts.usecases.list_broadcast_dispatches import (
     ListBroadcastDispatchesDTO,
@@ -105,6 +111,31 @@ class _BroadcastReportBaseView(KeycloakAPIView):
             status=status.HTTP_200_OK,
         )
 
+    def _build_payment_recovery_conversion_response(
+        self,
+        request: Request,
+        *,
+        project_uuid: UUID,
+        integrated_agent_uuid: Optional[UUID] = None,
+    ) -> Response:
+        query_serializer = GetPaymentRecoveryConversionMetricsQuerySerializer(
+            data=request.query_params
+        )
+        query_serializer.is_valid(raise_exception=True)
+        validated = query_serializer.validated_data
+
+        dto = GetPaymentRecoveryConversionMetricsDTO(
+            project_uuid=project_uuid,
+            integrated_agent_uuid=integrated_agent_uuid,
+            start_date=validated["start_date"],
+            end_date=validated["end_date"],
+        )
+        result = GetPaymentRecoveryConversionMetricsUseCase().execute(dto)
+        return Response(
+            PaymentRecoveryConversionMetricsSerializer(result).data,
+            status=status.HTTP_200_OK,
+        )
+
 
 class BroadcastProjectDispatchesView(_BroadcastReportBaseView):
     """GET ``/api/v3/broadcasts/projects/dispatches/`` — project-wide report."""
@@ -165,6 +196,28 @@ class BroadcastAgentSummaryView(_BroadcastAgentReportBaseView):
     def get(self, request: Request, agent_uuid: UUID) -> Response:
         integrated_agent = self._get_integrated_agent(request, agent_uuid)
         return self._build_summary_response(
+            request,
+            project_uuid=integrated_agent.project.uuid,
+            integrated_agent_uuid=integrated_agent.uuid,
+        )
+
+
+class BroadcastProjectPaymentRecoveryConversionView(_BroadcastReportBaseView):
+    """GET ``/api/v3/broadcasts/projects/payment-recovery/conversion/``."""
+
+    def get(self, request: Request) -> Response:
+        return self._build_payment_recovery_conversion_response(
+            request,
+            project_uuid=self._parse_project_uuid(request),
+        )
+
+
+class BroadcastAgentPaymentRecoveryConversionView(_BroadcastAgentReportBaseView):
+    """GET ``/api/v3/broadcasts/assigneds/{agent_uuid}/payment-recovery/conversion/``."""
+
+    def get(self, request: Request, agent_uuid: UUID) -> Response:
+        integrated_agent = self._get_integrated_agent(request, agent_uuid)
+        return self._build_payment_recovery_conversion_response(
             request,
             project_uuid=integrated_agent.project.uuid,
             integrated_agent_uuid=integrated_agent.uuid,

--- a/retail/broadcasts/tests/test_broadcast_report_views.py
+++ b/retail/broadcasts/tests/test_broadcast_report_views.py
@@ -1,10 +1,12 @@
 """End-to-end tests for broadcast report APIs."""
 
+from decimal import Decimal
 from uuid import uuid4
 
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -22,6 +24,7 @@ from retail.projects.models import Project
 
 
 User = get_user_model()
+PAYMENT_RECOVERY_AGENT_UUID = str(uuid4())
 
 
 @with_test_settings
@@ -282,6 +285,171 @@ class BroadcastReportViewsTest(BaseTestMixin, APITestCase):
     def test_agent_dispatches_returns_404_for_unknown_agent(self):
         unknown_url = reverse(
             "broadcast-agent-dispatches",
+            kwargs={"agent_uuid": str(uuid4())},
+        )
+
+        response = self._get(
+            unknown_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+@with_test_settings
+@override_settings(PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_AGENT_UUID)
+class BroadcastPaymentRecoveryConversionViewsTest(BaseTestMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions={"project_authorization": 2},
+        )
+
+        self.project = Project.objects.create(name="Project A", uuid=uuid4())
+        self.other_project = Project.objects.create(name="Project B", uuid=uuid4())
+        self.agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_AGENT_UUID,
+            name="Whatsapp Payment Recovery",
+            slug="payment-recovery",
+            description="",
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+        self.second_integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+
+        self.user = User.objects.create_user(
+            username="payment-recovery-tester",
+            password="x",
+            email="payment-recovery@example.com",
+        )
+        self.client.force_authenticate(self.user)
+
+        self.project_conversion_url = reverse(
+            "broadcast-project-payment-recovery-conversion"
+        )
+        self.agent_conversion_url = reverse(
+            "broadcast-agent-payment-recovery-conversion",
+            kwargs={"agent_uuid": str(self.integrated_agent.uuid)},
+        )
+        today = timezone.localdate()
+        start_date = today - timedelta(days=1)
+        end_date = today + timedelta(days=1)
+        self.query = (
+            f"start_date={start_date.isoformat()}&end_date={end_date.isoformat()}"
+        )
+
+    def _get(self, url, *, project_uuid=None, query=None):
+        headers = {"HTTP_AUTHORIZATION": "Bearer token"}
+        if project_uuid is not None:
+            headers["HTTP_PROJECT_UUID"] = str(project_uuid)
+        full_url = url
+        if query:
+            full_url = f"{url}?{query}"
+        return self.client.get(full_url, **headers)
+
+    def test_project_payment_recovery_conversion_returns_metrics(self):
+        broadcast = BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511888888888",
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-99",
+        )
+        BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511777777777",
+            status=BroadcastStatus.QUEUED,
+            order_id="order-queued",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            broadcast=broadcast,
+            order_id="order-99",
+            value=Decimal("150.00"),
+        )
+
+        response = self._get(
+            self.project_conversion_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_dispatches"], 1)
+        self.assertEqual(response.data["converted_payments"], 1)
+        self.assertEqual(str(response.data["conversion_rate"]), "100.00")
+        self.assertEqual(str(response.data["recovered_revenue"]), "150.00")
+        self.assertEqual(str(response.data["average_ticket"]), "150.00")
+
+    def test_project_payment_recovery_conversion_requires_project_header(self):
+        response = self._get(self.project_conversion_url, query=self.query)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_agent_payment_recovery_conversion_returns_only_matching_agent_rows(self):
+        broadcast = BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511666666666",
+            status=BroadcastStatus.SENT,
+            order_id="order-agent",
+        )
+        BroadcastMessage.objects.create(
+            project=self.project,
+            integrated_agent=self.second_integrated_agent,
+            template_name="payment_recovery",
+            contact_urn="whatsapp:5511555555555",
+            status=BroadcastStatus.SENT,
+            order_id="order-other-agent",
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            broadcast=broadcast,
+            order_id="order-agent",
+            value=Decimal("80.00"),
+        )
+
+        response = self._get(
+            self.agent_conversion_url,
+            project_uuid=self.project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_dispatches"], 1)
+        self.assertEqual(response.data["converted_payments"], 1)
+        self.assertEqual(str(response.data["recovered_revenue"]), "80.00")
+
+    def test_agent_payment_recovery_conversion_rejects_agent_from_other_project(self):
+        response = self._get(
+            self.agent_conversion_url,
+            project_uuid=self.other_project.uuid,
+            query=self.query,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_agent_payment_recovery_conversion_returns_404_for_unknown_agent(self):
+        unknown_url = reverse(
+            "broadcast-agent-payment-recovery-conversion",
             kwargs={"agent_uuid": str(uuid4())},
         )
 

--- a/retail/broadcasts/tests/test_get_payment_recovery_conversion_metrics.py
+++ b/retail/broadcasts/tests/test_get_payment_recovery_conversion_metrics.py
@@ -1,0 +1,310 @@
+"""Tests for ``GetPaymentRecoveryConversionMetricsUseCase``."""
+
+from datetime import datetime, timedelta, timezone as dt_timezone
+from decimal import Decimal
+from uuid import uuid4
+
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.broadcasts.models import (
+    BroadcastConversion,
+    BroadcastMessage,
+    BroadcastStatus,
+)
+from retail.broadcasts.usecases.get_payment_recovery_conversion_metrics import (
+    CACHE_KEY_TEMPLATE,
+    CURRENT_DAY_CACHE_TTL_SECONDS,
+    HISTORICAL_CACHE_TTL_SECONDS,
+    GetPaymentRecoveryConversionMetricsDTO,
+    GetPaymentRecoveryConversionMetricsUseCase,
+)
+from retail.projects.models import Project
+
+PAYMENT_RECOVERY_AGENT_UUID = str(uuid4())
+OTHER_AGENT_UUID = str(uuid4())
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "payment-recovery-metrics-tests",
+        }
+    },
+    PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_AGENT_UUID,
+)
+class GetPaymentRecoveryConversionMetricsUseCaseTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.project = Project.objects.create(name="Project A", uuid=uuid4())
+        self.other_project = Project.objects.create(name="Project B", uuid=uuid4())
+        self.payment_recovery_agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_AGENT_UUID,
+            name="Whatsapp Payment Recovery",
+            slug="payment-recovery",
+            description="",
+            project=self.project,
+        )
+        self.other_agent = Agent.objects.create(
+            uuid=OTHER_AGENT_UUID,
+            name="Abandoned Cart",
+            slug="abandoned-cart",
+            description="",
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            agent=self.payment_recovery_agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+            config={"payment_recovery": {"delay_minutes": 5}},
+        )
+        self.other_integrated_agent = IntegratedAgent.objects.create(
+            agent=self.payment_recovery_agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+            config={"payment_recovery": {"delay_minutes": 10}},
+        )
+        self.non_payment_recovery_integrated_agent = IntegratedAgent.objects.create(
+            agent=self.other_agent,
+            project=self.project,
+            channel_uuid=uuid4(),
+        )
+        self.use_case = GetPaymentRecoveryConversionMetricsUseCase()
+        today = timezone.localdate()
+        self.start_date = today - timedelta(days=1)
+        self.end_date = today + timedelta(days=1)
+
+    def tearDown(self):
+        cache.clear()
+
+    def _create_broadcast(
+        self,
+        *,
+        integrated_agent=None,
+        status=BroadcastStatus.DELIVERED,
+        **overrides,
+    ):
+        defaults = {
+            "project": self.project,
+            "integrated_agent": integrated_agent or self.integrated_agent,
+            "template_name": "payment_recovery",
+            "contact_urn": "whatsapp:5511999999999",
+            "status": status,
+            "order_id": f"order-{uuid4()}",
+        }
+        defaults.update(overrides)
+        return BroadcastMessage.objects.create(**defaults)
+
+    def _execute(self, **overrides):
+        dto = GetPaymentRecoveryConversionMetricsDTO(
+            project_uuid=self.project.uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            **overrides,
+        )
+        return self.use_case.execute(dto)
+
+    def test_returns_conversion_metrics_for_payment_recovery_dispatches(self):
+        broadcast_one = self._create_broadcast(status=BroadcastStatus.DELIVERED)
+        broadcast_two = self._create_broadcast(
+            integrated_agent=self.integrated_agent,
+            status=BroadcastStatus.SENT,
+            order_id="order-sent",
+        )
+        self._create_broadcast(status=BroadcastStatus.QUEUED, order_id="order-queued")
+        self._create_broadcast(status=BroadcastStatus.FAILED, order_id="order-failed")
+        self._create_broadcast(
+            integrated_agent=self.non_payment_recovery_integrated_agent,
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-other-agent",
+        )
+
+        converted_at = timezone.now()
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            broadcast=broadcast_one,
+            order_id=broadcast_one.order_id,
+            value=Decimal("100.00"),
+            converted_at=converted_at,
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            broadcast=broadcast_two,
+            order_id=broadcast_two.order_id,
+            value=Decimal("200.00"),
+            converted_at=converted_at + timedelta(hours=1),
+        )
+
+        result = self._execute()
+
+        self.assertEqual(result.total_dispatches, 2)
+        self.assertEqual(result.converted_payments, 2)
+        self.assertEqual(result.conversion_rate, Decimal("100.00"))
+        self.assertEqual(result.recovered_revenue, Decimal("300.00"))
+        self.assertEqual(result.average_ticket, Decimal("150.00"))
+        self.assertIsNotNone(result.first_conversion_at)
+        self.assertIsNotNone(result.last_conversion_at)
+        self.assertLessEqual(result.first_conversion_at, result.last_conversion_at)
+
+    def test_excludes_other_agents_and_out_of_range_rows(self):
+        self._create_broadcast(status=BroadcastStatus.DELIVERED)
+        self._create_broadcast(
+            integrated_agent=self.other_integrated_agent,
+            status=BroadcastStatus.DELIVERED,
+            order_id="other-delay",
+        )
+        out_of_range = self._create_broadcast(
+            status=BroadcastStatus.DELIVERED,
+            order_id="old-order",
+        )
+        BroadcastMessage.objects.filter(pk=out_of_range.pk).update(
+            created_at=datetime.combine(
+                self.start_date - timedelta(days=30),
+                datetime.min.time(),
+                tzinfo=dt_timezone.utc,
+            )
+        )
+
+        result = self._execute(integrated_agent_uuid=self.integrated_agent.uuid)
+
+        self.assertEqual(result.total_dispatches, 1)
+        self.assertEqual(result.converted_payments, 0)
+        self.assertEqual(result.conversion_rate, Decimal("0"))
+        self.assertEqual(result.recovered_revenue, Decimal("0"))
+        self.assertIsNone(result.average_ticket)
+
+    def test_aggregates_all_payment_recovery_agents_when_uuid_is_omitted(self):
+        self._create_broadcast(
+            integrated_agent=self.integrated_agent,
+            status=BroadcastStatus.DELIVERED,
+            order_id="order-a",
+        )
+        self._create_broadcast(
+            integrated_agent=self.other_integrated_agent,
+            status=BroadcastStatus.READ,
+            order_id="order-b",
+        )
+
+        result = self._execute()
+
+        self.assertEqual(result.total_dispatches, 2)
+
+    def test_returns_zeros_when_payment_recovery_agent_is_not_configured(self):
+        with override_settings(PAYMENT_RECOVERY_AGENT_UUID=""):
+            result = self._execute()
+
+        self.assertEqual(result.total_dispatches, 0)
+        self.assertEqual(result.converted_payments, 0)
+        self.assertEqual(result.recovered_revenue, Decimal("0"))
+
+    def test_uses_cache_for_historical_date_ranges(self):
+        historical_end = timezone.localdate() - timedelta(days=2)
+        historical_start = historical_end - timedelta(days=7)
+        broadcast = self._create_broadcast(status=BroadcastStatus.DELIVERED)
+        BroadcastMessage.objects.filter(pk=broadcast.pk).update(
+            created_at=datetime.combine(
+                historical_end,
+                datetime.min.time(),
+                tzinfo=dt_timezone.utc,
+            )
+        )
+
+        dto = GetPaymentRecoveryConversionMetricsDTO(
+            project_uuid=self.project.uuid,
+            start_date=historical_start,
+            end_date=historical_end,
+        )
+        first_result = self.use_case.execute(dto)
+        self.assertEqual(first_result.total_dispatches, 1)
+        BroadcastMessage.objects.all().delete()
+        second_result = self.use_case.execute(dto)
+
+        self.assertEqual(first_result, second_result)
+        cache_key = CACHE_KEY_TEMPLATE.format(
+            project_uuid=self.project.uuid,
+            agent_scope="all",
+            start_date=historical_start.isoformat(),
+            end_date=historical_end.isoformat(),
+        )
+        self.assertIsNotNone(cache.get(cache_key))
+
+    def test_uses_short_cache_when_date_range_includes_today(self):
+        self._create_broadcast(status=BroadcastStatus.DELIVERED)
+
+        first_result = self._execute()
+        BroadcastMessage.objects.all().delete()
+        second_result = self._execute()
+
+        self.assertEqual(first_result, second_result)
+        cache_key = CACHE_KEY_TEMPLATE.format(
+            project_uuid=self.project.uuid,
+            agent_scope="all",
+            start_date=self.start_date.isoformat(),
+            end_date=self.end_date.isoformat(),
+        )
+        self.assertIsNotNone(cache.get(cache_key))
+
+    @patch(
+        "retail.broadcasts.usecases.get_payment_recovery_conversion_metrics.cache.set"
+    )
+    def test_uses_one_minute_ttl_for_current_day_ranges(self, mock_cache_set):
+        self._create_broadcast(status=BroadcastStatus.DELIVERED)
+        self._execute()
+
+        mock_cache_set.assert_called_once()
+        self.assertEqual(
+            mock_cache_set.call_args.kwargs["timeout"], CURRENT_DAY_CACHE_TTL_SECONDS
+        )
+
+    @patch(
+        "retail.broadcasts.usecases.get_payment_recovery_conversion_metrics.cache.set"
+    )
+    def test_uses_long_ttl_for_historical_ranges(self, mock_cache_set):
+        historical_end = timezone.localdate() - timedelta(days=2)
+        historical_start = historical_end - timedelta(days=7)
+        dto = GetPaymentRecoveryConversionMetricsDTO(
+            project_uuid=self.project.uuid,
+            start_date=historical_start,
+            end_date=historical_end,
+        )
+        self.use_case.execute(dto)
+
+        mock_cache_set.assert_called_once()
+        self.assertEqual(
+            mock_cache_set.call_args.kwargs["timeout"], HISTORICAL_CACHE_TTL_SECONDS
+        )
+
+    def test_only_counts_conversions_linked_to_filtered_dispatches(self):
+        in_range_broadcast = self._create_broadcast(status=BroadcastStatus.DELIVERED)
+        self._create_broadcast(
+            status=BroadcastStatus.DELIVERED, order_id="no-conversion"
+        )
+
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            broadcast=in_range_broadcast,
+            order_id=in_range_broadcast.order_id,
+            value=Decimal("50.00"),
+        )
+        BroadcastConversion.objects.create(
+            project=self.project,
+            integrated_agent=self.integrated_agent,
+            order_id="orphan-order",
+            value=Decimal("999.00"),
+        )
+
+        result = self._execute()
+
+        self.assertEqual(result.total_dispatches, 2)
+        self.assertEqual(result.converted_payments, 1)
+        self.assertEqual(result.conversion_rate, Decimal("50.00"))
+        self.assertEqual(result.recovered_revenue, Decimal("50.00"))

--- a/retail/broadcasts/usecases/get_payment_recovery_conversion_metrics.py
+++ b/retail/broadcasts/usecases/get_payment_recovery_conversion_metrics.py
@@ -1,0 +1,237 @@
+"""Use case: payment recovery conversion metrics for copy-pix automation."""
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone as dt_timezone
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Optional
+from uuid import UUID
+
+from django.conf import settings
+from django.core.cache import cache
+from django.db.models import Count, DecimalField, Max, Min, Sum
+from django.db.models.functions import Coalesce
+
+from retail.broadcasts.models import BroadcastMessage, BroadcastStatus
+
+CACHE_KEY_TEMPLATE = (
+    "broadcasts:payment_recovery_metrics:{project_uuid}:{agent_scope}:"
+    "{start_date}:{end_date}"
+)
+# Closed date ranges (end_date strictly before today UTC) are stable — cache longer.
+HISTORICAL_CACHE_TTL_SECONDS = 3600
+# Ranges that include today may still change; short TTL coalesces burst traffic.
+CURRENT_DAY_CACHE_TTL_SECONDS = 60
+
+_EXCLUDED_DISPATCH_STATUSES = (
+    BroadcastStatus.QUEUED,
+    BroadcastStatus.FAILED,
+)
+_TWO_DECIMAL_PLACES = Decimal("0.01")
+
+
+@dataclass(frozen=True)
+class GetPaymentRecoveryConversionMetricsDTO:
+    """Input for ``GetPaymentRecoveryConversionMetricsUseCase``.
+
+    Metrics are scoped to payment-recovery dispatches whose
+    ``created_at`` falls within the inclusive UTC calendar range.
+    When ``integrated_agent_uuid`` is set, results are further
+    restricted to that integrated agent.
+    """
+
+    project_uuid: UUID
+    start_date: date
+    end_date: date
+    integrated_agent_uuid: Optional[UUID] = None
+
+
+@dataclass(frozen=True)
+class PaymentRecoveryConversionMetricsResult:
+    total_dispatches: int
+    converted_payments: int
+    conversion_rate: Decimal
+    recovered_revenue: Decimal
+    average_ticket: Optional[Decimal]
+    first_conversion_at: Optional[datetime]
+    last_conversion_at: Optional[datetime]
+
+
+class GetPaymentRecoveryConversionMetricsUseCase:
+    """Return payment-recovery conversion metrics aligned with PM analytics.
+
+    Dispatch denominator: ``BroadcastMessage`` rows whose status is not
+    ``queued`` or ``failed`` and whose ``created_at`` is in range.
+    Conversion numerator: distinct ``BroadcastConversion`` rows linked to
+    those dispatches via ``broadcast_id`` (last-touch attribution).
+    """
+
+    def execute(
+        self, dto: GetPaymentRecoveryConversionMetricsDTO
+    ) -> PaymentRecoveryConversionMetricsResult:
+        cache_ttl = self._resolve_cache_ttl(dto.end_date)
+        cache_key = self._build_cache_key(dto)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return self._deserialize(cached)
+
+        result = self._compute(dto)
+        cache.set(cache_key, self._serialize(result), timeout=cache_ttl)
+        return result
+
+    def _compute(
+        self, dto: GetPaymentRecoveryConversionMetricsDTO
+    ) -> PaymentRecoveryConversionMetricsResult:
+        payment_recovery_agent_uuid = getattr(
+            settings, "PAYMENT_RECOVERY_AGENT_UUID", ""
+        )
+        if not payment_recovery_agent_uuid:
+            return self._empty_result()
+
+        start_dt = datetime.combine(dto.start_date, time.min, tzinfo=dt_timezone.utc)
+        end_dt = datetime.combine(dto.end_date, time.max, tzinfo=dt_timezone.utc)
+
+        queryset = BroadcastMessage.objects.filter(
+            project__uuid=dto.project_uuid,
+            integrated_agent__agent_id=payment_recovery_agent_uuid,
+            created_at__range=(start_dt, end_dt),
+        ).exclude(status__in=_EXCLUDED_DISPATCH_STATUSES)
+
+        if dto.integrated_agent_uuid is not None:
+            queryset = queryset.filter(integrated_agent__uuid=dto.integrated_agent_uuid)
+
+        aggregates = queryset.aggregate(
+            total_dispatches=Count("id", distinct=True),
+            converted_payments=Count("conversions", distinct=True),
+            recovered_revenue=Coalesce(
+                Sum("conversions__value"),
+                Decimal("0"),
+                output_field=DecimalField(max_digits=14, decimal_places=2),
+            ),
+            first_conversion_at=Min("conversions__converted_at"),
+            last_conversion_at=Max("conversions__converted_at"),
+        )
+
+        total_dispatches = aggregates["total_dispatches"] or 0
+        converted_payments = aggregates["converted_payments"] or 0
+        recovered_revenue = aggregates["recovered_revenue"] or Decimal("0")
+
+        return PaymentRecoveryConversionMetricsResult(
+            total_dispatches=total_dispatches,
+            converted_payments=converted_payments,
+            conversion_rate=self._calculate_conversion_rate(
+                converted_payments, total_dispatches
+            ),
+            recovered_revenue=recovered_revenue,
+            average_ticket=self._calculate_average_ticket(
+                recovered_revenue, converted_payments
+            ),
+            first_conversion_at=aggregates["first_conversion_at"],
+            last_conversion_at=aggregates["last_conversion_at"],
+        )
+
+    @staticmethod
+    def _calculate_conversion_rate(
+        converted_payments: int, total_dispatches: int
+    ) -> Decimal:
+        if total_dispatches == 0:
+            return Decimal("0")
+        rate = Decimal(converted_payments) / Decimal(total_dispatches) * Decimal("100")
+        return rate.quantize(_TWO_DECIMAL_PLACES, rounding=ROUND_HALF_UP)
+
+    @staticmethod
+    def _calculate_average_ticket(
+        recovered_revenue: Decimal, converted_payments: int
+    ) -> Optional[Decimal]:
+        if converted_payments == 0:
+            return None
+        average = recovered_revenue / Decimal(converted_payments)
+        return average.quantize(_TWO_DECIMAL_PLACES, rounding=ROUND_HALF_UP)
+
+    @staticmethod
+    def _empty_result() -> PaymentRecoveryConversionMetricsResult:
+        return PaymentRecoveryConversionMetricsResult(
+            total_dispatches=0,
+            converted_payments=0,
+            conversion_rate=Decimal("0"),
+            recovered_revenue=Decimal("0"),
+            average_ticket=None,
+            first_conversion_at=None,
+            last_conversion_at=None,
+        )
+
+    @staticmethod
+    def _resolve_cache_ttl(end_date: date) -> int:
+        """Return cache TTL based on whether the range includes today (UTC).
+
+        Past-only ranges use a long TTL because metrics are stable.
+        Ranges reaching today use a short TTL to limit staleness while
+        still coalescing repeated dashboard refreshes.
+        """
+        today_utc = datetime.now(dt_timezone.utc).date()
+        if end_date >= today_utc:
+            return CURRENT_DAY_CACHE_TTL_SECONDS
+        return HISTORICAL_CACHE_TTL_SECONDS
+
+    @staticmethod
+    def _build_cache_key(dto: GetPaymentRecoveryConversionMetricsDTO) -> str:
+        agent_scope = (
+            str(dto.integrated_agent_uuid)
+            if dto.integrated_agent_uuid is not None
+            else "all"
+        )
+        return CACHE_KEY_TEMPLATE.format(
+            project_uuid=dto.project_uuid,
+            agent_scope=agent_scope,
+            start_date=dto.start_date.isoformat(),
+            end_date=dto.end_date.isoformat(),
+        )
+
+    @staticmethod
+    def _serialize(result: PaymentRecoveryConversionMetricsResult) -> dict[str, Any]:
+        return {
+            "total_dispatches": result.total_dispatches,
+            "converted_payments": result.converted_payments,
+            "conversion_rate": str(result.conversion_rate),
+            "recovered_revenue": str(result.recovered_revenue),
+            "average_ticket": (
+                str(result.average_ticket)
+                if result.average_ticket is not None
+                else None
+            ),
+            "first_conversion_at": (
+                result.first_conversion_at.isoformat()
+                if result.first_conversion_at is not None
+                else None
+            ),
+            "last_conversion_at": (
+                result.last_conversion_at.isoformat()
+                if result.last_conversion_at is not None
+                else None
+            ),
+        }
+
+    @staticmethod
+    def _deserialize(payload: dict[str, Any]) -> PaymentRecoveryConversionMetricsResult:
+        first_conversion_at = payload.get("first_conversion_at")
+        last_conversion_at = payload.get("last_conversion_at")
+        average_ticket = payload.get("average_ticket")
+
+        return PaymentRecoveryConversionMetricsResult(
+            total_dispatches=payload["total_dispatches"],
+            converted_payments=payload["converted_payments"],
+            conversion_rate=Decimal(payload["conversion_rate"]),
+            recovered_revenue=Decimal(payload["recovered_revenue"]),
+            average_ticket=(
+                Decimal(average_ticket) if average_ticket is not None else None
+            ),
+            first_conversion_at=(
+                datetime.fromisoformat(first_conversion_at)
+                if first_conversion_at is not None
+                else None
+            ),
+            last_conversion_at=(
+                datetime.fromisoformat(last_conversion_at)
+                if last_conversion_at is not None
+                else None
+            ),
+        )


### PR DESCRIPTION
## What

Adds two GET endpoints under `/api/v3/broadcasts/` to return payment
recovery (copy PIX) conversion metrics aligned with PM analytics:

- `projects/payment-recovery/conversion/` — project-wide
- `assigneds/{agent_uuid}/payment-recovery/conversion/` — agent-scoped

Response fields: `total_dispatches`, `converted_payments`, `conversion_rate`,
`recovered_revenue`, `average_ticket`, `first_conversion_at`, `last_conversion_at`.

Filters: `start_date` / `end_date` (query), `Project-Uuid` (header), optional
agent UUID (path). A single ORM aggregate query computes all metrics. Results
are cached with a dynamic TTL (1 hour for closed historical ranges, 1 minute
when the range includes today UTC).

## Why

Existing dispatch/summary APIs do not expose recovered revenue, conversion
rate, or payment-recovery-specific attribution. Product needs a dashboard-ready
endpoint that mirrors the SQL logic without direct database access.
