### PR TITLE
feat: Introduce MerchantAccountNotAllowedError and enhance context resolution for merchant accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.51.0
+- feat: Introduce MerchantAccountNotAllowedError and enhance context resolution for merchant accounts - #557
+
 # 5.50.1
 - refactor: Improve order form clone shipping with two-step address/SLA logic and item filtering
 

--- a/retail/swagger.py
+++ b/retail/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Gallery API Documentation",
-        default_version="v5.50.1",
+        default_version="v5.51.0",
         description="Documentation of the Gallery APIs",
     ),
     public=True,

--- a/retail/vtex/exceptions.py
+++ b/retail/vtex/exceptions.py
@@ -1,0 +1,9 @@
+class MerchantAccountNotAllowedError(Exception):
+    """Raised when merchant_name is not a seller of the project's VTEX account."""
+
+    def __init__(self, merchant_name: str, project_account: str):
+        self.merchant_name = merchant_name
+        self.project_account = project_account
+        super().__init__(
+            f"merchant_name={merchant_name} is not a seller of {project_account}"
+        )

--- a/retail/vtex/tests/test_payment_gateway_proxy_view.py
+++ b/retail/vtex/tests/test_payment_gateway_proxy_view.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
+from retail.vtex.exceptions import MerchantAccountNotAllowedError
 from retail.vtex.views import PaymentGatewayProxyView
 
 
@@ -136,6 +137,23 @@ class TestPaymentGatewayProxyView(TestCase):
         self.assertIsNone(dto.data)
         self.assertIsNone(dto.params)
         self.assertIsNone(dto.merchant_name)
+
+    @_jwt_auth_bypass("test-uuid")
+    @patch("retail.vtex.views.ProxyPaymentGatewayUseCase")
+    def test_returns_403_when_merchant_not_allowed(self, mock_cls, _auth):
+        mock_cls.return_value.execute.side_effect = MerchantAccountNotAllowedError(
+            "otherstore", "fakeaccount"
+        )
+
+        request = self.factory.post(
+            self.url,
+            {**self.valid_payload, "merchant_name": "otherstore"},
+            format="json",
+        )
+        response = self.view(request)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("otherstore", response.data["detail"])
 
     def test_returns_401_without_auth(self):
         request = self.factory.post(self.url, self.valid_payload, format="json")

--- a/retail/vtex/tests/usecases/test_base_vtex_usecase.py
+++ b/retail/vtex/tests/usecases/test_base_vtex_usecase.py
@@ -35,18 +35,15 @@ class BaseVtexUseCaseGetVtexContextTest(TestCase):
         self.assertEqual(vtex_account, "fakeaccount")
         self.assertEqual(domain, "fakeaccount.myvtex.com")
 
-    def test_merchant_name_overrides_domain_only(self):
-        vtex_account, domain = self.usecase._get_vtex_context(
-            str(self.project.uuid), merchant_name="otherstore"
-        )
+    def test_get_account_domain_returns_domain_only(self):
+        domain = self.usecase._get_account_domain(str(self.project.uuid))
 
-        self.assertEqual(vtex_account, "fakeaccount")
-        self.assertEqual(domain, "otherstore.myvtex.com")
+        self.assertEqual(domain, "fakeaccount.myvtex.com")
 
-    def test_cache_is_not_poisoned_by_merchant_override(self):
-        self.usecase._get_vtex_context(
-            str(self.project.uuid), merchant_name="otherstore"
-        )
+    def test_returns_cached_context_on_second_call(self):
+        self.usecase._get_vtex_context(str(self.project.uuid))
+        self.project.vtex_account = "changedaccount"
+        self.project.save()
 
         vtex_account, domain = self.usecase._get_vtex_context(str(self.project.uuid))
 

--- a/retail/vtex/tests/usecases/test_proxy_payment_gateway.py
+++ b/retail/vtex/tests/usecases/test_proxy_payment_gateway.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from django.test import TestCase
 
@@ -9,20 +9,25 @@ from retail.vtex.usecases.proxy_payment_gateway import ProxyPaymentGatewayUseCas
 class TestProxyPaymentGatewayUseCase(TestCase):
     def setUp(self):
         self.mock_service = MagicMock()
-        self.usecase = ProxyPaymentGatewayUseCase(vtex_io_service=self.mock_service)
+        self.mock_resolver = MagicMock()
+        self.usecase = ProxyPaymentGatewayUseCase(
+            vtex_io_service=self.mock_service,
+            context_resolver=self.mock_resolver,
+        )
         self.dto = ProxyPaymentGatewayDTO(
             method="GET",
             path="/api/pvt/transactions/ABC123/interactions",
         )
 
-    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
-    def test_execute_calls_service_with_correct_params(self, mock_context):
-        mock_context.return_value = ("teststore", "teststore.myvtex.com")
+    def test_execute_calls_service_with_correct_params(self):
+        self.mock_resolver.execute.return_value = ("teststore", "teststore.myvtex.com")
         self.mock_service.proxy_payment_gateway.return_value = {"data": []}
 
         result = self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
 
-        mock_context.assert_called_once_with("test-uuid", merchant_name=None)
+        self.mock_resolver.execute.assert_called_once_with(
+            "test-uuid", merchant_name=None
+        )
         self.mock_service.proxy_payment_gateway.assert_called_once_with(
             account_domain="teststore.myvtex.com",
             vtex_account="teststore",
@@ -34,9 +39,11 @@ class TestProxyPaymentGatewayUseCase(TestCase):
         )
         self.assertEqual(result, {"data": []})
 
