### PR TITLE
fix: Skip already integrated passive agents on re-onboarding

### DIFF
--- a/retail/clients/nexus/client.py
+++ b/retail/clients/nexus/client.py
@@ -126,6 +126,24 @@ class NexusClient(RequestClient, NexusClientInterface):
         )
         return response.json()
 
+    def list_team_agents(self, project_uuid: str) -> Dict:
+        """
+        Lists agents integrated to a project, including shared/official agents
+        assigned from other projects (active and inactive).
+
+        Args:
+            project_uuid: The project's unique identifier.
+
+        Returns:
+            Dict with ``manager`` and ``agents`` keys.
+        """
+        url = f"{self.base_url}/api/agents/app-teams/{str(project_uuid)}"
+
+        response = self.make_request(
+            url, method="GET", headers=self.authentication_instance.headers
+        )
+        return response.json()
+
     def check_agent_builder_exists(self, project_uuid: str) -> Dict:
         """
         Checks whether the agent manager has been configured for a project.

--- a/retail/interfaces/clients/nexus/client.py
+++ b/retail/interfaces/clients/nexus/client.py
@@ -78,6 +78,19 @@ class NexusClientInterface(Protocol):
         """
         ...
 
+    def list_team_agents(self, project_uuid: str) -> Dict:
+        """
+        Lists agents integrated to a project, including shared/official agents
+        assigned from other projects (active and inactive).
+
+        Args:
+            project_uuid: The project's unique identifier.
+
+        Returns:
+            Dict with ``manager`` and ``agents`` keys.
+        """
+        ...
+
     def check_agent_builder_exists(self, project_uuid: str) -> Dict:
         """
         Checks whether the agent manager has been configured for a project.

--- a/retail/projects/tests/test_install_channel_agents.py
+++ b/retail/projects/tests/test_install_channel_agents.py
@@ -72,7 +72,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.list_team_agents.return_value = {"agents": []}
         self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
 
         self.usecase.execute(self._build_dto())
@@ -104,10 +104,12 @@ class TestInstallChannelAgentsUseCase(TestCase):
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = [
-            {"uuid": "uuid-1"},
-            {"uuid": "uuid-3"},
-        ]
+        self.usecase.nexus_service.list_team_agents.return_value = {
+            "agents": [
+                {"uuid": "uuid-1", "active": True},
+                {"uuid": "uuid-3", "active": True},
+            ]
+        }
         self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
 
         self.usecase.execute(self._build_dto())
@@ -128,10 +130,12 @@ class TestInstallChannelAgentsUseCase(TestCase):
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = [
-            {"uuid": "uuid-1"},
-            {"uuid": "uuid-2"},
-        ]
+        self.usecase.nexus_service.list_team_agents.return_value = {
+            "agents": [
+                {"uuid": "uuid-1", "active": True},
+                {"uuid": "uuid-2", "active": True},
+            ]
+        }
 
         self.usecase.execute(self._build_dto())
 
@@ -213,7 +217,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.list_team_agents.return_value = {"agents": []}
         self.usecase.nexus_service.integrate_agent.return_value = None
 
         with self.assertRaises(InstallChannelAgentsError) as ctx:
@@ -230,7 +234,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.list_team_agents.return_value = {"agents": []}
         self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
 
         self.usecase.execute(self._build_dto())
@@ -255,7 +259,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = None
+        self.usecase.nexus_service.list_team_agents.return_value = None
         self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
 
         self.usecase.execute(self._build_dto())
@@ -266,14 +270,15 @@ class TestInstallChannelAgentsUseCase(TestCase):
         "retail.projects.usecases.install_channel_agents.get_channel_agents",
         return_value=[StubAgent("uuid-1", "Agent A")],
     )
-    def test_handles_nexus_list_agents_with_results_key(self, _mock_agents):
-        """Handles Nexus response wrapped in a 'results' key."""
+    def test_handles_nexus_list_agents_with_team_response(self, _mock_agents):
+        """Handles Nexus app-teams response with shared passive agents."""
         self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = {
-            "results": [{"uuid": "uuid-1"}]
+        self.usecase.nexus_service.list_team_agents.return_value = {
+            "manager": {"uuid": "manager-uuid", "active": True},
+            "agents": [{"uuid": "uuid-1", "active": True}],
         }
 
         self.usecase.execute(self._build_dto())
@@ -306,7 +311,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.list_team_agents.return_value = {"agents": []}
         self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
 
         self.usecase.execute(self._build_dto())
@@ -340,7 +345,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
             "app_uuid": "wpp-app-uuid",
             "flow_object_uuid": "wpp-channel-uuid",
         }
-        self.usecase.nexus_service.list_integrated_agents.return_value = []
+        self.usecase.nexus_service.list_team_agents.return_value = {"agents": []}
         self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
 
         self.usecase.execute(self._build_dto())

--- a/retail/projects/tests/test_integrate_agents.py
+++ b/retail/projects/tests/test_integrate_agents.py
@@ -30,7 +30,7 @@ class TestIntegrateAgentsUseCase(TestCase):
             progress=75,
         )
         self.mock_nexus_service = MagicMock()
-        self.mock_nexus_service.list_integrated_agents.return_value = []
+        self.mock_nexus_service.list_team_agents.return_value = {"agents": []}
         self.usecase = IntegrateAgentsUseCase(nexus_client=MagicMock())
         self.usecase.nexus_service = self.mock_nexus_service
 
@@ -123,10 +123,12 @@ class TestIntegrateAgentsUseCase(TestCase):
         ],
     )
     def test_skips_already_integrated_agents(self, _mock_agents):
-        self.mock_nexus_service.list_integrated_agents.return_value = [
-            {"uuid": "uuid-1"},
-            {"uuid": "uuid-3"},
-        ]
+        self.mock_nexus_service.list_team_agents.return_value = {
+            "agents": [
+                {"uuid": "uuid-1", "active": True},
+                {"uuid": "uuid-3", "active": True},
+            ]
+        }
         self.mock_nexus_service.integrate_agent.return_value = {"ok": True}
 
         self.usecase.execute("mystore")
@@ -147,7 +149,7 @@ class TestIntegrateAgentsUseCase(TestCase):
     )
     def test_integrates_all_when_nexus_list_returns_none(self, _mock_agents):
         """When Nexus list fails, all agents should still be integrated."""
-        self.mock_nexus_service.list_integrated_agents.return_value = None
+        self.mock_nexus_service.list_team_agents.return_value = None
         self.mock_nexus_service.integrate_agent.return_value = {"ok": True}
 
         self.usecase.execute("mystore")

--- a/retail/projects/tests/test_integrated_agent_lookup.py
+++ b/retail/projects/tests/test_integrated_agent_lookup.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.projects.models import Project
+from retail.projects.usecases.onboarding_agents.integrated_agent_lookup import (
+    _extract_uuids_from_team_response,
+    get_integrated_agent_uuids,
+)
+
+
+class TestIntegratedAgentLookup(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+        self.mock_nexus_service = MagicMock()
+
+    def test_get_integrated_agent_uuids_from_team_agents(self):
+        self.mock_nexus_service.list_team_agents.return_value = {
+            "manager": {"uuid": "manager-uuid", "active": True},
+            "agents": [
+                {"uuid": "passive-1", "active": True},
+                {"uuid": "passive-2", "active": True},
+            ],
+        }
+
+        result = get_integrated_agent_uuids(
+            str(self.project.uuid), self.mock_nexus_service
+        )
+
+        self.assertEqual(result, {"passive-1", "passive-2"})
+        self.mock_nexus_service.list_team_agents.assert_called_once_with(
+            str(self.project.uuid)
+        )
+
+    def test_get_integrated_agent_uuids_includes_retail_active_agents(self):
+        retail_agent = Agent.objects.create(
+            uuid=uuid4(),
+            name="Active Agent",
+            slug="active",
+            description="",
+            project=self.project,
+        )
+        IntegratedAgent.objects.create(
+            agent=retail_agent,
+            project=self.project,
+            is_active=True,
+        )
+        self.mock_nexus_service.list_team_agents.return_value = {"agents": []}
+
+        result = get_integrated_agent_uuids(
+            str(self.project.uuid), self.mock_nexus_service
+        )
+
+        self.assertEqual(result, {str(retail_agent.uuid)})
+
+    def test_get_integrated_agent_uuids_returns_empty_when_team_lookup_fails(self):
+        self.mock_nexus_service.list_team_agents.return_value = None
+
+        result = get_integrated_agent_uuids(
+            str(self.project.uuid), self.mock_nexus_service
+        )
+
+        self.assertEqual(result, set())
+
+    def test_extract_uuids_includes_inactive_integrations(self):
+        response = {
+            "agents": [
+                {"uuid": "active-agent", "active": True},
+                {"uuid": "inactive-agent", "active": False},
+            ]
+        }
+
+        result = _extract_uuids_from_team_response(response)
+
+        self.assertEqual(result, {"active-agent", "inactive-agent"})

--- a/retail/projects/usecases/integrate_agents.py
+++ b/retail/projects/usecases/integrate_agents.py
@@ -35,7 +35,7 @@ class IntegrateAgentsUseCase:
     itself via its ``integrate(context, nexus_service)`` method.
 
     Agents already integrated in the project are detected via the
-    Nexus list and skipped to avoid duplicates.
+    Nexus app-teams list and skipped to avoid duplicates.
 
     Progress: 75% -> 100%.
     """

