### PR TITLE
fix: Mark content base progress complete when crawl fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.47.1
+- fix: Mark content base progress complete when crawl fails
+
 # 5.47.0
 - feat: Add Sentry fingerprint and tags for structured error grouping
 - fix: Persist store URL locally before abandoned cart template creation

--- a/retail/projects/tests/test_content_base_progress_helpers.py
+++ b/retail/projects/tests/test_content_base_progress_helpers.py
@@ -10,6 +10,7 @@ from retail.projects.usecases.content_base_progress_helpers import (
     STATUS_UPLOADING,
     compute_overall_percent,
     compute_upload_percent,
+    mark_content_base_complete_with_no_files,
     persist_content_base_progress,
 )
 
@@ -117,3 +118,24 @@ class TestPersistContentBaseProgress(TestCase):
         self.assertEqual(snapshot["crawl_percent"], 100)
         self.assertEqual(snapshot["upload_percent"], 50)
         self.assertEqual(snapshot["total_files"], 2)
+
+
+class TestMarkContentBaseCompleteWithNoFiles(TestCase):
+    def setUp(self):
+        self.onboarding = ProjectOnboarding.objects.create(
+            vtex_account="mystore",
+            config={"vtex_host_store": "https://www.mystore.com/"},
+        )
+
+    def test_marks_progress_complete_with_zero_files(self):
+        mark_content_base_complete_with_no_files(self.onboarding)
+
+        self.onboarding.refresh_from_db()
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["status"], STATUS_COMPLETE)
+        self.assertEqual(snapshot["crawl_percent"], 100)
+        self.assertEqual(snapshot["upload_percent"], 100)
+        self.assertEqual(snapshot["total_files"], 0)
+        self.assertEqual(
+            self.onboarding.config["vtex_host_store"], "https://www.mystore.com/"
+        )

--- a/retail/projects/tests/test_start_crawl.py
+++ b/retail/projects/tests/test_start_crawl.py
@@ -69,6 +69,12 @@ class TestStartCrawlUseCase(TestCase):
         self.assertEqual(called_args[0], "mystore")
         self.assertEqual(called_args[1], "crawler_start")
 
+        snapshot = self.onboarding.config["content_base_progress"]
+        self.assertEqual(snapshot["status"], "complete")
+        self.assertEqual(snapshot["crawl_percent"], 100)
+        self.assertEqual(snapshot["upload_percent"], 100)
+        self.assertEqual(snapshot["total_files"], 0)
+
     def test_build_webhook_url(self):
         onboarding_uuid = str(uuid4())
         url = StartCrawlUseCase._build_webhook_url(onboarding_uuid)

--- a/retail/projects/tests/test_update_onboarding_progress.py
+++ b/retail/projects/tests/test_update_onboarding_progress.py
@@ -171,7 +171,13 @@ class TestUpdateOnboardingProgressUseCase(TestCase):
         )
         self.onboarding.refresh_from_db()
         self.assertEqual(
-            self.onboarding.config["content_base_progress"]["status"], "failed"
+            self.onboarding.config["content_base_progress"]["status"], "complete"
+        )
+        self.assertEqual(
+            self.onboarding.config["content_base_progress"]["crawl_percent"], 100
+        )
+        self.assertEqual(
+            self.onboarding.config["content_base_progress"]["upload_percent"], 100
         )
 
     # ── URL redirected event ───────────────────────────────────────

--- a/retail/projects/usecases/content_base_progress_helpers.py
+++ b/retail/projects/usecases/content_base_progress_helpers.py
@@ -56,3 +56,19 @@ def persist_content_base_progress(onboarding: ProjectOnboarding, **updates) -> N
     config["content_base_progress"] = snapshot
     onboarding.config = config
     onboarding.save(update_fields=["config"])