-    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
-    def test_execute_passes_merchant_name_to_context(self, mock_context):
-        mock_context.return_value = ("teststore", "otherstore.myvtex.com")
+    def test_execute_uses_merchant_account_for_jwt_and_host(self):
+        self.mock_resolver.execute.return_value = (
+            "otherstore",
+            "otherstore.myvtex.com",
+        )
         self.mock_service.proxy_payment_gateway.return_value = {"data": []}
 
         dto = ProxyPaymentGatewayDTO(
@@ -46,10 +53,12 @@ class TestProxyPaymentGatewayUseCase(TestCase):
         )
         result = self.usecase.execute(dto=dto, project_uuid="test-uuid")
 
-        mock_context.assert_called_once_with("test-uuid", merchant_name="otherstore")
+        self.mock_resolver.execute.assert_called_once_with(
+            "test-uuid", merchant_name="otherstore"
+        )
         self.mock_service.proxy_payment_gateway.assert_called_once_with(
             account_domain="otherstore.myvtex.com",
-            vtex_account="teststore",
+            vtex_account="otherstore",
             method="GET",
             path="/api/pvt/transactions/ABC123/interactions",
             headers=None,
@@ -58,9 +67,8 @@ class TestProxyPaymentGatewayUseCase(TestCase):
         )
         self.assertEqual(result, {"data": []})
 
