### PR TITLE
refactor: Read project_uuid from JWT context instead of request body in LinkProjectView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.48.3
+- refactor: Read project_uuid from JWT context instead of request body in LinkProjectView
+
 # 5.48.2
 - Add cache-busting v param to Weni WebChat loader scripts
 

--- a/retail/swagger.py
+++ b/retail/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Gallery API Documentation",
-        default_version="v5.48.2",
+        default_version="v5.48.3",
         description="Documentation of the Gallery APIs",
     ),
     public=True,

--- a/retail/vtex/serializers.py
+++ b/retail/vtex/serializers.py
@@ -23,12 +23,6 @@ class CreateProjectUserSerializer(serializers.Serializer):
     user_email = serializers.EmailField(required=True)
 
 
-class LinkProjectSerializer(serializers.Serializer):
-    """Validates the payload for linking a project to a VTEX account."""
-
-    project_uuid = serializers.UUIDField(required=True)
-
-
 class VtexProxySerializer(serializers.Serializer):
     """
     Validates the payload for VTEX proxy requests.

--- a/retail/vtex/tests/test_link_project_view.py
+++ b/retail/vtex/tests/test_link_project_view.py
@@ -8,80 +8,62 @@ from retail.clients.exceptions import CustomAPIException
 from retail.internal.test_mixins import patch_retail_auth
 
 
-def _auth_bypass():
-    """Patches unified retail auth with a tenant-scoped JWT context."""
-
-    return patch_retail_auth(vtex_account="mystore", user_email="user@vtex.com")
-
-
 class TestLinkProjectView(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.url = "/vtex/account/mystore/link-project/"
         self.project_uuid = str(uuid4())
 
-    @_auth_bypass()
-    @patch("retail.vtex.views.LinkProjectUseCase")
-    def test_returns_200_with_success(self, mock_cls, _auth):
-        mock_cls.return_value.execute.return_value = {"success": True}
+    def _auth_bypass(self, **overrides):
+        """Patches unified retail auth with a tenant-scoped JWT context."""
+        defaults = {
+            "project_uuid": self.project_uuid,
+            "vtex_account": "mystore",
+            "user_email": "user@vtex.com",
+        }
+        defaults.update(overrides)
+        return patch_retail_auth(**defaults)
 
-        response = self.client.post(
-            self.url,
-            {"project_uuid": self.project_uuid},
-            format="json",
-        )
+    def test_returns_200_with_success(self):
+        with self._auth_bypass(), patch(
+            "retail.vtex.views.LinkProjectUseCase"
+        ) as mock_cls:
+            mock_cls.return_value.execute.return_value = {"success": True}
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"success": True})
+            response = self.client.post(self.url, {}, format="json")
 
-    @_auth_bypass()
-    @patch("retail.vtex.views.LinkProjectUseCase")
-    def test_passes_correct_dto(self, mock_cls, _auth):
-        mock_cls.return_value.execute.return_value = {"success": True}
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), {"success": True})
 
-        self.client.post(
-            self.url,
-            {"project_uuid": self.project_uuid},
-            format="json",
-        )
+    def test_passes_correct_dto(self):
+        with self._auth_bypass(), patch(
+            "retail.vtex.views.LinkProjectUseCase"
+        ) as mock_cls:
+            mock_cls.return_value.execute.return_value = {"success": True}
 
-        dto = mock_cls.return_value.execute.call_args[0][0]
-        self.assertEqual(dto.vtex_account, "mystore")
-        self.assertEqual(dto.project_uuid, self.project_uuid)
+            self.client.post(self.url, {}, format="json")
 
-    @_auth_bypass()
-    def test_returns_400_when_project_uuid_missing(self, _auth):
-        response = self.client.post(self.url, {}, format="json")
-        self.assertEqual(response.status_code, 400)
+            dto = mock_cls.return_value.execute.call_args[0][0]
+            self.assertEqual(dto.vtex_account, "mystore")
+            self.assertEqual(dto.project_uuid, self.project_uuid)
 
-    @_auth_bypass()
-    def test_returns_400_for_invalid_project_uuid(self, _auth):
-        response = self.client.post(
-            self.url,
-            {"project_uuid": "not-a-uuid"},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 400)
+    def test_returns_403_when_project_uuid_missing_from_auth(self):
+        with self._auth_bypass(project_uuid=None):
+            response = self.client.post(self.url, {}, format="json")
+            self.assertEqual(response.status_code, 403)
 
-    @_auth_bypass()
-    @patch("retail.vtex.views.LinkProjectUseCase")
-    def test_returns_connect_error_status(self, mock_cls, _auth):
-        mock_cls.return_value.execute.side_effect = CustomAPIException(
-            detail="already linked", status_code=400
-        )
+    def test_returns_connect_error_status(self):
+        with self._auth_bypass(), patch(
+            "retail.vtex.views.LinkProjectUseCase"
+        ) as mock_cls:
+            mock_cls.return_value.execute.side_effect = CustomAPIException(
+                detail="already linked", status_code=400
+            )
 
-        response = self.client.post(
-            self.url,
-            {"project_uuid": self.project_uuid},
-            format="json",
-        )
+            response = self.client.post(self.url, {}, format="json")
 
-        self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.status_code, 400)
 
     def test_returns_401_without_auth(self):
-        response = self.client.post(
-            self.url,
-            {"project_uuid": self.project_uuid},
-            format="json",
-        )
+        response = self.client.post(self.url, {}, format="json")
         self.assertIn(response.status_code, [401, 403])

--- a/retail/vtex/views.py
+++ b/retail/vtex/views.py
@@ -14,7 +14,6 @@ from retail.vtex.dtos.register_order_form_dto import RegisterOrderFormDTO
 from retail.vtex.serializers import (
     CreateProjectUserSerializer,
     LeadSerializer,
-    LinkProjectSerializer,
     OrderFormTrackingSerializer,
     OrdersQueryParamsSerializer,
     PaymentGatewayProxySerializer,
@@ -468,20 +467,19 @@ class LinkProjectView(WeniAuthMixin, APIView):
     """
     Links an existing project to a VTEX account.
 
