### PR TITLE
refactor: Improve order form clone shipping with two-step address/SLA logic and item filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.50.1
+- refactor: Improve order form clone shipping with two-step address/SLA logic and item filtering
+
 # 5.50.0
 - feat: Add first_successful_sent_at field to GalleryAgentSerializer
 - feat: Track first successful broadcast send on IntegratedAgent

--- a/retail/swagger.py
+++ b/retail/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Gallery API Documentation",
-        default_version="v5.50.0",
+        default_version="v5.50.1",
         description="Documentation of the Gallery APIs",
     ),
     public=True,

--- a/retail/vtex/tests/usecases/test_clone_order_form.py
+++ b/retail/vtex/tests/usecases/test_clone_order_form.py
@@ -57,10 +57,25 @@ class CloneOrderFormUseCaseTest(TestCase):
             return_value=(self.vtex_account, "test-account.myvtex.com")
         )
 
+        self.clone_items = [
+            {"id": "sku-1", "quantity": 2, "seller": "1"},
+            {"id": "sku-2", "quantity": 1, "seller": "1"},
+        ]
         self.mock_checkout.create_cart.return_value = {"orderFormId": "clone-of"}
-        self.mock_checkout.add_items.return_value = {"orderFormId": "clone-of"}
+        self.mock_checkout.add_items.return_value = {
+            "orderFormId": "clone-of",
+            "items": self.clone_items,
+        }
         self.mock_checkout.set_client_profile_data.return_value = {}
-        self.mock_checkout.set_shipping_data.return_value = {}
+        self.mock_checkout.set_shipping_data.return_value = {
+            "orderFormId": "clone-of",
+            "items": self.clone_items,
+            "shippingData": {
+                "selectedAddresses": [
+                    {"postalCode": "01310-100", "addressId": "clone-addr"}
+                ]
+            },
+        }
         self.mock_checkout.set_client_preferences_data.return_value = {}
         self.mock_checkout.set_marketing_data.return_value = {}
 
@@ -90,7 +105,31 @@ class CloneOrderFormUseCaseTest(TestCase):
             ],
         )
         self.mock_checkout.set_client_profile_data.assert_called_once()
-        self.mock_checkout.set_shipping_data.assert_called_once()
+        self.assertEqual(self.mock_checkout.set_shipping_data.call_count, 2)
+        address_payload = self.mock_checkout.set_shipping_data.call_args_list[0].kwargs[
+            "shipping_data"
+        ]
+        self.assertEqual(
+            address_payload["selectedAddresses"], [{"postalCode": "01310-100"}]
+        )
+        self.assertNotIn("logisticsInfo", address_payload)
+        sla_payload = self.mock_checkout.set_shipping_data.call_args_list[1].kwargs[
+            "shipping_data"
+        ]
+        self.assertEqual(
+            sla_payload["logisticsInfo"],
+            [
+                {
+                    "itemIndex": 0,
+                    "selectedSla": "Normal",
+                    "selectedDeliveryChannel": "delivery",
+                }
+            ],
+        )
+        self.assertEqual(
+            sla_payload["selectedAddresses"],
+            [{"postalCode": "01310-100", "addressId": "clone-addr"}],
+        )
         self.mock_checkout.set_client_preferences_data.assert_called_once()
         self.mock_checkout.set_marketing_data.assert_called_once()
         self.mock_checkout.get_order_form.assert_not_called()
@@ -242,3 +281,240 @@ class CloneOrderFormUseCaseTest(TestCase):
         ]
         self.assertEqual(payload["corporateName"], "Corp Ltd")
         self.assertTrue(payload["isCorporate"])
