### PR TITLE
feat: Add optional merchant_name to payment gateway and transaction proxy DTOs, serializers, and use cases

### DIFF
--- a/retail/vtex/dtos/proxy_payment_gateway_dto.py
+++ b/retail/vtex/dtos/proxy_payment_gateway_dto.py
@@ -11,3 +11,4 @@ class ProxyPaymentGatewayDTO:
     headers: Optional[dict] = None
     data: Optional[Union[dict, list]] = None
     params: Optional[dict] = None
+    merchant_name: Optional[str] = None

--- a/retail/vtex/dtos/proxy_payment_transaction_dto.py
+++ b/retail/vtex/dtos/proxy_payment_transaction_dto.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True, slots=True)
@@ -7,3 +8,4 @@ class ProxyPaymentTransactionDTO:
 
     transaction_id: str
     payments: tuple
+    merchant_name: Optional[str] = None

--- a/retail/vtex/serializers.py
+++ b/retail/vtex/serializers.py
@@ -59,6 +59,7 @@ class ProxyPaymentTransactionSerializer(serializers.Serializer):
         required=True,
         allow_empty=False,
     )
+    merchant_name = serializers.CharField(required=False, allow_null=True)
 
 
 class PaymentGatewayProxySerializer(serializers.Serializer):
@@ -69,3 +70,4 @@ class PaymentGatewayProxySerializer(serializers.Serializer):
     headers = serializers.DictField(required=False, allow_null=True)
     data = serializers.JSONField(required=False, allow_null=True)
     params = serializers.DictField(required=False, allow_null=True)
+    merchant_name = serializers.CharField(required=False, allow_null=True)

--- a/retail/vtex/tests/test_payment_gateway_proxy_serializer.py
+++ b/retail/vtex/tests/test_payment_gateway_proxy_serializer.py
@@ -85,6 +85,31 @@ class TestPaymentGatewayProxySerializer(TestCase):
         self.assertTrue(serializer.is_valid())
         self.assertIsNone(serializer.validated_data.get("params"))
 