-    The IO front-end calls this route to attach a project_uuid to the
-    authenticated ``vtex_account``. The vtex_account uniqueness validations are
-    enforced at the root (Connect), which also triggers the Insights
-    migration; this view then mirrors the link locally.
+    Both ``vtex_account`` and ``project_uuid`` are read from the authenticated
+    JWT context (never from the body or path). The vtex_account uniqueness
+    validations are enforced at the root (Connect), which also triggers the
+    Insights migration; this view then mirrors the link locally.
     """
 
     def post(self, request: Request, vtex_account: str) -> Response:
         vtex_account = self.auth.vtex_account
-        serializer = LinkProjectSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
+        project_uuid = self.auth.project_uuid
 
         dto = LinkProjectDTO(
             vtex_account=vtex_account,
-            project_uuid=str(serializer.validated_data["project_uuid"]),
+            project_uuid=str(project_uuid),
         )
 
         try:


### PR DESCRIPTION
### TL;DR

`project_uuid` is now sourced exclusively from the JWT auth context instead of the request body when linking a project to a VTEX account.

### What changed?

The `LinkProjectView` no longer reads `project_uuid` from the request body. Instead, it reads both `vtex_account` and `project_uuid` directly from the authenticated JWT context (`self.auth.project_uuid`). As a result, `LinkProjectSerializer` (which previously validated the body payload) has been removed entirely.

Tests have been updated to reflect this new behavior:

- Requests no longer need to send `project_uuid` in the body.
- A missing `project_uuid` in the auth context now returns a `403` instead of a `400`.
- The `_auth_bypass` helper was converted from a module-level decorator factory to an instance method, allowing it to accept `project_uuid` from `setUp` and support per-test overrides.

### Why make this change?

Accepting `project_uuid` from the request body introduced a potential trust boundary issue — a caller could supply an arbitrary UUID. Reading it from the authenticated JWT context ensures the value is authoritative and tamper-proof, aligning with how `vtex_account` was already being handled.