--- a/retail/projects/usecases/onboarding_agents/integrated_agent_lookup.py
+++ b/retail/projects/usecases/onboarding_agents/integrated_agent_lookup.py
@@ -2,7 +2,7 @@
 Shared lookup for agents already integrated in a project.
 
 Combines two sources to build a complete set of integrated agent UUIDs:
-  - Nexus API (passive agents toggled via app-assign)
+  - Nexus app-teams API (passive/shared agents toggled via app-assign)
   - Retail DB (active agents assigned via IntegratedAgent)
 
 Used by both IntegrateAgentsUseCase (onboarding flow) and
@@ -10,7 +10,7 @@ InstallChannelAgentsUseCase (post-onboarding channel addition)
 to skip agents that are already integrated.
 """
 
-from typing import Set
+from typing import Any, Dict, List, Set
 
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.services.nexus.service import NexusService
@@ -26,13 +26,28 @@ def get_integrated_agent_uuids(
 
 
 def _get_nexus_uuids(project_uuid: str, nexus_service: NexusService) -> Set[str]:
-    """Fetches UUIDs of passive agents integrated via Nexus."""
-    response = nexus_service.list_integrated_agents(project_uuid)
+    """Fetches UUIDs of agents integrated via Nexus app-assign.
+
+    Uses app-teams (not app-my-agents) because passive/official agents
+    belong to another project and only appear in the team integration list.
+    """
+    response = nexus_service.list_team_agents(project_uuid)
     if not response:
         return set()
 
-    agents = response if isinstance(response, list) else response.get("results", [])
-    return {str(agent.get("uuid", "")) for agent in agents if agent.get("uuid")}
+    return _extract_uuids_from_team_response(response)
+
+
+def _extract_uuids_from_team_response(response: Dict[str, Any]) -> Set[str]:
+    """Extracts agent UUIDs from app-teams, including inactive integrations.
+
+    app-teams returns every IntegratedAgent for the project (active or not).
+    We skip all of them to avoid re-assigning passives that were deliberately
+    deactivated; only agents with no Nexus link (e.g. after unassign) are
+    integrated again.
+    """
+    agents: List[Dict[str, Any]] = response.get("agents", [])
+    return {str(agent["uuid"]) for agent in agents if agent.get("uuid")}
 
 
 def _get_retail_uuids(project_uuid: str) -> Set[str]:

--- a/retail/services/nexus/service.py
+++ b/retail/services/nexus/service.py
@@ -87,6 +87,20 @@ class NexusService:
             )
             return None
 
+    def list_team_agents(self, project_uuid: str) -> Optional[Dict]:
+        """
+        Lists agents integrated with a project, including shared agents
+        (active and inactive).
+        """
+        try:
+            return self.nexus_client.list_team_agents(project_uuid)
+        except CustomAPIException as e:
+            logger.error(
+                f"Error {e.status_code} when listing team agents "
+                f"for project {project_uuid}."
+            )
+            return None
+
     def check_agent_builder_exists(self, project_uuid: str) -> Optional[Dict]:
         """
         Checks whether the agent manager has been configured for a project.

