### PR TITLE
feat: Add optional merchant_name field to VtexProxySerializer and update related use cases

### DIFF
--- a/retail/vtex/serializers.py
+++ b/retail/vtex/serializers.py
@@ -44,6 +44,7 @@ class VtexProxySerializer(serializers.Serializer):
     headers = serializers.DictField(required=False, allow_null=True)
     data = serializers.JSONField(required=False, allow_null=True)
     params = serializers.DictField(required=False, allow_null=True)
+    merchant_name = serializers.CharField(required=False, allow_null=True)
 
 
 class LeadSerializer(serializers.Serializer):

--- a/retail/vtex/tests/test_vtex_proxy_serializer.py
+++ b/retail/vtex/tests/test_vtex_proxy_serializer.py
@@ -1,0 +1,50 @@
+from django.test import TestCase
+
+from retail.vtex.serializers import VtexProxySerializer
+
+
+class TestVtexProxySerializer(TestCase):
+    def test_valid_minimal_payload(self):
+        serializer = VtexProxySerializer(
+            data={"method": "GET", "path": "/api/oms/pvt/orders"}
+        )
+        self.assertTrue(serializer.is_valid())
+
+    def test_merchant_name_is_optional(self):
+        serializer = VtexProxySerializer(
+            data={"method": "GET", "path": "/api/oms/pvt/orders"}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("merchant_name"))
+
+    def test_accepts_merchant_name(self):
+        serializer = VtexProxySerializer(
+            data={
+                "method": "GET",
+                "path": "/api/oms/pvt/orders",
+                "merchant_name": "otherstore",
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["merchant_name"], "otherstore")
+
+    def test_merchant_name_accepts_null(self):
+        serializer = VtexProxySerializer(
+            data={
+                "method": "GET",
+                "path": "/api/oms/pvt/orders",
+                "merchant_name": None,
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("merchant_name"))
+
+    def test_method_is_required(self):
+        serializer = VtexProxySerializer(data={"path": "/some/path"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("method", serializer.errors)
+
+    def test_path_is_required(self):
+        serializer = VtexProxySerializer(data={"method": "GET"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("path", serializer.errors)

--- a/retail/vtex/tests/usecases/test_base_vtex_usecase.py
+++ b/retail/vtex/tests/usecases/test_base_vtex_usecase.py
@@ -1,0 +1,72 @@
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.projects.models import Project
+from retail.vtex.usecases.base import BaseVtexUseCase
+
+
+class _ConcreteVtexUseCase(BaseVtexUseCase):
+    """Minimal concrete subclass so BaseVtexUseCase can be exercised in tests."""
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test-vtex-context",
+        }
+    }
+)
+class BaseVtexUseCaseGetVtexContextTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.usecase = _ConcreteVtexUseCase()
+        self.project = Project.objects.create(
+            name="Test Project",
+            uuid=uuid4(),
+            vtex_account="fakeaccount",
+        )
+
+    def test_returns_project_account_and_domain(self):
+        vtex_account, domain = self.usecase._get_vtex_context(str(self.project.uuid))
+
+        self.assertEqual(vtex_account, "fakeaccount")
+        self.assertEqual(domain, "fakeaccount.myvtex.com")
+
+    def test_merchant_name_overrides_domain_only(self):
+        vtex_account, domain = self.usecase._get_vtex_context(
+            str(self.project.uuid), merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "fakeaccount")
+        self.assertEqual(domain, "otherstore.myvtex.com")
+
+    def test_cache_is_not_poisoned_by_merchant_override(self):
+        self.usecase._get_vtex_context(
+            str(self.project.uuid), merchant_name="otherstore"
+        )
+
+        vtex_account, domain = self.usecase._get_vtex_context(str(self.project.uuid))
+
+        self.assertEqual(vtex_account, "fakeaccount")
+        self.assertEqual(domain, "fakeaccount.myvtex.com")
+
+    def test_raises_when_project_not_found(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.usecase._get_vtex_context(str(uuid4()))
+
+        self.assertIn("Project not found", str(ctx.exception))
+
+    def test_raises_when_vtex_account_missing(self):
+        project = Project.objects.create(
+            name="No Account",
+            uuid=uuid4(),
+            vtex_account=None,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            self.usecase._get_vtex_context(str(project.uuid))
+
+        self.assertIn("VTEX account not defined", str(ctx.exception))

--- a/retail/vtex/tests/usecases/test_proxy_vtex.py
+++ b/retail/vtex/tests/usecases/test_proxy_vtex.py
@@ -24,8 +24,35 @@ class ProxyVtexUsecaseTest(TestCase):
         )
 
         self.assertEqual(result, {"ok": True})
+        mock_context.assert_called_once_with("project-uuid", merchant_name=None)
         self.mock_service.proxy_vtex.assert_called_once_with(
             account_domain="lojasrede.myvtex.com",
+            vtex_account="lojasrede",
+            method="GET",
+            path="/api/oms/pvt/orders",
+            headers=None,
+            data=None,
+            params=None,
+        )
+
+    @patch.object(ProxyVtexUsecase, "_get_vtex_context")
+    def test_execute_passes_merchant_name_to_context(self, mock_context):
+        mock_context.return_value = ("lojasrede", "otherstore.myvtex.com")
+        self.mock_service.proxy_vtex.return_value = {"ok": True}
+
+        result = self.usecase.execute(
+            method="GET",
+            path="/api/oms/pvt/orders",
+            project_uuid="project-uuid",
+            merchant_name="otherstore",
+        )
+
+        self.assertEqual(result, {"ok": True})
+        mock_context.assert_called_once_with(
+            "project-uuid", merchant_name="otherstore"
+        )
+        self.mock_service.proxy_vtex.assert_called_once_with(
+            account_domain="otherstore.myvtex.com",
             vtex_account="lojasrede",
             method="GET",
             path="/api/oms/pvt/orders",

--- a/retail/vtex/usecases/base.py
+++ b/retail/vtex/usecases/base.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Tuple
+from typing import Optional, Tuple
 
 from django.core.cache import cache
 from retail.projects.models import Project
@@ -13,9 +13,14 @@ class BaseVtexUseCase(ABC):
     Provides common utilities such as domain and account resolution from project UUID.
     """
 
-    def _get_vtex_context(self, project_uuid: str) -> Tuple[str, str]:
+    def _get_vtex_context(
+        self, project_uuid: str, merchant_name: Optional[str] = None
+    ) -> Tuple[str, str]:
         """
         Retrieves VTEX account and domain for a project (single DB hit, cached).
+
+        When merchant_name is provided, the returned domain uses that account name
+        while vtex_account remains the project's account (used for JWT auth).
 
         Returns:
             Tuple of (vtex_account, account_domain).
@@ -23,21 +28,26 @@ class BaseVtexUseCase(ABC):
         cache_key = f"project_vtex_context_{project_uuid}"
         cached = cache.get(cache_key)
         if cached:
-            return cached
+            vtex_account, _project_domain = cached
+        else:
+            try:
+                project = Project.objects.get(uuid=project_uuid)
+            except Project.DoesNotExist:
+                raise ValueError("Project not found for given UUID.")
 
-        try:
-            project = Project.objects.get(uuid=project_uuid)
-        except Project.DoesNotExist:
-            raise ValueError("Project not found for given UUID.")
+            if not project.vtex_account:
+                raise ValueError("VTEX account not defined for project.")
 
-        if not project.vtex_account:
-            raise ValueError("VTEX account not defined for project.")
+            vtex_account = project.vtex_account
+            project_domain = f"{vtex_account}.myvtex.com"
+            cache.set(
+                cache_key,
+                (vtex_account, project_domain),
+                timeout=VTEX_CONTEXT_CACHE_TTL,
+            )
 
-        vtex_account = project.vtex_account
-        domain = f"{vtex_account}.myvtex.com"
-        result = (vtex_account, domain)
-        cache.set(cache_key, result, timeout=VTEX_CONTEXT_CACHE_TTL)
-        return result
+        domain_account = merchant_name or vtex_account
+        return (vtex_account, f"{domain_account}.myvtex.com")
 
     def _get_account_domain(self, project_uuid: str) -> str:
         """Shortcut that returns only the domain."""

--- a/retail/vtex/usecases/proxy_vtex.py
+++ b/retail/vtex/usecases/proxy_vtex.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Optional, Union
 
 from rest_framework.exceptions import ValidationError
 
@@ -39,6 +39,7 @@ class ProxyVtexUsecase(BaseVtexUseCase):
         data: Union[dict, list] = None,
         params: dict = None,
         project_uuid: str = None,
+        merchant_name: Optional[str] = None,
     ) -> dict:
         """
         Execute the proxy VTEX use case.
@@ -50,6 +51,8 @@ class ProxyVtexUsecase(BaseVtexUseCase):
             data (Union[dict, list], optional): Request body data for POST, PUT, PATCH requests.
             params (dict, optional): Query parameters to be appended to the URL.
             project_uuid (str): Project UUID to get the account domain.
+            merchant_name (str, optional): Overrides only the account domain used in
+                the proxy URL; JWT auth still uses the project's vtex_account.
 
         Returns:
             dict: Response data from VTEX platform.
@@ -59,14 +62,17 @@ class ProxyVtexUsecase(BaseVtexUseCase):
             CustomAPIException: When the upstream VTEX IO request fails.
         """
         try:
-            vtex_account, account_domain = self._get_vtex_context(project_uuid)
+            vtex_account, account_domain = self._get_vtex_context(
+                project_uuid, merchant_name=merchant_name
+            )
         except ValueError as exc:
             logger.error(f"VTEX context error for project_uuid={project_uuid}: {exc}")
             raise ValidationError({"detail": str(exc)}) from exc
 
         logger.info(
             f"Proxying VTEX request: method={method} path={path} "
-            f"project_uuid={project_uuid} vtex_account={vtex_account}"
+            f"project_uuid={project_uuid} vtex_account={vtex_account} "
+            f"account_domain={account_domain}"
         )
 
         try:

--- a/retail/vtex/views.py
+++ b/retail/vtex/views.py
@@ -302,6 +302,7 @@ class VtexProxyView(BaseVtexProxyView):
             data=validated_data.get("data"),
             params=validated_data.get("params"),
             project_uuid=self.project_uuid,
+            merchant_name=validated_data.get("merchant_name"),
         )
 
         return Response(result, status=status.HTTP_200_OK)


### PR DESCRIPTION
### TL;DR

Adds optional `merchant_name` support to the VTEX proxy, allowing the proxy URL domain to be overridden without affecting JWT authentication credentials.

### What changed?

- `VtexProxySerializer` now accepts an optional, nullable `merchant_name` field.
- `BaseVtexUseCase._get_vtex_context` accepts an optional `merchant_name` parameter. When provided, the returned domain uses that merchant name (e.g. `otherstore.myvtex.com`) while `vtex_account` remains the project's own account for JWT auth. The cache is not affected by merchant name overrides, preventing cache poisoning.
- `ProxyVtexUsecase.execute` forwards `merchant_name` to `_get_vtex_context` and logs the resolved `account_domain`.
- The proxy view extracts `merchant_name` from the validated request payload and passes it to the use case.

### How to test?

1. Send a proxy request without `merchant_name` — behavior should be identical to before, resolving the domain from the project's `vtex_account`.
2. Send a proxy request with `merchant_name: "otherstore"` — the upstream VTEX call should target `otherstore.myvtex.com` while JWT auth still uses the project's account.
3. Send a request with `merchant_name: null` — should behave the same as omitting the field entirely.
4. Run the new unit tests:
   - `retail/vtex/tests/test_vtex_proxy_serializer.py`
   - `retail/vtex/tests/usecases/test_base_vtex_usecase.py`
   - `retail/vtex/tests/usecases/test_proxy_vtex.py`

### Why make this change?

Some VTEX marketplace setups require proxying requests to a seller or merchant domain that differs from the project's own VTEX account. This change enables that routing flexibility while keeping authentication tied to the project's account, and ensures the shared cache is never polluted by per-request merchant overrides.