+
+    def test_skips_gift_and_assembly_child_items(self):
+        source = _full_source_order_form(
+            items=[
+                {"id": "sku-1", "quantity": 1, "seller": "1"},
+                {"id": "sku-gift", "quantity": 1, "seller": "1", "isGift": True},
+                {
+                    "id": "sku-child",
+                    "quantity": 1,
+                    "seller": "1",
+                    "parentItemIndex": 0,
+                },
+            ]
+        )
+
+        self.use_case.execute(
+            project_uuid=self.project_uuid,
+            vtex_account=self.vtex_account,
+            order_form=source,
+        )
+
+        order_items = self.mock_checkout.add_items.call_args.kwargs["order_items"]
+        self.assertEqual(order_items, [{"id": "sku-1", "quantity": 1, "seller": "1"}])
+
+    def test_shipping_drops_source_address_id_and_null_fields(self):
+        source = _full_source_order_form(
+            shippingData={
+                "selectedAddresses": [
+                    {
+                        "addressType": "search",
+                        "receiverName": None,
+                        "addressId": "-1782765895361",
+                        "isDisposable": True,
+                        "postalCode": "04040",
+                        "geoCoordinates": [-99.15, 19.34],
+                    }
+                ],
+                "logisticsInfo": [],
+            }
+        )
+
+        self.use_case.execute(
+            project_uuid=self.project_uuid,
+            vtex_account=self.vtex_account,
+            order_form=source,
+        )
+
+        payload = self.mock_checkout.set_shipping_data.call_args.kwargs["shipping_data"]
+        address = payload["selectedAddresses"][0]
+        self.assertEqual(address["addressType"], "search")
+        self.assertEqual(address["postalCode"], "04040")
+        self.assertNotIn("addressId", address)
+        self.assertNotIn("receiverName", address)
+        self.assertEqual(self.mock_checkout.set_shipping_data.call_count, 1)
+
+    def test_shipping_remaps_logistics_indexes_to_clone_items(self):
+        source = _full_source_order_form(
+            items=[
+                {"id": "sku-1", "quantity": 1, "seller": "1"},
+                {"id": "sku-unavailable", "quantity": 1, "seller": "1"},
+            ],
+            shippingData={
+                "selectedAddresses": [{"postalCode": "04040", "country": "MEX"}],
+                "logisticsInfo": [
+                    {
+                        "itemIndex": 0,
+                        "selectedSla": "Pickup A",
+                        "selectedDeliveryChannel": "pickup-in-point",
+                        "pickupPointId": "PP135",
+                    },
+                    {
+                        "itemIndex": 1,
+                        "selectedSla": "Pickup A",
+                        "selectedDeliveryChannel": "pickup-in-point",
+                        "pickupPointId": "PP135",
+                    },
+                ],
+            },
+        )
+        self.mock_checkout.add_items.return_value = {
+            "orderFormId": "clone-of",
+            "items": [{"id": "sku-1", "quantity": 1, "seller": "1"}],
+        }
+        self.mock_checkout.set_shipping_data.return_value = {
+            "items": [{"id": "sku-1", "quantity": 1, "seller": "1"}],
+            "shippingData": {
+                "selectedAddresses": [
+                    {"postalCode": "04040", "addressId": "clone-addr"}
+                ]
+            },
+        }
+
+        self.use_case.execute(
+            project_uuid=self.project_uuid,
+            vtex_account=self.vtex_account,
+            order_form=source,
+        )
+
+        sla_payload = self.mock_checkout.set_shipping_data.call_args_list[1].kwargs[
+            "shipping_data"
+        ]
+        self.assertEqual(
+            sla_payload["logisticsInfo"],
+            [
+                {
+                    "itemIndex": 0,
+                    "selectedSla": "Pickup A",
+                    "selectedDeliveryChannel": "pickup-in-point",
+                    "pickupPointId": "PP135",
+                }
+            ],
+        )
+        self.assertEqual(
+            sla_payload["selectedAddresses"],
+            [{"postalCode": "04040", "addressId": "clone-addr"}],
+        )
+
+    def test_remap_logistics_skips_incomplete_and_unmatched_rows(self):
+        remapped = self.use_case._remap_logistics_info(
+            source_items=[{"id": "sku-1", "seller": "1"}],
+            source_logistics=[
+                {"selectedSla": "Normal"},
+                {"itemIndex": 99, "selectedSla": "Normal"},
+                {
+                    "itemIndex": 0,
+                    "selectedSla": "Normal",
+                    "selectedDeliveryChannel": "delivery",
+                },
+            ],
+            clone_items=[{"id": "sku-1", "seller": "1"}],
+        )
+
+        self.assertEqual(
+            remapped,
+            [
+                {
+                    "itemIndex": 0,
+                    "selectedSla": "Normal",
+                    "selectedDeliveryChannel": "delivery",
+                }
+            ],
+        )
+
+    def test_remap_logistics_returns_empty_when_clone_has_no_items(self):
+        remapped = self.use_case._remap_logistics_info(
+            source_items=[{"id": "sku-1", "seller": "1"}],
+            source_logistics=[{"itemIndex": 0, "selectedSla": "Normal"}],
+            clone_items=[],
+        )
+
+        self.assertEqual(remapped, [])
+
+    def test_skips_sla_selection_when_address_step_fails(self):
+        self.mock_checkout.set_shipping_data.return_value = None
+
+        result = self.use_case.execute(
+            project_uuid=self.project_uuid,
+            vtex_account=self.vtex_account,
+            order_form=_full_source_order_form(),
+        )
+
+        self.assertEqual(result.order_form_id, "clone-of")
+        self.assertEqual(self.mock_checkout.set_shipping_data.call_count, 1)
+
+    def test_sla_selection_failure_is_best_effort(self):
+        self.mock_checkout.set_shipping_data.side_effect = [
+            {
+                "items": self.clone_items,
+                "shippingData": {
+                    "selectedAddresses": [
+                        {"postalCode": "01310-100", "addressId": "clone-addr"}
+                    ]
+                },
+            },
+            None,
+        ]
+
+        result = self.use_case.execute(
+            project_uuid=self.project_uuid,
+            vtex_account=self.vtex_account,
+            order_form=_full_source_order_form(),
+        )
+
+        self.assertEqual(result.order_form_id, "clone-of")
+        self.assertEqual(self.mock_checkout.set_shipping_data.call_count, 2)
+
+    def test_sla_payload_falls_back_to_source_addresses_when_clone_omits_them(self):
+        self.mock_checkout.set_shipping_data.return_value = {
+            "items": self.clone_items,
+            "shippingData": {},
+        }
+
+        self.use_case.execute(
+            project_uuid=self.project_uuid,
+            vtex_account=self.vtex_account,
+            order_form=_full_source_order_form(),
+        )
+
+        sla_payload = self.mock_checkout.set_shipping_data.call_args_list[1].kwargs[
+            "shipping_data"
+        ]
+        self.assertEqual(
+            sla_payload["selectedAddresses"], [{"postalCode": "01310-100"}]
+        )
+
+    def test_shipping_with_logistics_only_skips_address_step(self):
+        source = _full_source_order_form(
+            shippingData={
+                "logisticsInfo": [
+                    {
+                        "itemIndex": 0,
+                        "selectedSla": "Normal",
+                        "selectedDeliveryChannel": "delivery",
+                    }
+                ],
+            }
+        )
+
+        self.use_case.execute(
+            project_uuid=self.project_uuid,
+            vtex_account=self.vtex_account,
+            order_form=source,
+        )
+
+        self.assertEqual(self.mock_checkout.set_shipping_data.call_count, 1)
+        payload = self.mock_checkout.set_shipping_data.call_args.kwargs["shipping_data"]
+        self.assertNotIn("selectedAddresses", payload)
+        self.assertEqual(
+            payload["logisticsInfo"],
+            [
+                {
+                    "itemIndex": 0,
+                    "selectedSla": "Normal",
+                    "selectedDeliveryChannel": "delivery",
+                }
+            ],
+        )