-    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
-    def test_execute_forwards_optional_fields(self, mock_context):
-        mock_context.return_value = ("teststore", "teststore.myvtex.com")
+    def test_execute_forwards_optional_fields(self):
+        self.mock_resolver.execute.return_value = ("teststore", "teststore.myvtex.com")
         self.mock_service.proxy_payment_gateway.return_value = {}
 
         dto = ProxyPaymentGatewayDTO(
@@ -77,25 +85,26 @@ class TestProxyPaymentGatewayUseCase(TestCase):
         self.assertEqual(call_kwargs["data"], {"key": "value"})
         self.assertEqual(call_kwargs["params"], {"an": "teststore"})
 
-    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
-    def test_execute_raises_when_project_not_found(self, mock_context):
-        mock_context.side_effect = ValueError("Project not found for given UUID.")
+    def test_execute_raises_when_project_not_found(self):
+        self.mock_resolver.execute.side_effect = ValueError(
+            "Project not found for given UUID."
+        )
 
         with self.assertRaises(ValueError) as ctx:
             self.usecase.execute(dto=self.dto, project_uuid="invalid-uuid")
 
         self.assertIn("Project not found", str(ctx.exception))
 
-    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
-    def test_execute_raises_when_vtex_account_missing(self, mock_context):
-        mock_context.side_effect = ValueError("VTEX account not defined for project.")
+    def test_execute_raises_when_vtex_account_missing(self):
+        self.mock_resolver.execute.side_effect = ValueError(
+            "VTEX account not defined for project."
+        )
 
         with self.assertRaises(ValueError):
             self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
 
-    @patch.object(ProxyPaymentGatewayUseCase, "_get_vtex_context")
-    def test_execute_returns_service_response(self, mock_context):
-        mock_context.return_value = ("teststore", "teststore.myvtex.com")
+    def test_execute_returns_service_response(self):
+        self.mock_resolver.execute.return_value = ("teststore", "teststore.myvtex.com")
         expected = {
             "status": 200,
             "data": [{"transactionId": "ABC123", "payments": []}],
@@ -105,3 +114,11 @@ class TestProxyPaymentGatewayUseCase(TestCase):
         result = self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
 
         self.assertEqual(result, expected)
+
+    def test_defaults_context_resolver_from_service(self):
+        from retail.vtex.usecases.resolve_proxy_context import (
+            ResolveProxyContextUseCase,
+        )
+
+        usecase = ProxyPaymentGatewayUseCase(vtex_io_service=MagicMock())
+        self.assertIsInstance(usecase.context_resolver, ResolveProxyContextUseCase)

--- a/retail/vtex/tests/usecases/test_proxy_payment_transaction.py
+++ b/retail/vtex/tests/usecases/test_proxy_payment_transaction.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from django.test import TestCase
 
@@ -11,20 +11,25 @@ from retail.vtex.usecases.proxy_payment_transaction import (
 class TestProxyPaymentTransactionUseCase(TestCase):
     def setUp(self):
         self.mock_service = MagicMock()
-        self.usecase = ProxyPaymentTransactionUseCase(vtex_io_service=self.mock_service)
+        self.mock_resolver = MagicMock()
+        self.usecase = ProxyPaymentTransactionUseCase(
+            vtex_io_service=self.mock_service,
+            context_resolver=self.mock_resolver,
+        )
         self.dto = ProxyPaymentTransactionDTO(
             transaction_id="ABC123",
             payments=({"paymentSystem": "2", "value": 1000},),
         )
 
-    @patch.object(ProxyPaymentTransactionUseCase, "_get_vtex_context")
-    def test_execute_calls_service_with_correct_params(self, mock_context):
-        mock_context.return_value = ("teststore", "teststore.myvtex.com")
+    def test_execute_calls_service_with_correct_params(self):
+        self.mock_resolver.execute.return_value = ("teststore", "teststore.myvtex.com")
         self.mock_service.proxy_payment_transaction.return_value = {"ok": True}
 
         result = self.usecase.execute(dto=self.dto, project_uuid="test-uuid")
 
-        mock_context.assert_called_once_with("test-uuid", merchant_name=None)
+        self.mock_resolver.execute.assert_called_once_with(
+            "test-uuid", merchant_name=None
+        )
         self.mock_service.proxy_payment_transaction.assert_called_once_with(
             account_domain="teststore.myvtex.com",
             vtex_account="teststore",
@@ -33,9 +38,11 @@ class TestProxyPaymentTransactionUseCase(TestCase):
         )
         self.assertEqual(result, {"ok": True})
 
-    @patch.object(ProxyPaymentTransactionUseCase, "_get_vtex_context")
-    def test_execute_passes_merchant_name_to_context(self, mock_context):
-        mock_context.return_value = ("teststore", "otherstore.myvtex.com")
+    def test_execute_uses_merchant_account_for_jwt_and_host(self):
+        self.mock_resolver.execute.return_value = (
+            "otherstore",
+            "otherstore.myvtex.com",
+        )
         self.mock_service.proxy_payment_transaction.return_value = {"ok": True}
 
         dto = ProxyPaymentTransactionDTO(
@@ -45,11 +52,21 @@ class TestProxyPaymentTransactionUseCase(TestCase):
         )
         result = self.usecase.execute(dto=dto, project_uuid="test-uuid")
 
-        mock_context.assert_called_once_with("test-uuid", merchant_name="otherstore")
+        self.mock_resolver.execute.assert_called_once_with(
+            "test-uuid", merchant_name="otherstore"
+        )
         self.mock_service.proxy_payment_transaction.assert_called_once_with(
             account_domain="otherstore.myvtex.com",
-            vtex_account="teststore",
+            vtex_account="otherstore",
             transaction_id="ABC123",
             payments=[{"paymentSystem": "2", "value": 1000}],
         )
         self.assertEqual(result, {"ok": True})
+
+    def test_defaults_context_resolver_from_service(self):
+        from retail.vtex.usecases.resolve_proxy_context import (
+            ResolveProxyContextUseCase,
+        )
+
+        usecase = ProxyPaymentTransactionUseCase(vtex_io_service=MagicMock())
+        self.assertIsInstance(usecase.context_resolver, ResolveProxyContextUseCase)

--- a/retail/vtex/tests/usecases/test_proxy_vtex.py
+++ b/retail/vtex/tests/usecases/test_proxy_vtex.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from django.test import TestCase
 from rest_framework.exceptions import ValidationError
@@ -10,11 +10,14 @@ from retail.vtex.usecases.proxy_vtex import ProxyVtexUsecase
 class ProxyVtexUsecaseTest(TestCase):
     def setUp(self):
         self.mock_service = MagicMock()
-        self.usecase = ProxyVtexUsecase(vtex_io_service=self.mock_service)
+        self.mock_resolver = MagicMock()
+        self.usecase = ProxyVtexUsecase(
+            vtex_io_service=self.mock_service,
+            context_resolver=self.mock_resolver,
+        )
 
-    @patch.object(ProxyVtexUsecase, "_get_vtex_context")
-    def test_execute_returns_service_response(self, mock_context):
-        mock_context.return_value = ("lojasrede", "lojasrede.myvtex.com")
+    def test_execute_returns_service_response(self):
+        self.mock_resolver.execute.return_value = ("lojasrede", "lojasrede.myvtex.com")
         self.mock_service.proxy_vtex.return_value = {"ok": True}
 
         result = self.usecase.execute(
@@ -24,7 +27,9 @@ class ProxyVtexUsecaseTest(TestCase):
         )
 
         self.assertEqual(result, {"ok": True})
-        mock_context.assert_called_once_with("project-uuid", merchant_name=None)
+        self.mock_resolver.execute.assert_called_once_with(
+            "project-uuid", merchant_name=None
+        )
         self.mock_service.proxy_vtex.assert_called_once_with(
             account_domain="lojasrede.myvtex.com",
             vtex_account="lojasrede",
@@ -35,9 +40,11 @@ class ProxyVtexUsecaseTest(TestCase):
             params=None,
         )
 
-    @patch.object(ProxyVtexUsecase, "_get_vtex_context")
-    def test_execute_passes_merchant_name_to_context(self, mock_context):
-        mock_context.return_value = ("lojasrede", "otherstore.myvtex.com")
+    def test_execute_uses_merchant_account_for_jwt_and_host(self):
+        self.mock_resolver.execute.return_value = (
+            "otherstore",
+            "otherstore.myvtex.com",
+        )
         self.mock_service.proxy_vtex.return_value = {"ok": True}
 
         result = self.usecase.execute(
@@ -48,12 +55,12 @@ class ProxyVtexUsecaseTest(TestCase):
         )
 
         self.assertEqual(result, {"ok": True})
-        mock_context.assert_called_once_with(
+        self.mock_resolver.execute.assert_called_once_with(
             "project-uuid", merchant_name="otherstore"
         )
         self.mock_service.proxy_vtex.assert_called_once_with(
             account_domain="otherstore.myvtex.com",
-            vtex_account="lojasrede",
+            vtex_account="otherstore",
             method="GET",
             path="/api/oms/pvt/orders",
             headers=None,
@@ -61,9 +68,10 @@ class ProxyVtexUsecaseTest(TestCase):
             params=None,
         )
 
-    @patch.object(ProxyVtexUsecase, "_get_vtex_context")
-    def test_execute_raises_validation_error_when_context_invalid(self, mock_context):
-        mock_context.side_effect = ValueError("Project not found for given UUID.")
+    def test_execute_raises_validation_error_when_context_invalid(self):
+        self.mock_resolver.execute.side_effect = ValueError(
+            "Project not found for given UUID."
+        )
 
         with self.assertRaises(ValidationError):
             self.usecase.execute(
@@ -74,9 +82,8 @@ class ProxyVtexUsecaseTest(TestCase):
 
         self.mock_service.proxy_vtex.assert_not_called()
 
-    @patch.object(ProxyVtexUsecase, "_get_vtex_context")
-    def test_execute_reraises_custom_api_exception(self, mock_context):
-        mock_context.return_value = ("lojasrede", "lojasrede.myvtex.com")
+    def test_execute_reraises_custom_api_exception(self):
+        self.mock_resolver.execute.return_value = ("lojasrede", "lojasrede.myvtex.com")
         self.mock_service.proxy_vtex.side_effect = CustomAPIException(
             detail="upstream error",
             status_code=429,
@@ -91,11 +98,8 @@ class ProxyVtexUsecaseTest(TestCase):
 
         self.assertEqual(ctx.exception.status_code, 429)
 
-    @patch.object(ProxyVtexUsecase, "_get_vtex_context")
-    def test_execute_wraps_unexpected_errors_as_custom_api_exception(
-        self, mock_context
-    ):
-        mock_context.return_value = ("lojasrede", "lojasrede.myvtex.com")
+    def test_execute_wraps_unexpected_errors_as_custom_api_exception(self):
+        self.mock_resolver.execute.return_value = ("lojasrede", "lojasrede.myvtex.com")
         self.mock_service.proxy_vtex.side_effect = RuntimeError("boom")
 
         with self.assertRaises(CustomAPIException) as ctx:
@@ -107,3 +111,11 @@ class ProxyVtexUsecaseTest(TestCase):
 
         self.assertEqual(ctx.exception.status_code, 502)
         self.assertIn("Unexpected proxy error", str(ctx.exception.detail))
+
+    def test_defaults_context_resolver_from_service(self):
+        from retail.vtex.usecases.resolve_proxy_context import (
+            ResolveProxyContextUseCase,
+        )
+
+        usecase = ProxyVtexUsecase(vtex_io_service=MagicMock())
+        self.assertIsInstance(usecase.context_resolver, ResolveProxyContextUseCase)

--- a/retail/vtex/tests/usecases/test_resolve_proxy_context.py
+++ b/retail/vtex/tests/usecases/test_resolve_proxy_context.py
@@ -1,0 +1,292 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.clients.exceptions import CustomAPIException
+from retail.projects.models import Project
+from retail.vtex.exceptions import MerchantAccountNotAllowedError
+from retail.vtex.usecases.resolve_proxy_context import (
+    SELLER_REGISTER_PATH,
+    ResolveProxyContextUseCase,
+)
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test-resolve-proxy-context",
+        }
+    }
+)
+class ResolveProxyContextUseCaseTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.mock_service = MagicMock()
+        self.usecase = ResolveProxyContextUseCase(vtex_io_service=self.mock_service)
+        self.project = Project.objects.create(
+            name="Test Project",
+            uuid=uuid4(),
+            vtex_account="fakeaccount",
+        )
+        self.project_uuid = str(self.project.uuid)
+
+    def test_returns_parent_context_when_merchant_name_absent(self):
+        vtex_account, domain = self.usecase.execute(self.project_uuid)
+
+        self.assertEqual(vtex_account, "fakeaccount")
+        self.assertEqual(domain, "fakeaccount.myvtex.com")
+        self.mock_service.proxy_vtex.assert_not_called()
+
+    def test_returns_parent_context_when_merchant_name_matches_project(self):
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="FakeAccount"
+        )
+
+        self.assertEqual(vtex_account, "fakeaccount")
+        self.assertEqual(domain, "fakeaccount.myvtex.com")
+        self.mock_service.proxy_vtex.assert_not_called()
+
+    def test_rejects_malformed_merchant_name_without_calling_vtex(self):
+        with self.assertRaises(MerchantAccountNotAllowedError) as ctx:
+            self.usecase.execute(self.project_uuid, merchant_name="bad_name!")
+
+        self.assertEqual(ctx.exception.merchant_name, "bad_name!")
+        self.assertEqual(ctx.exception.project_account, "fakeaccount")
+        self.mock_service.proxy_vtex.assert_not_called()
+
+    def test_allows_merchant_from_seller_by_id(self):
+        self.mock_service.proxy_vtex.return_value = {
+            "account": "otherstore",
+            "isVtex": True,
+        }
+
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "otherstore")
+        self.assertEqual(domain, "otherstore.myvtex.com")
+        self.mock_service.proxy_vtex.assert_called_once_with(
+            account_domain="fakeaccount.myvtex.com",
+            vtex_account="fakeaccount",
+            method="GET",
+            path=f"{SELLER_REGISTER_PATH}/otherstore",
+            params=None,
+        )
+
+    def test_denies_seller_when_is_vtex_is_false(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            {"account": "otherstore", "isVtex": False},
+            [],
+        ]
+
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+    def test_allows_merchant_from_list_after_by_id_404(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            CustomAPIException(detail="not found", status_code=404),
+            [{"account": "otherstore", "isVtex": True}],
+        ]
+
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "otherstore")
+        self.assertEqual(domain, "otherstore.myvtex.com")
+        list_call = self.mock_service.proxy_vtex.call_args_list[1][1]
+        self.assertEqual(list_call["account_domain"], "fakeaccount.myvtex.com")
+        self.assertEqual(list_call["vtex_account"], "fakeaccount")
+        self.assertEqual(list_call["path"], SELLER_REGISTER_PATH)
+        self.assertEqual(
+            list_call["params"],
+            {"keyword": "otherstore", "from": "0", "to": "100"},
+        )
+
+    def test_denies_when_list_has_no_matching_seller(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            CustomAPIException(detail="not found", status_code=404),
+            [{"account": "someoneelse", "isVtex": True}],
+        ]
+
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+    def test_does_not_cache_deny_on_non_404_upstream_error(self):
+        self.mock_service.proxy_vtex.side_effect = CustomAPIException(
+            detail="boom", status_code=500
+        )
+
+        with self.assertRaises(CustomAPIException):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+        self.mock_service.proxy_vtex.reset_mock()
+        self.mock_service.proxy_vtex.side_effect = CustomAPIException(
+            detail="boom", status_code=500
+        )
+
+        with self.assertRaises(CustomAPIException):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+        self.mock_service.proxy_vtex.assert_called_once()
+
+    def test_cache_hit_skips_seller_lookup(self):
+        self.mock_service.proxy_vtex.return_value = {
+            "account": "otherstore",
+            "isVtex": True,
+        }
+        self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+        self.mock_service.proxy_vtex.reset_mock()
+
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "otherstore")
+        self.assertEqual(domain, "otherstore.myvtex.com")
+        self.mock_service.proxy_vtex.assert_not_called()
+
+    def test_deny_is_cached(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            CustomAPIException(detail="not found", status_code=404),
+            [],
+        ]
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+        self.mock_service.proxy_vtex.reset_mock()
+
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+        self.mock_service.proxy_vtex.assert_not_called()
+
+    def test_does_not_match_non_string_account(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            {"account": 123, "isVtex": True},
+            [],
+        ]
+
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+    def test_does_not_match_seller_name_field(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            {"name": "otherstore", "account": "someoneelse", "isVtex": True},
+            [],
+        ]
+
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+    def test_does_not_match_merchant_name_field(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            {
+                "MerchantName": "otherstore",
+                "account": "someoneelse",
+                "isVtex": True,
+            },
+            [],
+        ]
+
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+    def test_allows_seller_list_payload_from_by_id(self):
+        self.mock_service.proxy_vtex.return_value = [
+            "skip",
+            {"account": "otherstore", "isVtex": True},
+        ]
+
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "otherstore")
+        self.assertEqual(domain, "otherstore.myvtex.com")
+
+    def test_allows_seller_from_list_items_key(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            CustomAPIException(detail="not found", status_code=404),
+            {"items": [{"account": "otherstore", "isVtex": True}]},
+        ]
+
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "otherstore")
+        self.assertEqual(domain, "otherstore.myvtex.com")
+
+    def test_allows_seller_from_list_data_key(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            CustomAPIException(detail="not found", status_code=404),
+            {"data": [{"account": "otherstore", "isVtex": True}]},
+        ]
+
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "otherstore")
+        self.assertEqual(domain, "otherstore.myvtex.com")
+
+    def test_treats_list_404_as_empty(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            CustomAPIException(detail="not found", status_code=404),
+            CustomAPIException(detail="not found", status_code=404),
+        ]
+
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+    def test_ignores_non_dict_seller_payload(self):
+        self.mock_service.proxy_vtex.side_effect = ["not-a-seller", []]
+
+        with self.assertRaises(MerchantAccountNotAllowedError):
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+    def test_allows_when_is_vtex_is_missing(self):
+        self.mock_service.proxy_vtex.return_value = {"account": "otherstore"}
+
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "otherstore")
+        self.assertEqual(domain, "otherstore.myvtex.com")
+
+    def test_propagates_list_non_404_upstream_error(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            CustomAPIException(detail="not found", status_code=404),
+            CustomAPIException(detail="boom", status_code=503),
+        ]
+
+        with self.assertRaises(CustomAPIException) as ctx:
+            self.usecase.execute(self.project_uuid, merchant_name="otherstore")
+
+        self.assertEqual(ctx.exception.status_code, 503)
+
+    def test_treats_empty_merchant_name_as_parent(self):
+        vtex_account, domain = self.usecase.execute(self.project_uuid, merchant_name="")
+
+        self.assertEqual(vtex_account, "fakeaccount")
+        self.assertEqual(domain, "fakeaccount.myvtex.com")
+        self.mock_service.proxy_vtex.assert_not_called()
+
+    def test_allows_seller_from_sellers_key(self):
+        self.mock_service.proxy_vtex.side_effect = [
+            CustomAPIException(detail="not found", status_code=404),
+            {"sellers": [{"Account": "otherstore", "IsVtex": True}]},
+        ]
+
+        vtex_account, domain = self.usecase.execute(
+            self.project_uuid, merchant_name="otherstore"
+        )
+
+        self.assertEqual(vtex_account, "otherstore")
+        self.assertEqual(domain, "otherstore.myvtex.com")