+    def test_merchant_name_is_optional(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/some/path"}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("merchant_name"))
+
+    def test_accepts_merchant_name(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={
+                "method": "GET",
+                "path": "/some/path",
+                "merchant_name": "otherstore",
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["merchant_name"], "otherstore")
+
+    def test_merchant_name_accepts_null(self):
+        serializer = PaymentGatewayProxySerializer(
+            data={"method": "GET", "path": "/some/path", "merchant_name": None}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("merchant_name"))
+
     def test_headers_accepts_null(self):
         serializer = PaymentGatewayProxySerializer(
             data={"method": "GET", "path": "/some/path", "headers": None}

--- a/retail/vtex/tests/test_payment_gateway_proxy_view.py
+++ b/retail/vtex/tests/test_payment_gateway_proxy_view.py
@@ -58,6 +58,7 @@ class TestPaymentGatewayProxyView(TestCase):
             "headers": {"X-Custom": "value"},
             "data": {"key": "value"},
             "params": {"an": "teststore"},
+            "merchant_name": "otherstore",
         }
         request = self.factory.post(self.url, payload, format="json")
         self.view(request)
@@ -69,6 +70,7 @@ class TestPaymentGatewayProxyView(TestCase):
         self.assertEqual(dto.headers, {"X-Custom": "value"})
         self.assertEqual(dto.data, {"key": "value"})
         self.assertEqual(dto.params, {"an": "teststore"})
+        self.assertEqual(dto.merchant_name, "otherstore")
         self.assertEqual(call_kwargs["project_uuid"], "test-uuid")
 
     @_jwt_auth_bypass("test-uuid")
@@ -133,6 +135,7 @@ class TestPaymentGatewayProxyView(TestCase):
         self.assertIsNone(dto.headers)
         self.assertIsNone(dto.data)
         self.assertIsNone(dto.params)
+        self.assertIsNone(dto.merchant_name)
 
     def test_returns_401_without_auth(self):
         request = self.factory.post(self.url, self.valid_payload, format="json")

--- a/retail/vtex/tests/test_payment_transaction_proxy_view.py
+++ b/retail/vtex/tests/test_payment_transaction_proxy_view.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from retail.vtex.views import PaymentTransactionProxyView
+
+
+def _jwt_auth_bypass(project_uuid: str):
+    def side_effect(request):
+        request.project_uuid = project_uuid
+        request.vtex_account = None
+        request.jwt_payload = {"project_uuid": project_uuid}
+        return (None, None)
+
+    return patch(
+        "retail.internal.jwt_authenticators.JWTModuleAuthentication.authenticate",
+        side_effect=side_effect,
+    )
+
+
+class TestPaymentTransactionProxyView(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view = PaymentTransactionProxyView.as_view()
+        self.url = "/vtex/payments/send-transaction/"
+        self.valid_payload = {
+            "transaction_id": "ABC123",
+            "payments": [{"paymentSystem": "2", "value": 1000}],
+        }
+
+    @_jwt_auth_bypass("test-uuid")
+    @patch("retail.vtex.views.ProxyPaymentTransactionUseCase")
+    def test_passes_merchant_name_on_dto(self, mock_cls, _auth):
+        mock_cls.return_value.execute.return_value = {}
+
+        payload = {**self.valid_payload, "merchant_name": "otherstore"}
+        request = self.factory.post(self.url, payload, format="json")
+        self.view(request)
+
+        call_kwargs = mock_cls.return_value.execute.call_args[1]
+        dto = call_kwargs["dto"]
+        self.assertEqual(dto.transaction_id, "ABC123")
+        self.assertEqual(dto.payments, ({"paymentSystem": "2", "value": 1000},))
+        self.assertEqual(dto.merchant_name, "otherstore")
+        self.assertEqual(call_kwargs["project_uuid"], "test-uuid")
+
+    @_jwt_auth_bypass("test-uuid")
+    @patch("retail.vtex.views.ProxyPaymentTransactionUseCase")
+    def test_merchant_name_defaults_to_none(self, mock_cls, _auth):
+        mock_cls.return_value.execute.return_value = {}
+
+        request = self.factory.post(self.url, self.valid_payload, format="json")
+        self.view(request)
+
+        dto = mock_cls.return_value.execute.call_args[1]["dto"]
+        self.assertIsNone(dto.merchant_name)

--- a/retail/vtex/tests/test_proxy_payment_transaction_serializer.py
+++ b/retail/vtex/tests/test_proxy_payment_transaction_serializer.py
@@ -1,0 +1,34 @@
+from django.test import TestCase
+
+from retail.vtex.serializers import ProxyPaymentTransactionSerializer
+
+
+class TestProxyPaymentTransactionSerializer(TestCase):
+    def setUp(self):
+        self.valid_payload = {
+            "transaction_id": "ABC123",
+            "payments": [{"paymentSystem": "2", "value": 1000}],
+        }
+
+    def test_valid_minimal_payload(self):
+        serializer = ProxyPaymentTransactionSerializer(data=self.valid_payload)
+        self.assertTrue(serializer.is_valid())
+
+    def test_merchant_name_is_optional(self):
+        serializer = ProxyPaymentTransactionSerializer(data=self.valid_payload)
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("merchant_name"))
+
+    def test_accepts_merchant_name(self):
+        serializer = ProxyPaymentTransactionSerializer(
+            data={**self.valid_payload, "merchant_name": "otherstore"}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["merchant_name"], "otherstore")
+
+    def test_merchant_name_accepts_null(self):
+        serializer = ProxyPaymentTransactionSerializer(
+            data={**self.valid_payload, "merchant_name": None}
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIsNone(serializer.validated_data.get("merchant_name"))

--- a/retail/vtex/tests/usecases/test_proxy_payment_gateway.py
+++ b/retail/vtex/tests/usecases/test_proxy_payment_gateway.py
@@ -22,8 +22,33 @@ class TestProxyPaymentGatewayUseCase(TestCase):
 
         result = self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
 
+        mock_context.assert_called_once_with("test-uuid", merchant_name=None)
         self.mock_service.proxy_payment_gateway.assert_called_once_with(
             account_domain="teststore.myvtex.com",
+            vtex_account="teststore",
+            method="GET",
+            path="/api/pvt/transactions/ABC123/interactions",
+            headers=None,
+            data=None,
+            params=None,
+        )
+        self.assertEqual(result, {"data": []})
+
+    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
+    def test_execute_passes_merchant_name_to_context(self, mock_context):
+        mock_context.return_value = ("teststore", "otherstore.myvtex.com")
+        self.mock_service.proxy_payment_gateway.return_value = {"data": []}
+
+        dto = ProxyPaymentGatewayDTO(
+            method="GET",
+            path="/api/pvt/transactions/ABC123/interactions",
+            merchant_name="otherstore",
+        )
+        result = self.usecase.execute(dto=dto, project_uuid="test-uuid")
+
+        mock_context.assert_called_once_with("test-uuid", merchant_name="otherstore")
+        self.mock_service.proxy_payment_gateway.assert_called_once_with(
+            account_domain="otherstore.myvtex.com",
             vtex_account="teststore",
             method="GET",
             path="/api/pvt/transactions/ABC123/interactions",

--- a/retail/vtex/tests/usecases/test_proxy_payment_transaction.py
+++ b/retail/vtex/tests/usecases/test_proxy_payment_transaction.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from retail.vtex.dtos.proxy_payment_transaction_dto import ProxyPaymentTransactionDTO
+from retail.vtex.usecases.proxy_payment_transaction import (
+    ProxyPaymentTransactionUseCase,
+)
+
+
+class TestProxyPaymentTransactionUseCase(TestCase):
+    def setUp(self):
+        self.mock_service = MagicMock()
+        self.usecase = ProxyPaymentTransactionUseCase(vtex_io_service=self.mock_service)
+        self.dto = ProxyPaymentTransactionDTO(
+            transaction_id="ABC123",
+            payments=({"paymentSystem": "2", "value": 1000},),
+        )
+
+    @patch.object(ProxyPaymentTransactionUseCase, "_get_vtex_context")
+    def test_execute_calls_service_with_correct_params(self, mock_context):
+        mock_context.return_value = ("teststore", "teststore.myvtex.com")
+        self.mock_service.proxy_payment_transaction.return_value = {"ok": True}
+
+        result = self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
+
+        mock_context.assert_called_once_with("test-uuid", merchant_name=None)
+        self.mock_service.proxy_payment_transaction.assert_called_once_with(
+            account_domain="teststore.myvtex.com",
+            vtex_account="teststore",
+            transaction_id="ABC123",
+            payments=[{"paymentSystem": "2", "value": 1000}],
+        )
+        self.assertEqual(result, {"ok": True})
+
+    @patch.object(ProxyPaymentTransactionUseCase, "_get_vtex_context")
+    def test_execute_passes_merchant_name_to_context(self, mock_context):
+        mock_context.return_value = ("teststore", "otherstore.myvtex.com")
+        self.mock_service.proxy_payment_transaction.return_value = {"ok": True}
+
+        dto = ProxyPaymentTransactionDTO(
+            transaction_id="ABC123",
+            payments=({"paymentSystem": "2", "value": 1000},),
+            merchant_name="otherstore",
+        )
+        result = self.usecase.execute(dto=dto, project_uuid="test-uuid")
+
+        mock_context.assert_called_once_with("test-uuid", merchant_name="otherstore")
+        self.mock_service.proxy_payment_transaction.assert_called_once_with(
+            account_domain="otherstore.myvtex.com",
+            vtex_account="teststore",
+            transaction_id="ABC123",
+            payments=[{"paymentSystem": "2", "value": 1000}],
+        )
+        self.assertEqual(result, {"ok": True})

--- a/retail/vtex/usecases/proxy_payment_gateway.py
+++ b/retail/vtex/usecases/proxy_payment_gateway.py
@@ -27,11 +27,14 @@ class ProxyPaymentGatewayUseCase(BaseVtexUseCase):
         Returns:
             dict: Response from the VTEX IO proxy-payment-gateway route.
         """
-        vtex_account, account_domain = self._get_vtex_context(project_uuid)
+        vtex_account, account_domain = self._get_vtex_context(
+            project_uuid, merchant_name=dto.merchant_name
+        )
 
         logger.info(
             f"Proxying payment gateway request for "
-            f"vtex_account={vtex_account} method={dto.method} path={dto.path}"
+            f"vtex_account={vtex_account} account_domain={account_domain} "
+            f"method={dto.method} path={dto.path}"
         )
 
         return self.vtex_io_service.proxy_payment_gateway(

--- a/retail/vtex/usecases/proxy_payment_transaction.py
+++ b/retail/vtex/usecases/proxy_payment_transaction.py
@@ -27,11 +27,14 @@ class ProxyPaymentTransactionUseCase(BaseVtexUseCase):
         Returns:
             dict: Response from the VTEX IO proxy-payment-transaction route.
         """
-        vtex_account, account_domain = self._get_vtex_context(project_uuid)
+        vtex_account, account_domain = self._get_vtex_context(
+            project_uuid, merchant_name=dto.merchant_name
+        )
 
         logger.info(
             f"Proxying payment transaction for "
-            f"vtex_account={vtex_account} transaction_id={dto.transaction_id}"
+            f"vtex_account={vtex_account} account_domain={account_domain} "
+            f"transaction_id={dto.transaction_id}"
         )
 
         return self.vtex_io_service.proxy_payment_transaction(

--- a/retail/vtex/views.py
+++ b/retail/vtex/views.py
@@ -341,6 +341,7 @@ class PaymentTransactionProxyView(BaseVtexProxyView):
         dto = ProxyPaymentTransactionDTO(
             transaction_id=serializer.validated_data["transaction_id"],
             payments=tuple(serializer.validated_data["payments"]),
+            merchant_name=serializer.validated_data.get("merchant_name"),
         )
 
         result = self.usecase.execute(dto=dto, project_uuid=self.project_uuid)
@@ -387,6 +388,7 @@ class PaymentGatewayProxyView(BaseVtexProxyView):
             headers=validated.get("headers"),
             data=validated.get("data"),
             params=validated.get("params"),
+            merchant_name=validated.get("merchant_name"),
         )
 
         result = self.usecase.execute(dto=dto, project_uuid=self.project_uuid)


### PR DESCRIPTION
### TL;DR

Adds optional `merchant_name` support to both the payment gateway proxy and payment transaction proxy flows, allowing requests to be routed to a different VTEX merchant account domain.

### What changed?

- `ProxyPaymentGatewayDTO` and `ProxyPaymentTransactionDTO` now accept an optional `merchant_name` field.
- `ProxyPaymentTransactionSerializer` and `PaymentGatewayProxySerializer` expose `merchant_name` as an optional, nullable field.
- Both `ProxyPaymentGatewayUseCase` and `ProxyPaymentTransactionUseCase` forward `merchant_name` to `_get_vtex_context`, enabling the resolved `account_domain` to reflect the specified merchant rather than the default one.
- Log messages in both use cases now include `account_domain` alongside `vtex_account` for better observability.
- Both views pass `merchant_name` from the serializer's validated data into their respective DTOs.

### Why make this change?

Some payment flows involve a merchant account that differs from the project's default VTEX account. Passing `merchant_name` explicitly allows the proxy to resolve the correct `account_domain` for those cases, enabling multi-merchant support without changing the project's base configuration.