--- a/retail/vtex/usecases/clone_order_form.py
+++ b/retail/vtex/usecases/clone_order_form.py
@@ -6,8 +6,9 @@ notification did not drive.
 """
 
 import logging
+from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from retail.services.vtex_checkout.service import VtexCheckoutService
 from retail.vtex.usecases.base import BaseVtexUseCase
@@ -41,6 +42,22 @@ _MARKETING_DATA_FIELDS = (
     "utmiPage",
     "coupon",
     "marketingTags",
+)
+
+_ADDRESS_FIELDS = (
+    "addressType",
+    "receiverName",
+    "isDisposable",
+    "postalCode",
+    "city",
+    "state",
+    "country",
+    "street",
+    "number",
+    "neighborhood",
+    "complement",
+    "reference",
+    "geoCoordinates",
 )
 
 
@@ -121,6 +138,7 @@ class CloneOrderFormUseCase(BaseVtexUseCase):
             vtex_account=vtex_account,
             order_form_id=new_order_form_id,
             source=source,
+            clone_items=added.get("items") or [],
         )
 
         marketing_data = self._build_marketing_data(source.get("marketingData"))
@@ -173,16 +191,23 @@ class CloneOrderFormUseCase(BaseVtexUseCase):
     def _build_order_items(self, items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         order_items: List[Dict[str, Any]] = []
         for item in items:
-            item_id = item.get("id")
-            if item_id is None:
+            if not self._should_copy_item(item):
                 continue
-            order_item: Dict[str, Any] = {
-                "id": item_id,
-                "quantity": item.get("quantity", 1),
-                "seller": item.get("seller", "1"),
-            }
-            order_items.append(order_item)
+            order_items.append(
+                {
+                    "id": item["id"],
+                    "quantity": item.get("quantity", 1),
+                    "seller": item.get("seller", "1"),
+                }
+            )
         return order_items
+
+    def _should_copy_item(self, item: Dict[str, Any]) -> bool:
+        if item.get("id") is None:
+            return False
+        if item.get("isGift"):
+            return False
+        return item.get("parentItemIndex") is None
 
     def _apply_attachments_best_effort(
         self,
@@ -190,6 +215,7 @@ class CloneOrderFormUseCase(BaseVtexUseCase):
         vtex_account: str,
         order_form_id: str,
         source: Dict[str, Any],
+        clone_items: List[Dict[str, Any]],
     ) -> None:
         profile_payload = self._build_client_profile_payload(
             source.get("clientProfileData")
@@ -207,19 +233,13 @@ class CloneOrderFormUseCase(BaseVtexUseCase):
                     f"orderForm={order_form_id} vtex_account={vtex_account}"
                 )
 
-        shipping_payload = self._build_shipping_payload(source.get("shippingData"))
-        if shipping_payload:
-            result = self.checkout_service.set_shipping_data(
-                account_domain=account_domain,
-                vtex_account=vtex_account,
-                order_form_id=order_form_id,
-                shipping_data=shipping_payload,
-            )
-            if result is None:
-                logger.warning(
-                    f"Best-effort shippingData failed for clone "
-                    f"orderForm={order_form_id} vtex_account={vtex_account}"
-                )
+        self._apply_shipping_best_effort(
+            account_domain=account_domain,
+            vtex_account=vtex_account,
+            order_form_id=order_form_id,
+            source=source,
+            clone_items=clone_items,
+        )
 
         preferences_payload = self._build_client_preferences_payload(
             source.get("clientPreferencesData")
@@ -273,31 +293,134 @@ class CloneOrderFormUseCase(BaseVtexUseCase):
 
         return payload or None
 
-    def _build_shipping_payload(
-        self, shipping_data: Optional[Dict[str, Any]]
-    ) -> Optional[Dict[str, Any]]:
+    def _apply_shipping_best_effort(
+        self,
+        account_domain: str,
+        vtex_account: str,
+        order_form_id: str,
+        source: Dict[str, Any],
+        clone_items: List[Dict[str, Any]],
+    ) -> None:
+        """Copy shipping in two steps.
+
+        A new cart often has no ``logisticsInfo`` until an address is set.
+        Posting source ``itemIndex`` values (or SLAs) in the same request
+        is rejected as "invalid item index", especially for pickup carts.
+        """
+        shipping_data = source.get("shippingData")
         if not shipping_data:
+            return
+
+        selected_addresses = self._sanitize_selected_addresses(
+            shipping_data.get("selectedAddresses")
+        )
+        addressed = None
+        if selected_addresses:
+            addressed = self.checkout_service.set_shipping_data(
+                account_domain=account_domain,
+                vtex_account=vtex_account,
+                order_form_id=order_form_id,
+                shipping_data={
+                    "clearAddressIfPostalCodeNotFound": False,
+                    "selectedAddresses": selected_addresses,
+                },
+            )
+            if addressed is None:
+                logger.warning(
+                    f"Best-effort shippingData address failed for clone "
+                    f"orderForm={order_form_id} vtex_account={vtex_account}"
+                )
+                return
+            clone_items = addressed.get("items") or clone_items
+
+        logistics_info = self._remap_logistics_info(
+            source_items=source.get("items") or [],
+            source_logistics=shipping_data.get("logisticsInfo") or [],
+            clone_items=clone_items,
+        )
+        if not logistics_info:
+            return
+
+        payload: Dict[str, Any] = {"logisticsInfo": logistics_info}
+        if addressed is not None:
+            clone_addresses = (addressed.get("shippingData") or {}).get(
+                "selectedAddresses"
+            )
+            if clone_addresses:
+                payload["selectedAddresses"] = clone_addresses
+            elif selected_addresses:
+                payload["selectedAddresses"] = selected_addresses
+
+        result = self.checkout_service.set_shipping_data(
+            account_domain=account_domain,
+            vtex_account=vtex_account,
+            order_form_id=order_form_id,
+            shipping_data=payload,
+        )
+        if result is None:
+            logger.warning(
+                f"Best-effort shippingData SLA selection failed for clone "
+                f"orderForm={order_form_id} vtex_account={vtex_account}"
+            )
+
+    def _sanitize_selected_addresses(
+        self, addresses: Optional[List[Dict[str, Any]]]
+    ) -> Optional[List[Dict[str, Any]]]:
+        if not addresses:
             return None
 
-        payload: Dict[str, Any] = {}
-        selected_addresses = shipping_data.get("selectedAddresses")
-        if selected_addresses:
-            payload["selectedAddresses"] = selected_addresses
+        sanitized: List[Dict[str, Any]] = []
+        for address in addresses:
+            payload = {
+                field: address[field]
+                for field in _ADDRESS_FIELDS
+                if field in address and address[field] is not None
+            }
+            if payload:
+                sanitized.append(payload)
+        return sanitized or None
 
-        logistics_info = shipping_data.get("logisticsInfo") or []
-        slim_logistics = [
-            {
-                "itemIndex": entry["itemIndex"],
+    def _remap_logistics_info(
+        self,
+        source_items: List[Dict[str, Any]],
+        source_logistics: List[Dict[str, Any]],
+        clone_items: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Map source logistics rows onto the clone's actual item indexes.
+
+        Source indexes are invalid when the clone has fewer items (gift
+        skipped, SKU unavailable, assembly child not sold separately).
+        """
+        if not clone_items or not source_logistics:
+            return []
+
+        source_key_by_index = {
+            index: self._item_key(item) for index, item in enumerate(source_items)
+        }
+        clone_indexes_by_key: Dict[Tuple[str, str], deque] = defaultdict(deque)
+        for index, item in enumerate(clone_items):
+            clone_indexes_by_key[self._item_key(item)].append(index)
+
+        remapped: List[Dict[str, Any]] = []
+        for entry in source_logistics:
+            if "itemIndex" not in entry:
+                continue
+            key = source_key_by_index.get(entry["itemIndex"])
+            if key is None or not clone_indexes_by_key[key]:
+                continue
+            clone_index = clone_indexes_by_key[key].popleft()
+            remapped_entry: Dict[str, Any] = {
+                "itemIndex": clone_index,
                 "selectedSla": entry.get("selectedSla"),
                 "selectedDeliveryChannel": entry.get("selectedDeliveryChannel"),
             }