--- a/retail/vtex/usecases/base.py
+++ b/retail/vtex/usecases/base.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Optional, Tuple
+from typing import Tuple
 
 from django.core.cache import cache
 from retail.projects.models import Project
@@ -13,14 +13,9 @@ class BaseVtexUseCase(ABC):
     Provides common utilities such as domain and account resolution from project UUID.
     """
 
-    def _get_vtex_context(
-        self, project_uuid: str, merchant_name: Optional[str] = None
-    ) -> Tuple[str, str]:
+    def _get_vtex_context(self, project_uuid: str) -> Tuple[str, str]:
         """
         Retrieves VTEX account and domain for a project (single DB hit, cached).
-
-        When merchant_name is provided, the returned domain uses that account name
-        while vtex_account remains the project's account (used for JWT auth).
 
         Returns:
             Tuple of (vtex_account, account_domain).
@@ -28,26 +23,21 @@ class BaseVtexUseCase(ABC):
         cache_key = f"project_vtex_context_{project_uuid}"
         cached = cache.get(cache_key)
         if cached:
-            vtex_account, _project_domain = cached
-        else:
-            try:
-                project = Project.objects.get(uuid=project_uuid)
-            except Project.DoesNotExist:
-                raise ValueError("Project not found for given UUID.")
+            return cached
 
