### PR TITLE
feat: Add `first_successful_sent_at` field to GalleryAgentSerializer

### DIFF
--- a/retail/agents/domains/agent_management/serializers.py
+++ b/retail/agents/domains/agent_management/serializers.py
@@ -95,6 +95,7 @@ class GalleryAgentSerializer(ReadAgentSerializer):
     assigned_agent_uuid = serializers.SerializerMethodField("get_assigned_agent_uuid")
     channel_uuid = serializers.SerializerMethodField()
     credentials = serializers.JSONField()
+    first_successful_sent_at = serializers.SerializerMethodField()
 
     def _get_assigned_integrated_agent(self, obj):
         project_uuid = self.context.get("project_uuid")
@@ -121,6 +122,10 @@ class GalleryAgentSerializer(ReadAgentSerializer):
         return (
             str(assigned.channel_uuid) if assigned and assigned.channel_uuid else None
         )
+
+    def get_first_successful_sent_at(self, obj):
+        assigned = self._get_assigned_integrated_agent(obj)
+        return assigned.first_successful_sent_at if assigned else None
 
 
 class PreApprovedTemplateSerializer(serializers.Serializer):

--- a/retail/agents/tests/serializers/test_gallery_agent_serializer.py
+++ b/retail/agents/tests/serializers/test_gallery_agent_serializer.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.utils import timezone
 
 from uuid import uuid4
 
@@ -36,8 +37,38 @@ class GalleryAgentSerializerTest(TestCase):
         self.assertTrue(data["assigned"])
         self.assertEqual(data["assigned_agent_uuid"], str(integrated_agent.uuid))
         self.assertEqual(data["channel_uuid"], str(channel_uuid))
+        self.assertIsNone(data["first_successful_sent_at"])
+
+    def test_assigned_gallery_agent_returns_first_successful_sent_at(self):
+        stamped = timezone.now()
+        integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            is_active=True,
+            first_successful_sent_at=stamped,
+        )
+        integrated_agent.refresh_from_db()
+
+        data = GalleryAgentSerializer(
+            self.agent,
+            context={"project_uuid": str(self.project.uuid)},
+        ).data
+
+        self.assertEqual(
+            data["first_successful_sent_at"],
+            integrated_agent.first_successful_sent_at,
+        )
 
     def test_unassigned_gallery_agent_returns_null_integrated_identifiers(self):
+        data = GalleryAgentSerializer(
+            self.agent,
+            context={"project_uuid": str(self.project.uuid)},
+        ).data
+
+        self.assertFalse(data["assigned"])
+        self.assertIsNone(data["assigned_agent_uuid"])
+        self.assertIsNone(data["channel_uuid"])
+        self.assertIsNone(data["first_successful_sent_at"])
         data = GalleryAgentSerializer(
             self.agent,
             context={"project_uuid": str(self.project.uuid)},


### PR DESCRIPTION
### TL;DR

Exposes `first_successful_sent_at` from `IntegratedAgent` through the `GalleryAgentSerializer`.

### What changed?

`GalleryAgentSerializer` now includes a `first_successful_sent_at` field that retrieves the timestamp from the assigned `IntegratedAgent`. If no agent is assigned, the field returns `null`.

### How to test?

- Assign an `IntegratedAgent` to a project with a `first_successful_sent_at` value set and verify the serializer returns the correct timestamp.
- Check that an unassigned agent or one without a `first_successful_sent_at` value returns `null` for the field.

### Why make this change?

Consumers of the gallery agent endpoint need to know when an integrated agent first successfully sent a message, allowing them to track activation status or display relevant information to users.