### PR TITLE
feat: Enhance OnboardingPatchSerializer to save only updated fields and add test for concurrent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.48.1
+- feat: Enhance OnboardingPatchSerializer to save only updated fields and add test for concurrent updates
+- feat: Add optional merchant_name field to VtexProxySerializer and update related use cases
+
 # 5.48.0
 - feat: Adopt weni-commons JWT auth and read tenant from token
 

--- a/retail/projects/serializer.py
+++ b/retail/projects/serializer.py
@@ -57,11 +57,23 @@ class CrawlerWebhookSerializer(serializers.Serializer):
 
 
 class OnboardingPatchSerializer(serializers.ModelSerializer):
-    """Serializer for PATCH updates to ProjectOnboarding (front-end editable fields)."""
+    """Serializer for PATCH updates to ProjectOnboarding (front-end editable fields).
+
+    Saves only the patched columns via ``update_fields`` so concurrent
+    writers that updated other fields are not overwritten by a stale
+    in-memory instance (DRF's default ``ModelSerializer.update`` does a
+    full ``instance.save()``).
+    """
 
     class Meta:
         model = ProjectOnboarding
         fields = ["completed", "current_page", "skipped"]
+
+    def update(self, instance, validated_data):
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save(update_fields=list(validated_data.keys()))
+        return instance
 
 
 class InstallChannelAgentsSerializer(serializers.Serializer):

--- a/retail/projects/tests/test_views.py
+++ b/retail/projects/tests/test_views.py
@@ -6,6 +6,7 @@ from rest_framework.test import APIClient
 from weni_commons.auth import WeniAuthContext, WeniAuthUser
 
 from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.serializer import OnboardingPatchSerializer
 from retail.projects.usecases.install_channel_agents import InstallChannelAgentsError
 
 
@@ -328,6 +329,34 @@ class TestOnboardingPatchView(TestCase):
         )
 
         self.assertEqual(response.status_code, 404)
+
+    def test_patch_does_not_wipe_channels_when_instance_is_stale(self):
+        """
+        Reproduces the start-setup / PATCH race: PATCH loaded an empty
+        config, start-setup then wrote channels, and a full save() from
+        the stale instance must not overwrite config.
+        """
+        stale = ProjectOnboarding.objects.get(pk=self.onboarding.pk)
+        self.assertEqual(stale.config, {})
+
+        ProjectOnboarding.objects.filter(pk=self.onboarding.pk).update(
+            config={"channels": {"wwc": {}}},
+            current_step="PROJECT_CONFIG",
+            progress=0,
+        )
+
+        serializer = OnboardingPatchSerializer(
+            stale, data={"current_page": "setup_channel"}, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.onboarding.refresh_from_db()
+        self.assertEqual(self.onboarding.current_page, "setup_channel")
+        self.assertEqual(
+            self.onboarding.config,
+            {"channels": {"wwc": {}}},
+        )
 
     @auth_bypass(vtex_account=None)
     def test_missing_tenant_returns_403(self, _mock_auth):

--- a/retail/swagger.py
+++ b/retail/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Gallery API Documentation",
-        default_version="v5.48.0",
+        default_version="v5.48.1",
         description="Documentation of the Gallery APIs",
     ),
     public=True,


### PR DESCRIPTION
### TL;DR

Fix a race condition in `OnboardingPatchSerializer` where a stale in-memory instance could overwrite fields updated by a concurrent writer.

### What changed?

`OnboardingPatchSerializer` now overrides the `update` method to call `instance.save(update_fields=...)`, passing only the fields present in the validated data. This prevents DRF's default full `save()` from overwriting fields that were modified by another process between the time the instance was loaded and when the save occurs.

### How to test?

A regression test was added that simulates the race condition:
1. Load a `ProjectOnboarding` instance with an empty `config`.
2. Simulate a concurrent write that sets `config` to `{"channels": {"wwc": {}}}` directly in the database.
3. Use `OnboardingPatchSerializer` to PATCH only `current_page` on the stale instance.
4. Verify that `current_page` is updated to the new value **and** that `config` still contains `{"channels": {"wwc": {}}}` — confirming the concurrent write was not overwritten.

### Why make this change?

During the onboarding flow, a race condition could occur between the `start-setup` task (which writes channel data to `config`) and a concurrent PATCH request that loaded the instance before that write happened. Because DRF's default `ModelSerializer.update` performs a full `instance.save()`, the stale in-memory state would overwrite the `config` field, wiping out the channels written by `start-setup`. Limiting the save to only the patched fields eliminates this risk.