+
+
+def mark_content_base_complete_with_no_files(onboarding: ProjectOnboarding) -> None:
+    """
+    Marks content-base progress as done when there is nothing to upload.
+
+    Used for empty crawl results and crawl failures (start or webhook):
+    the content base has no work left, so clients should see 100%.
+    """
+    persist_content_base_progress(
+        onboarding,
+        crawl_percent=100,
+        upload_percent=100,
+        status=STATUS_COMPLETE,
+        total_files=0,
+    )

--- a/retail/projects/usecases/start_crawl.py
+++ b/retail/projects/usecases/start_crawl.py
@@ -5,6 +5,9 @@ from django.conf import settings
 from retail.clients.crawler.client import CrawlerClient
 from retail.interfaces.clients.crawler.client import CrawlerClientInterface
 from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.content_base_progress_helpers import (
+    mark_content_base_complete_with_no_files,
+)
 from retail.projects.usecases.manager_defaults import get_manager_defaults
 from retail.projects.usecases.onboarding_defaults import get_instructions
 from retail.projects.usecases.save_background_failure import (
@@ -72,6 +75,7 @@ class StartCrawlUseCase:
             SaveBackgroundFailureUseCase.execute(
                 vtex_account, "crawler_start", error_msg
             )
+            mark_content_base_complete_with_no_files(onboarding)
             logger.error(
                 f"Crawler start failed for vtex_account={vtex_account}: {error_msg}"
             )

--- a/retail/projects/usecases/update_onboarding_progress.py
+++ b/retail/projects/usecases/update_onboarding_progress.py
@@ -8,10 +8,9 @@ from retail.projects.tasks import (
     task_upload_nexus_contents,
 )
 from retail.projects.usecases.content_base_progress_helpers import (
-    STATUS_COMPLETE,
     STATUS_CRAWLING,
-    STATUS_FAILED,
     STATUS_UPLOADING,
+    mark_content_base_complete_with_no_files,
     persist_content_base_progress,
 )
 from retail.projects.usecases.onboarding_dto import CrawlerWebhookDTO
@@ -88,13 +87,7 @@ class UpdateOnboardingProgressUseCase:
         contents = dto.data.get("contents", [])
         total_files = len(contents)
         if total_files == 0:
-            persist_content_base_progress(
-                onboarding,
-                crawl_percent=100,
-                upload_percent=100,
-                status=STATUS_COMPLETE,
-                total_files=0,
-            )
+            mark_content_base_complete_with_no_files(onboarding)
         else:
             persist_content_base_progress(
                 onboarding,
@@ -132,6 +125,9 @@ class UpdateOnboardingProgressUseCase:
         decoupled from the background crawl outcome. The failure is
         persisted under ``config["background_error"]`` for ops
         visibility, and ``crawler_result`` is set to ``FAIL``.
+
+        Content-base progress is marked complete: with no crawl output
+        there is nothing left to upload.
         """
         onboarding.crawler_result = ProjectOnboarding.FAIL
         onboarding.save(update_fields=["crawler_result"])
@@ -140,7 +136,7 @@ class UpdateOnboardingProgressUseCase:
         SaveBackgroundFailureUseCase.execute(
             onboarding.vtex_account, "crawl", error_msg
         )
-        persist_content_base_progress(onboarding, status=STATUS_FAILED)
+        mark_content_base_complete_with_no_files(onboarding)
         logger.warning(
             f"Background crawl failed for onboarding={onboarding.uuid}: {error_msg}"
         )

--- a/retail/swagger.py
+++ b/retail/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Gallery API Documentation",
-        default_version="v5.47.0",
+        default_version="v5.47.1",
         description="Documentation of the Gallery APIs",
     ),
     public=True,


### PR DESCRIPTION
## What
Marks content-base progress as 100% complete when the crawl fails (start request or `crawl.failed` webhook), matching the existing empty-crawl behavior. Introduces `mark_content_base_complete_with_no_files` for the shared path.

## Why
A failed crawl produces nothing to upload, but progress stayed at 0% (start failure) or `status=failed` (webhook). Clients should treat the content-base phase as done.