### PR TITLE
fix: Read template tenant from JWT instead of request body

### DIFF
--- a/retail/templates/serializers.py
+++ b/retail/templates/serializers.py
@@ -62,11 +62,12 @@ class TemplateMetadataSerializer(serializers.Serializer):
 
 
 class CreateTemplateSerializer(serializers.Serializer):
+    """Validate template creation payload; ``project_uuid`` comes from ``self.auth``."""
+
     template_translation = serializers.JSONField(required=True)
     template_name = serializers.CharField(required=True)
     category = serializers.CharField(required=True)
     app_uuid = serializers.CharField(required=True)
-    project_uuid = serializers.CharField(required=True)
     rule_code = serializers.CharField(required=False)
 
 
@@ -165,13 +166,14 @@ def _normalize_blank_footer(value: str | None) -> str | None:
 
 
 class UpdateTemplateContentSerializer(serializers.Serializer):
+    """Validate template content edits; ``project_uuid`` comes from ``self.auth``."""
+
     template_body = serializers.CharField(required=False)
     template_header = serializers.CharField(required=False)
     template_footer = serializers.CharField(required=False, allow_blank=True)
     template_button = serializers.ListField(required=False)
     template_body_params = serializers.ListField(required=False)
     app_uuid = serializers.CharField(required=True)
-    project_uuid = serializers.CharField(required=True)
     parameters = ParameterSerializer(many=True, required=False, allow_null=True)
     language = serializers.CharField(required=False, allow_null=True)
 
@@ -205,10 +207,11 @@ class UpdateLibraryTemplateSerializer(serializers.Serializer):
 
 
 class CreateCustomTemplateSerializer(serializers.Serializer):
+    """Validate custom template payload; ``project_uuid`` comes from ``self.auth``."""
+
     template_translation = serializers.JSONField(required=True)
     category = serializers.CharField()
     app_uuid = serializers.CharField(required=True)
-    project_uuid = serializers.CharField(required=True)
     integrated_agent_uuid = serializers.CharField(required=True)
     parameters = ParameterSerializer(many=True, required=True)
     display_name = serializers.CharField(required=True)
@@ -224,9 +227,8 @@ class ValidateTemplateSampleSerializer(UpdateTemplateContentSerializer):
     """Serializer for ``POST /api/v3/templates/<uuid>/sample/``.
 
     Schema-compatible with ``UpdateTemplateContentSerializer``; layers
-    on length caps and button-mode disjointness. The tenant-authority
-    check (body ``project_uuid`` vs. the authenticated project) lives in
-    the view, which owns the auth context. Anchor: FR-003 / FR-003a /
+    on length caps and button-mode disjointness. The project scope comes
+    from ``self.auth`` in the view. Anchor: FR-003 / FR-003a /
     FR-014 (see ``specs/004-template-sample-validation/spec.md``).
     """
 

--- a/retail/templates/tests/serializers/test_template_serializers.py
+++ b/retail/templates/tests/serializers/test_template_serializers.py
@@ -315,19 +315,29 @@ class TestCreateTemplateSerializer(TestCase):
             "template_name": "test_template",
             "category": "UTILITY",
             "app_uuid": str(uuid4()),
-            "project_uuid": str(uuid4()),
             "rule_code": "def test(): pass",
         }
 
         serializer = CreateTemplateSerializer(data=data)
-        self.assertTrue(serializer.is_valid())
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_valid_data_without_project_uuid(self):
+        data = {
+            "template_translation": {"en": {"text": "Hello"}},
+            "template_name": "test_template",
+            "category": "UTILITY",
+            "app_uuid": str(uuid4()),
+        }
+
+        serializer = CreateTemplateSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertNotIn("project_uuid", serializer.validated_data)
 
     def test_missing_required_fields(self):
         data = {
             "template_translation": {"en": {"text": "Hello"}},
             "category": "UTILITY",
             "app_uuid": str(uuid4()),
-            "project_uuid": str(uuid4()),
         }
 
         serializer = CreateTemplateSerializer(data=data)
@@ -340,7 +350,6 @@ class TestCreateTemplateSerializer(TestCase):
             "template_name": "test_template",
             "category": "UTILITY",
             "app_uuid": str(uuid4()),
-            "project_uuid": str(uuid4()),
         }
 
         serializer = CreateTemplateSerializer(data=data)