-            if not project.vtex_account:
-                raise ValueError("VTEX account not defined for project.")
+        try:
+            project = Project.objects.get(uuid=project_uuid)
+        except Project.DoesNotExist:
+            raise ValueError("Project not found for given UUID.")
 
-            vtex_account = project.vtex_account
-            project_domain = f"{vtex_account}.myvtex.com"
-            cache.set(
-                cache_key,
-                (vtex_account, project_domain),
-                timeout=VTEX_CONTEXT_CACHE_TTL,
-            )
+        if not project.vtex_account:
+            raise ValueError("VTEX account not defined for project.")
 
-        domain_account = merchant_name or vtex_account
-        return (vtex_account, f"{domain_account}.myvtex.com")
+        vtex_account = project.vtex_account
+        project_domain = f"{vtex_account}.myvtex.com"
+        context = (vtex_account, project_domain)
+        cache.set(cache_key, context, timeout=VTEX_CONTEXT_CACHE_TTL)
+        return context
 
     def _get_account_domain(self, project_uuid: str) -> str:
         """Shortcut that returns only the domain."""

--- a/retail/vtex/usecases/proxy_payment_gateway.py
+++ b/retail/vtex/usecases/proxy_payment_gateway.py
@@ -1,8 +1,10 @@
 import logging