-            for entry in logistics_info
-            if "itemIndex" in entry
-        ]
-        if slim_logistics:
-            payload["logisticsInfo"] = slim_logistics
+            if entry.get("pickupPointId"):
+                remapped_entry["pickupPointId"] = entry["pickupPointId"]
+            remapped.append(remapped_entry)
+        return remapped
 
-        return payload or None
+    def _item_key(self, item: Dict[str, Any]) -> Tuple[str, str]:
+        return (str(item.get("id")), str(item.get("seller", "1")))
 
     def _build_client_preferences_payload(
         self, preferences: Optional[Dict[str, Any]]


### PR DESCRIPTION
## Order Form Clone: Shipping & Item Filtering Improvements

- Added logic to skip gift items (`isGift: true`) and assembly child items (`parentItemIndex` set) when building the item list for a cloned order form.
- Introduced `_sanitize_selected_addresses` to strip `addressId`, `null`-valued fields, and other source-specific fields before posting addresses to the clone cart.
- Split shipping data application into two sequential steps: first set the address to allow VTEX to generate valid logistics info, then apply SLA/delivery channel selections using remapped item indexes.
- Implemented `_remap_logistics_info` to correctly map source logistics rows onto the clone's actual item indexes, handling cases where items are unavailable, skipped, or differ in count between source and clone.
- Added `_item_key` helper to match source and clone items by `(id, seller)` for logistics remapping.
- Made SLA selection best-effort, logging warnings and continuing without failure if the address step or SLA step returns `None`.
- Added tests covering gift/child item skipping, address field sanitization, logistics index remapping, partial clone item availability, fallback behavior when address or SLA steps fail, and edge cases in `_remap_logistics_info`.