@@ -348,15 +357,15 @@ class TestCreateTemplateSerializer(TestCase):
 
 
 class TestUpdateTemplateContentSerializer(TestCase):
-    def test_valid_data_with_body(self):
+    def test_valid_data_without_project_uuid(self):
         data = {
             "template_body": "Updated body",
             "app_uuid": str(uuid4()),
-            "project_uuid": str(uuid4()),
         }
 
         serializer = UpdateTemplateContentSerializer(data=data)
-        self.assertTrue(serializer.is_valid())
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertNotIn("project_uuid", serializer.validated_data)
 
     def test_valid_data_with_header(self):
         data = {
@@ -439,7 +448,7 @@ class TestUpdateTemplateContentSerializer(TestCase):
         self.assertIn("non_field_errors", serializer.errors)
 
     def test_invalid_data_no_content_fields(self):
-        data = {"app_uuid": str(uuid4()), "project_uuid": str(uuid4())}
+        data = {"app_uuid": str(uuid4())}
 
         serializer = UpdateTemplateContentSerializer(data=data)
         self.assertFalse(serializer.is_valid())
@@ -501,20 +510,32 @@ class TestCreateCustomTemplateSerializer(TestCase):
             "template_translation": {"en": {"text": "Custom template"}},
             "category": "UTILITY",
             "app_uuid": str(uuid4()),
-            "project_uuid": str(uuid4()),
             "integrated_agent_uuid": str(uuid4()),
             "parameters": [{"name": "start_condition", "value": "condition"}],
             "display_name": "Custom Template",
         }
 
         serializer = CreateCustomTemplateSerializer(data=data)
-        self.assertTrue(serializer.is_valid())
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_valid_data_without_project_uuid(self):
+        data = {
+            "template_translation": {"en": {"text": "Custom template"}},
+            "category": "UTILITY",
+            "app_uuid": str(uuid4()),
+            "integrated_agent_uuid": str(uuid4()),
+            "parameters": [{"name": "start_condition", "value": "condition"}],
+            "display_name": "Custom Template",
+        }
+
+        serializer = CreateCustomTemplateSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertNotIn("project_uuid", serializer.validated_data)
 
     def test_missing_required_fields(self):
         data = {
             "template_translation": {"en": {"text": "Custom template"}},
             "app_uuid": str(uuid4()),
-            "project_uuid": str(uuid4()),
             "integrated_agent_uuid": str(uuid4()),
             "parameters": [],
         }
@@ -574,6 +595,15 @@ class TestValidateTemplateSampleSerializer(TestCase):
 
     def _serializer(self, data):
         return ValidateTemplateSampleSerializer(data=data)
+
+    def test_valid_without_project_uuid(self):
+        data = {
+            "template_body": "Olá",
+            "app_uuid": self.app_uuid,
+        }
+        serializer = self._serializer(data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertNotIn("project_uuid", serializer.validated_data)
 
     def test_body_at_1024_chars_passes(self):
         data = {**self.base_data, "template_body": "x" * 1024}

--- a/retail/templates/tests/views/test_template_viewset.py
+++ b/retail/templates/tests/views/test_template_viewset.py
@@ -192,6 +192,42 @@ class TemplateViewSetTest(BaseTestMixin, APITestCase):
             str(self.project.uuid), self.user.email
         )
 