+from typing import Optional
 
 from retail.services.vtex_io.service import VtexIOService
 from retail.vtex.dtos.proxy_payment_gateway_dto import ProxyPaymentGatewayDTO
 from retail.vtex.usecases.base import BaseVtexUseCase
+from retail.vtex.usecases.resolve_proxy_context import ResolveProxyContextUseCase
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +15,15 @@ class ProxyPaymentGatewayUseCase(BaseVtexUseCase):
     proxy route (/_v/proxy-payment-gateway).
     """
 
-    def __init__(self, vtex_io_service: VtexIOService):
+    def __init__(
+        self,
+        vtex_io_service: VtexIOService,
+        context_resolver: Optional[ResolveProxyContextUseCase] = None,
+    ):
         self.vtex_io_service = vtex_io_service
+        self.context_resolver = context_resolver or ResolveProxyContextUseCase(
+            vtex_io_service
+        )
 
     def execute(self, dto: ProxyPaymentGatewayDTO, project_uuid: str) -> dict:
         """
@@ -27,7 +36,7 @@ class ProxyPaymentGatewayUseCase(BaseVtexUseCase):
         Returns:
             dict: Response from the VTEX IO proxy-payment-gateway route.
         """
-        vtex_account, account_domain = self._get_vtex_context(
+        vtex_account, account_domain = self.context_resolver.execute(
             project_uuid, merchant_name=dto.merchant_name
         )
 

--- a/retail/vtex/usecases/proxy_payment_transaction.py
+++ b/retail/vtex/usecases/proxy_payment_transaction.py
@@ -1,8 +1,10 @@
 import logging
+from typing import Optional
 
 from retail.services.vtex_io.service import VtexIOService
 from retail.vtex.dtos.proxy_payment_transaction_dto import ProxyPaymentTransactionDTO
 from retail.vtex.usecases.base import BaseVtexUseCase
+from retail.vtex.usecases.resolve_proxy_context import ResolveProxyContextUseCase
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +15,15 @@ class ProxyPaymentTransactionUseCase(BaseVtexUseCase):
     agentic-cx proxy-payment-transaction route.
     """
 
-    def __init__(self, vtex_io_service: VtexIOService):
+    def __init__(
+        self,
+        vtex_io_service: VtexIOService,
+        context_resolver: Optional[ResolveProxyContextUseCase] = None,
+    ):
         self.vtex_io_service = vtex_io_service
+        self.context_resolver = context_resolver or ResolveProxyContextUseCase(
+            vtex_io_service
+        )
 
     def execute(self, dto: ProxyPaymentTransactionDTO, project_uuid: str) -> dict:
         """
@@ -27,7 +36,7 @@ class ProxyPaymentTransactionUseCase(BaseVtexUseCase):
         Returns:
             dict: Response from the VTEX IO proxy-payment-transaction route.
         """