--- a/retail/services/tests/test_nexus.py
+++ b/retail/services/tests/test_nexus.py
@@ -104,6 +104,31 @@ class TestNexusService(TestCase):
         )
         self.assertIsNone(result)
 
+    def test_list_team_agents_success(self):
+        expected_response = {
+            "manager": {"uuid": "manager-uuid", "active": True},
+            "agents": [{"uuid": "passive-uuid", "active": True}],
+        }
+        self.mock_nexus_client.list_team_agents.return_value = expected_response
+
+        result = self.service.list_team_agents(self.project_uuid)
+
+        self.mock_nexus_client.list_team_agents.assert_called_once_with(
+            self.project_uuid
+        )
+        self.assertEqual(result, expected_response)
+
+    def test_list_team_agents_custom_api_exception(self):
+        exception = CustomAPIException(status_code=403, detail="Forbidden")
+        self.mock_nexus_client.list_team_agents.side_effect = exception
+
+        result = self.service.list_team_agents(self.project_uuid)
+
+        self.mock_nexus_client.list_team_agents.assert_called_once_with(
+            self.project_uuid
+        )
+        self.assertIsNone(result)
+
     def test_check_agent_builder_exists_success(self):
         expected = {"data": {"has_agent": True, "name": "Test Manager"}}
         self.mock_nexus_client.check_agent_builder_exists.return_value = expected


### PR DESCRIPTION
## What

When re-running onboarding on an existing linked project, passive agents
were being re-integrated because the idempotency check used Nexus
`GET /api/agents/app-my-agents/{project_uuid}`, which only lists agents
owned by the project — not official/shared passives integrated via
`app-assign` from another project.

This change adds `list_team_agents` (`GET /api/agents/app-teams/{project_uuid}`)
and updates `get_integrated_agent_uuids` to build the skip set from
`response["agents"][].uuid`, including inactive integrations so
deliberately deactivated passives are not reactivated on re-onboarding.

Affected flows: `IntegrateAgentsUseCase` and `InstallChannelAgentsUseCase`.

## Why

Re-onboarding an existing VTEX project was redundantly calling
`app-assign` for passive agents already linked in Nexus, causing
perceived duplication and unnecessary side effects in the integration flow.