+    def test_create_template_without_body_project_uuid(self):
+        """POST succeeds when project_uuid comes only from the JWT auth context."""
+        self.setup_internal_user_permissions(self.user)
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions=ConnectServicePermissionScenarios.CONTRIBUTOR_PERMISSIONS,
+        )
+
+        template = Template.objects.create(
+            uuid=uuid4(),
+            name="test_template",
+            parent=self.parent,
+        )
+
+        captured_payload = {}
+
+        def capture_execute(payload):
+            captured_payload.update(payload)
+            return template
+
+        self.create_usecase.execute = capture_execute
+
+        payload = {
+            "template_translation": {"en": {"text": "Hello"}},
+            "template_name": "test_template",
+            "category": "test",
+            "app_uuid": str(uuid4()),
+        }
+
+        response = self.client.post(reverse("template-list"), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(captured_payload["project_uuid"], str(self.project.uuid))
+        self.assertNotIn("project_uuid", payload)
+        self.assertNotIn("project_uuid", response.data)
+
     def test_create_template_invalid_data(self):
         """Test template creation fails with invalid data"""
         self.setup_internal_user_permissions(self.user)
@@ -397,6 +433,77 @@ class TemplateViewSetTest(BaseTestMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["name"], "test_template")
 
+    def test_partial_update_template_content_without_body_project_uuid(self):
+        """PATCH succeeds when project_uuid comes only from the JWT auth context."""
+        self.setup_internal_user_permissions(self.user)
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions=ConnectServicePermissionScenarios.CONTRIBUTOR_PERMISSIONS,
+        )
+
+        template = Template.objects.create(
+            uuid=uuid4(),
+            name="test_template",
+            parent=self.parent,
+        )
+        version = Version.objects.create(
+            template=template,
+            template_name="test_template",
+            integrations_app_uuid=uuid4(),
+            project=self.project,
+            status="APPROVED",
+        )
+        template.current_version = version
+        template.save()
+
+        captured_data = {}
+
+        def capture_execute(data):
+            captured_data.update(data)
+            return Template.objects.create(
+                uuid=uuid4(),
+                name="test_template",
+                parent=self.parent,
+            )
+
+        self.update_content_usecase.execute = capture_execute
+
+        payload = {
+            "template_body": "Updated template body with {{placeholder}}",
+            "app_uuid": str(uuid4()),
+            "parameters": None,
+        }
+
+        template_uuid = str(template.uuid)
+        url = reverse("template-detail", args=[template_uuid])
+
+        response = self.client.patch(url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(captured_data["project_uuid"], str(self.project.uuid))
+        self.assertNotIn("project_uuid", payload)
+        self.assertNotIn("project_uuid", response.data)
+
+    def test_partial_update_without_body_project_uuid_missing_token_returns_403(
+        self,
+    ):
+        """Missing tenant in JWT must return 403, not a serializer project_uuid error."""
+        self.set_retail_auth(project_uuid=None, user_email=self.user.email)
+
+        payload = {
+            "template_body": "Updated template body",
+            "app_uuid": str(uuid4()),
+        }
+
+        response = self.client.patch(
+            reverse("template-detail", args=[str(uuid4())]),
+            payload,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertNotIn("project_uuid", response.data)
+
     def test_partial_update_template_content_with_custom_template_parameters(self):
         """Test template content update with custom template parameters"""
         self.setup_internal_user_permissions(self.user)
@@ -479,6 +586,7 @@ class TemplateViewSetTest(BaseTestMixin, APITestCase):
         response = self.client.patch(url, payload, format="json", **headers)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertNotIn("project_uuid", response.data)
 
     def test_partial_update_template_content_not_found(self):
         """Test template content update with non-existent template"""
@@ -634,6 +742,76 @@ class TemplateViewSetTest(BaseTestMixin, APITestCase):
         self.assertEqual(response.data["display_name"], "Custom Template")
         self.assertEqual(response.data["is_custom"], True)
 
+    def test_create_custom_template_without_body_project_uuid(self):
+        """POST custom succeeds when project_uuid comes only from JWT auth."""
+        self.setup_internal_user_permissions(self.user)
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions=ConnectServicePermissionScenarios.CONTRIBUTOR_PERMISSIONS,
+        )
+
+        template = Template.objects.create(
+            uuid=uuid4(),
+            name="custom_template",
+            display_name="Custom Template",
+            integrated_agent=self.integrated_agent,
+            rule_code="def custom_rule(): return True",
+            metadata={"test": "data"},
+        )
+
+        captured_payload = {}
+
+        def capture_execute(payload):
+            captured_payload.update(payload)
+            return template
+
+        self.create_custom_usecase.execute = capture_execute
+
+        payload = {
+            "template_translation": {
+                "template_header": "Test Header",
+                "template_body": "Test Body {{name}}",
+                "template_footer": "Test Footer",
+                "template_button": [{"type": "URL", "text": "Click here"}],
+            },
+            "category": "custom",
+            "app_uuid": str(uuid4()),
+            "integrated_agent_uuid": str(self.integrated_agent.uuid),
+            "parameters": [
+                {
+                    "name": "start_condition",
+                    "value": "user.is_active == true",
+                }
+            ],
+            "display_name": "Custom Template Display",
+        }
+
+        response = self.client.post(reverse("template-custom"), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(captured_payload["project_uuid"], str(self.project.uuid))
+        self.assertNotIn("project_uuid", payload)
+        self.assertNotIn("project_uuid", response.data)
+
+    def test_create_custom_template_without_body_project_uuid_missing_token_returns_403(
+        self,
+    ):
+        self.set_retail_auth(project_uuid=None, user_email=self.user.email)
+
+        payload = {
+            "template_translation": {"en": {"text": "Custom"}},
+            "category": "custom",
+            "app_uuid": str(uuid4()),
+            "integrated_agent_uuid": str(self.integrated_agent.uuid),
+            "parameters": [{"name": "start_condition", "value": "true"}],
+            "display_name": "Custom Template",
+        }
+
+        response = self.client.post(reverse("template-custom"), payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertNotIn("project_uuid", response.data)
+
     def test_missing_project_uuid_in_token_returns_403(self):
         """Test that a token without project scope returns 403 Forbidden"""
         self.set_retail_auth(project_uuid=None, user_email=self.user.email)
@@ -643,7 +821,6 @@ class TemplateViewSetTest(BaseTestMixin, APITestCase):
             "template_name": "test_template",
             "category": "test",
             "app_uuid": str(uuid4()),
-            "project_uuid": str(self.project.uuid),
         }
 
         response = self.client.post(
@@ -653,6 +830,7 @@ class TemplateViewSetTest(BaseTestMixin, APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertNotIn("project_uuid", response.data)
 
     def test_missing_user_email_query_param_returns_403(self):
         """Test that missing user_email query parameter returns 403 Forbidden"""

--- a/retail/templates/tests/views/test_validate_template_sample_view.py
+++ b/retail/templates/tests/views/test_validate_template_sample_view.py
@@ -39,7 +39,6 @@ USECASE_PATCH_PATH = "retail.templates.views.ValidateTemplateSampleUseCase"
 INTEGRATIONS_SERVICE_PATCH_PATH = (
     "retail.services.integrations.service.IntegrationsService"
 )
-VIEW_LOGGER = "retail.templates.views"
 
 
 @with_test_settings
@@ -230,30 +229,84 @@ class ValidateTemplateSampleViewTest(BaseTestMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("template_body", response.data)
 
-    def test_project_uuid_mismatch_returns_400_and_emits_warning_log(
+    def test_sample_without_body_project_uuid_succeeds(self, mock_integrations_service):
+        """Replicates the App IO proxy pattern: body has no tenant field."""
+        self._set_up_authorized_request()
+
+        payload = {
+            "template_body": "Updated body",
+            "app_uuid": str(uuid4()),
+        }
+
+        result = ValidateTemplateSampleResult(
+            category="UTILITY",
+            template_updated=True,
+            template=self.template,
+            meta_sample_response={"success": True, "category": "UTILITY"},
+        )
+
+        with patch(USECASE_PATCH_PATH) as mock_use_case_class:
+            mock_use_case_class.return_value.execute.return_value = result
+            response = self.client.post(
+                self._sample_url(),
+                payload,
+                format="json",
+            )
+            dto = mock_use_case_class.return_value.execute.call_args.args[0]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(dto.project_uuid, str(self.project.uuid))
+        self.assertNotIn("project_uuid", payload)
+        self.assertNotIn("project_uuid", response.data)
+
+    def test_body_project_uuid_is_ignored_and_token_tenant_is_used(
         self, mock_integrations_service
     ):
+        """Body ``project_uuid`` is not authoritative under Weni auth."""
         self._set_up_authorized_request()
         headers, _ = self._project_headers_and_params()
         payload = self._default_payload(project_uuid=str(uuid4()))
 
+        result = ValidateTemplateSampleResult(
+            category="UTILITY",
+            template_updated=True,
+            template=self.template,
+            meta_sample_response={"success": True, "category": "UTILITY"},
+        )
+
         with patch(USECASE_PATCH_PATH) as mock_use_case_class:
-            with self.assertLogs(VIEW_LOGGER, level="WARNING") as log_ctx:
-                response = self.client.post(
-                    self._sample_url(),
-                    payload,
-                    format="json",
-                    **headers,
-                )
+            mock_use_case_class.return_value.execute.return_value = result
+            response = self.client.post(
+                self._sample_url(),
+                payload,
+                format="json",
+                **headers,
+            )
+            dto = mock_use_case_class.return_value.execute.call_args.args[0]
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(dto.project_uuid, str(self.project.uuid))
+
+    def test_sample_without_body_project_uuid_missing_token_returns_403(
+        self, mock_integrations_service
+    ):
+        self.set_retail_auth(project_uuid=None, user_email=self.user.email)
+
+        payload = {
+            "template_body": "Updated body",
+            "app_uuid": str(uuid4()),
+        }
+
+        with patch(USECASE_PATCH_PATH) as mock_use_case_class:
+            response = self.client.post(
+                self._sample_url(),
+                payload,
+                format="json",
+            )
             mock_use_case_class.return_value.execute.assert_not_called()
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("project_uuid", response.data)
-        any_mismatch_log = any(
-            "[TemplateSampleValidation] project_uuid_mismatch:" in record.getMessage()
-            for record in log_ctx.records
-        )
-        self.assertTrue(any_mismatch_log)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertNotIn("project_uuid", response.data)
 
     def test_template_uuid_not_found_returns_404(self, mock_integrations_service):
         self._set_up_authorized_request()
@@ -275,27 +328,31 @@ class ValidateTemplateSampleViewTest(BaseTestMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_project_uuid_mismatch_is_rejected_before_use_case(
+    def test_body_project_uuid_does_not_short_circuit_sample_flow(
         self, mock_integrations_service
     ):
-        """Pin that the tenant-authority check short-circuits the sample flow.
-
-        A body ``project_uuid`` diverging from the authenticated tenant must
-        be rejected by the view before the use case runs, so a cross-tenant
-        body never reaches Meta.
-        """
+        """A divergent body tenant must not block the sample flow; JWT is authoritative."""
         self._set_up_authorized_request()
         payload = self._default_payload(project_uuid=str(uuid4()))
 
+        result = ValidateTemplateSampleResult(
+            category="UTILITY",
+            template_updated=True,
+            template=self.template,
+            meta_sample_response={"success": True, "category": "UTILITY"},
+        )
+
         with patch(USECASE_PATCH_PATH) as mock_use_case_class:
+            mock_use_case_class.return_value.execute.return_value = result
             response = self.client.post(
                 self._sample_url(),
                 payload,
                 format="json",
             )
-            mock_use_case_class.return_value.execute.assert_not_called()
+            dto = mock_use_case_class.return_value.execute.call_args.args[0]
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(dto.project_uuid, str(self.project.uuid))
 
 
 META_SERVICE_PATCH_PATH = "retail.services.meta.service.MetaService"
@@ -699,7 +756,7 @@ class ValidateTemplateSampleViewCrossTenantIsolationTest(BaseTestMixin, APITestC
             "current_version_id": self.template.current_version_id,
         }
 
-    def test_project_uuid_mismatch_blocks_request_and_emits_audit_log(
+    def test_body_project_uuid_is_ignored_for_cross_tenant_isolation(
         self, mock_integrations_service, mock_meta_service
     ):
         self.setup_internal_user_permissions(self.user)
@@ -708,29 +765,26 @@ class ValidateTemplateSampleViewCrossTenantIsolationTest(BaseTestMixin, APITestC
             permissions=ConnectServicePermissionScenarios.CONTRIBUTOR_PERMISSIONS,
         )
         other_project_uuid = uuid4()
-        pre_snapshot = self._snapshot_template_state()
 
-        with self.assertLogs(VIEW_LOGGER, level="WARNING") as log_ctx:
+        result = ValidateTemplateSampleResult(
+            category="UTILITY",
+            template_updated=True,
+            template=self.template,
+            meta_sample_response={"success": True, "category": "UTILITY"},
+        )
+
+        with patch(USECASE_PATCH_PATH) as mock_use_case_class:
+            mock_use_case_class.return_value.execute.return_value = result
             response = self.client.post(
                 self._sample_url(),
                 self._default_payload(project_uuid=other_project_uuid),
                 format="json",
                 HTTP_PROJECT_UUID=str(self.project.uuid),
             )
+            dto = mock_use_case_class.return_value.execute.call_args.args[0]
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("project_uuid", response.data)
-
-        mock_meta_service.return_value.submit_template_sample.assert_not_called()
-        mock_integrations_service.return_value.get_channel_app.assert_not_called()
-
-        self.assertEqual(self._snapshot_template_state(), pre_snapshot)
-
-        any_mismatch_log = any(
-            "[TemplateSampleValidation] project_uuid_mismatch:" in record.getMessage()
-            for record in log_ctx.records
-        )
-        self.assertTrue(any_mismatch_log)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(dto.project_uuid, str(self.project.uuid))
 
     def test_unauthenticated_request_is_rejected_before_use_case(
         self, mock_integrations_service, mock_meta_service

--- a/retail/templates/views.py
+++ b/retail/templates/views.py
@@ -10,7 +10,6 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework import status
-from rest_framework.exceptions import ErrorDetail, ValidationError
 from weni_commons.auth import CanCommunicateInternally, IsWeniAuthenticated
 
 from retail.internal.permissions import HasWeniProjectPermission
@@ -80,9 +79,6 @@ _SAMPLE_DOMAIN_ERROR_HTTP_TRANSLATIONS = {
     ),
 }
 
-_PROJECT_UUID_MISMATCH_MESSAGE = "project_uuid does not match the authenticated project"
-_PROJECT_UUID_MISMATCH_CODE = "project_uuid_mismatch"
-
 
 class TemplateViewSet(WeniAuthMixin, ViewSet):
     permission_classes = [IsWeniAuthenticated, HasWeniProjectPermission]
@@ -139,9 +135,10 @@ class TemplateViewSet(WeniAuthMixin, ViewSet):
         Expected payload:
             {
                 "template_body": "<new body string with {{placeholders}}>",
-                "app_uuid": "<application identifier>",
-                "project_uuid": "<project identifier>"
+                "app_uuid": "<application identifier>"
             }
+
+        The project scope is read from the authenticated context (``self.auth``).
 
         URL format:
             PATCH /templates/{uuid}/
@@ -201,8 +198,6 @@ class TemplateViewSet(WeniAuthMixin, ViewSet):
         request_serializer = ValidateTemplateSampleSerializer(data=request.data)
         request_serializer.is_valid(raise_exception=True)
 
-        self._reject_cross_tenant_project_uuid(pk, request_serializer.validated_data)
-
         validated_data = {
             **request_serializer.validated_data,
             "project_uuid": self.auth.project_uuid,
@@ -248,45 +243,6 @@ class TemplateViewSet(WeniAuthMixin, ViewSet):
             project_uuid=validated_data["project_uuid"],
             parameters=validated_data.get("parameters"),
             language=validated_data.get("language"),
-        )
-
-    def _reject_cross_tenant_project_uuid(
-        self, template_uuid: UUID, validated_data: dict
-    ) -> None:
-        """Reject a sample whose body ``project_uuid`` diverges from the token.
-
-        The authenticated tenant (``self.auth``) is authoritative; a
-        divergent body value would let an operator authorized for project A
-        target project B's WABA. Emits the FR-008a audit log before raising
-        the 400. Anchor: FR-002b / FR-007f / FR-008a / SC-008.
-
-        Args:
-            template_uuid: The template UUID from the URL, for the audit log.
-            validated_data: The serializer's validated payload.
-        """
-        if not self.auth.has_project_uuid:
-            return
-
-        token_project_uuid = self.auth.project_uuid
-        body_project_uuid = validated_data.get("project_uuid")
-        if not body_project_uuid or body_project_uuid == token_project_uuid:
-            return
-
-        logger.warning(
-            "[TemplateSampleValidation] project_uuid_mismatch: "
-            f"token_project_uuid={token_project_uuid} "
-            f"body_project_uuid={body_project_uuid} "
-            f"template_uuid={template_uuid}"
-        )
-        raise ValidationError(
-            {
-                "project_uuid": [
-                    ErrorDetail(
-                        _PROJECT_UUID_MISMATCH_MESSAGE,
-                        code=_PROJECT_UUID_MISMATCH_CODE,
-                    )
-                ]
-            }
         )
 
 


### PR DESCRIPTION
## What

Aligns all operator-facing template endpoints with the Weni JWT auth contract
used by the App IO proxy. Serializers no longer require `project_uuid` in the
request body for POST create, POST custom, PATCH content update, and POST
sample validation. Each view injects the tenant from `self.auth.project_uuid`
after serializer validation.

Removed the obsolete `_reject_cross_tenant_project_uuid` guard from the sample
action; tenant isolation is enforced by `HasWeniProjectPermission` and the JWT
is the sole source of truth.

## Why

The App IO proxy forwards requests with `X-Weni-Auth` JWT but strips
`project_uuid` from the body. Production returned
`{"project_uuid": ["This field is required."]}` because serializers still
required the field even though views already read the tenant from the token.