-        vtex_account, account_domain = self._get_vtex_context(
+        vtex_account, account_domain = self.context_resolver.execute(
             project_uuid, merchant_name=dto.merchant_name
         )
 

--- a/retail/vtex/usecases/proxy_vtex.py
+++ b/retail/vtex/usecases/proxy_vtex.py
@@ -10,6 +10,7 @@ from retail.observability.sentry import (
 )
 from retail.services.vtex_io.service import VtexIOService
 from retail.vtex.usecases.base import BaseVtexUseCase
+from retail.vtex.usecases.resolve_proxy_context import ResolveProxyContextUseCase
 
 
 logger = logging.getLogger(__name__)
@@ -22,14 +23,22 @@ class ProxyVtexUsecase(BaseVtexUseCase):
     Use case for proxying requests to VTEX IO API endpoints.
     """
 
-    def __init__(self, vtex_io_service: VtexIOService):
+    def __init__(
+        self,
+        vtex_io_service: VtexIOService,
+        context_resolver: Optional[ResolveProxyContextUseCase] = None,
+    ):
         """
         Initialize the proxy VTEX use case.
 
         Args:
             vtex_io_service (VtexIOService): The VTEX IO service instance.
+            context_resolver: Resolves JWT account and host, including merchant overrides.
         """
         self.vtex_io_service = vtex_io_service
+        self.context_resolver = context_resolver or ResolveProxyContextUseCase(
+            vtex_io_service
+        )
 
     def execute(
         self,
@@ -51,8 +60,8 @@ class ProxyVtexUsecase(BaseVtexUseCase):
             data (Union[dict, list], optional): Request body data for POST, PUT, PATCH requests.
             params (dict, optional): Query parameters to be appended to the URL.
             project_uuid (str): Project UUID to get the account domain.
-            merchant_name (str, optional): Overrides only the account domain used in
-                the proxy URL; JWT auth still uses the project's vtex_account.
+            merchant_name (str, optional): When allowed as a seller of the project
+                account, JWT and host both target this merchant.
 
         Returns:
             dict: Response data from VTEX platform.
@@ -62,7 +71,7 @@ class ProxyVtexUsecase(BaseVtexUseCase):
             CustomAPIException: When the upstream VTEX IO request fails.
         """
         try:
-            vtex_account, account_domain = self._get_vtex_context(
+            vtex_account, account_domain = self.context_resolver.execute(
                 project_uuid, merchant_name=merchant_name
             )
         except ValueError as exc:

--- a/retail/vtex/usecases/resolve_proxy_context.py
+++ b/retail/vtex/usecases/resolve_proxy_context.py
@@ -1,0 +1,188 @@
+import logging
+import re
+from typing import Optional, Tuple
+
+from django.core.cache import cache
+
+from retail.clients.exceptions import CustomAPIException
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.exceptions import MerchantAccountNotAllowedError
+from retail.vtex.usecases.base import BaseVtexUseCase
+
+logger = logging.getLogger(__name__)
+
+VTEX_ACCOUNT_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]{0,48}[a-z0-9])?$")
+SELLER_REGISTER_PATH = "/api/seller-register/pvt/sellers"
+MERCHANT_ACCESS_CACHE_TTL = 3600
+CACHE_ALLOW = "allow"
+CACHE_DENY = "deny"
+
+
+class ResolveProxyContextUseCase(BaseVtexUseCase):
+    """
+    Resolves the VTEX account and host for proxy calls.
+
+    JWT and host always target the same account. A merchant override is
+    accepted only when seller-register on the parent account lists that
+    merchant as a VTEX seller.
+    """
+
+    def __init__(self, vtex_io_service: VtexIOService):
+        self.vtex_io_service = vtex_io_service
+
+    def execute(
+        self, project_uuid: str, merchant_name: Optional[str] = None
+    ) -> Tuple[str, str]:
+        parent_account, parent_domain = self._get_vtex_context(project_uuid)
+
+        if self._targets_parent_account(merchant_name, parent_account):
+            return parent_account, parent_domain
+
+        if not self._is_valid_vtex_account_name(merchant_name):
+            logger.warning(
+                f"Rejected malformed merchant_name={merchant_name!r} "
+                f"for parent_account={parent_account}"
+            )
+            raise MerchantAccountNotAllowedError(merchant_name, parent_account)
+
+        cached = self._cached_decision(parent_account, merchant_name)
+        if cached is False:
+            raise MerchantAccountNotAllowedError(merchant_name, parent_account)
+        if cached is True:
+            return self._merchant_context(merchant_name)
+
+        allowed = self._is_seller_of_parent(
+            parent_account, parent_domain, merchant_name
+        )
+        self._store_decision(parent_account, merchant_name, allowed)
+        if not allowed:
+            logger.warning(
+                f"Denied merchant_name={merchant_name} for "
+                f"parent_account={parent_account}: not a VTEX seller"
+            )
+            raise MerchantAccountNotAllowedError(merchant_name, parent_account)
+
+        logger.info(
+            f"Allowed merchant_name={merchant_name} as seller of "
+            f"parent_account={parent_account}"
+        )
+        return self._merchant_context(merchant_name)
+
+    def _targets_parent_account(
+        self, merchant_name: Optional[str], parent_account: str
+    ) -> bool:
+        if not merchant_name:
+            return True
+        return merchant_name.lower() == parent_account.lower()
+
+    def _is_valid_vtex_account_name(self, merchant_name: str) -> bool:
+        return bool(VTEX_ACCOUNT_PATTERN.fullmatch(merchant_name))
+
+    def _merchant_context(self, merchant_name: str) -> Tuple[str, str]:
+        return merchant_name, f"{merchant_name}.myvtex.com"
+
+    def _cache_key(self, parent_account: str, merchant_name: str) -> str:
+        return (
+            f"proxy_merchant_allowed_{parent_account.lower()}_{merchant_name.lower()}"
+        )
+
+    def _cached_decision(
+        self, parent_account: str, merchant_name: str
+    ) -> Optional[bool]:
+        cached = cache.get(self._cache_key(parent_account, merchant_name))
+        if cached == CACHE_ALLOW:
+            return True
+        if cached == CACHE_DENY:
+            return False
+        return None
+
+    def _store_decision(
+        self, parent_account: str, merchant_name: str, allowed: bool
+    ) -> None:
+        cache.set(
+            self._cache_key(parent_account, merchant_name),
+            CACHE_ALLOW if allowed else CACHE_DENY,
+            timeout=MERCHANT_ACCESS_CACHE_TTL,
+        )
+
+    def _is_seller_of_parent(
+        self, parent_account: str, parent_domain: str, merchant_name: str
+    ) -> bool:
+        seller = self._fetch_seller_by_id(parent_account, parent_domain, merchant_name)
+        if seller is not None and self._seller_matches(seller, merchant_name):
+            return True
+
+        for candidate in self._list_sellers(
+            parent_account, parent_domain, merchant_name
+        ):
+            if self._seller_matches(candidate, merchant_name):
+                return True
+        return False
+
+    def _fetch_seller_by_id(
+        self, parent_account: str, parent_domain: str, merchant_name: str
+    ) -> Optional[dict]:
+        try:
+            payload = self._proxy_parent(
+                parent_account,
+                parent_domain,
+                path=f"{SELLER_REGISTER_PATH}/{merchant_name}",
+            )
+        except CustomAPIException as exc:
+            if exc.status_code == 404:
+                return None
+            raise
+
+        sellers = self._as_seller_list(payload)
+        return sellers[0] if sellers else None
+
+    def _list_sellers(
+        self, parent_account: str, parent_domain: str, merchant_name: str
+    ) -> list:
+        try:
+            payload = self._proxy_parent(
+                parent_account,
+                parent_domain,
+                path=SELLER_REGISTER_PATH,
+                params={"keyword": merchant_name, "from": "0", "to": "100"},
+            )
+        except CustomAPIException as exc:
+            if exc.status_code == 404:
+                return []
+            raise
+        return self._as_seller_list(payload)
+
+    def _proxy_parent(
+        self,
+        parent_account: str,
+        parent_domain: str,
+        path: str,
+        params: Optional[dict] = None,
+    ):
+        return self.vtex_io_service.proxy_vtex(
+            account_domain=parent_domain,
+            vtex_account=parent_account,
+            method="GET",
+            path=path,
+            params=params,
+        )
+
+    def _as_seller_list(self, payload) -> list:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if not isinstance(payload, dict):
+            return []
+        for key in ("items", "data", "sellers"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+        return [payload]
+
+    def _seller_matches(self, seller: dict, merchant_name: str) -> bool:
+        account = seller.get("account") or seller.get("Account")
+        if not isinstance(account, str):
+            return False
+        if account.lower() != merchant_name.lower():
+            return False
+        is_vtex = seller.get("isVtex", seller.get("IsVtex"))
+        return is_vtex is not False

--- a/retail/vtex/views.py
+++ b/retail/vtex/views.py
@@ -9,6 +9,7 @@ from retail.clients.exceptions import CustomAPIException
 from retail.internal.jwt_mixins import JWTModuleAuthMixin
 from retail.internal.views import KeycloakAPIView
 from retail.internal.weni_mixins import WeniAuthMixin
+from retail.vtex.exceptions import MerchantAccountNotAllowedError
 
 from retail.vtex.dtos.register_order_form_dto import RegisterOrderFormDTO
 from retail.vtex.serializers import (
@@ -56,6 +57,15 @@ class BaseVtexProxyView(JWTModuleAuthMixin, APIView):
 
     Includes shared behaviors like JWT authentication.
     """
+
+    def handle_exception(self, exc):
+        if isinstance(exc, MerchantAccountNotAllowedError):
+            logger.warning(str(exc))
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return super().handle_exception(exc)
 
 
 class OrdersProxyView(BaseVtexProxyView):


### PR DESCRIPTION
## Merchant Account Validation for VTEX Proxy Routes

- Added `MerchantAccountNotAllowedError` to handle cases where a `merchant_name` is not a seller of the project's VTEX account.
- Updated `BaseVtexProxyView` to log and return a 403 response when this exception is raised.
- Extracted merchant resolution logic into a new `ResolveProxyContextUseCase` that validates a `merchant_name` against the parent account's seller register before allowing it to be used as both the JWT account and proxy host.
- `ProxyVtexUsecase`, `ProxyPaymentGatewayUseCase`, and `ProxyPaymentTransactionUseCase` now delegate context resolution to `ResolveProxyContextUseCase` via an injectable `context_resolver`, defaulting to a standard instance when none is provided.
- Simplified `BaseVtexUseCase._get_vtex_context` by removing the `merchant_name` override parameter, since that responsibility now belongs to `ResolveProxyContextUseCase`.
- Added caching for seller allow/deny decisions to avoid redundant calls to the VTEX seller register API.
- Added tests covering seller lookup by ID and by list, cache behavior, malformed merchant names, non-VTEX sellers, and upstream error propagation.