### PR TITLE
feat: Integrate Agentic CX script activation into onboarding and agent assignment processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.54.0
+- fix: Ignore pre-cart VTEX orders in purchase detection
+
 # 5.53.0
 - fix: Ignore pre-cart VTEX orders in purchase detection
 - feat: Route order-status and PIX webhooks to origin sub-accounts

--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -24,6 +24,7 @@ from retail.services.integrations.service import IntegrationsService
 from retail.services.meta import MetaService
 from retail.interfaces.services.integrations import IntegrationsServiceInterface
 from retail.interfaces.services.meta import MetaServiceInterface
+from retail.projects.agentic_cx_tasks import task_ensure_agentic_cx_script_active
 from retail.projects.models import Project
 from retail.templates.usecases.create_library_template import (
     LibraryTemplateData,
@@ -727,6 +728,12 @@ class AssignAgentUseCase:
             direct_send=direct_send,
         )
         logger.info(f"[AssignAgent] integrated_agent created={integrated_agent.uuid}")
+
+        vtex_account = project.vtex_account
+        if vtex_account:
+            transaction.on_commit(
+                lambda: task_ensure_agentic_cx_script_active.delay(vtex_account)
+            )
 
         self._create_credentials(integrated_agent, agent, credentials)
 

--- a/retail/agents/tests/usecases/test_assign_agent.py
+++ b/retail/agents/tests/usecases/test_assign_agent.py
@@ -565,6 +565,38 @@ class AssignAgentUseCaseTest(TestCase):
         self.assertEqual(integrated_agent.project, self.project)
         self.assertTrue(integrated_agent.is_active)
 
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.task_ensure_agentic_cx_script_active"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateLibraryTemplateUseCase"
+    )
+    def test_execute_dispatches_agentic_cx_script_on_commit(
+        self, mock_create_library_use_case, mock_task
+    ):
+        mock_integrations_service = MagicMock()
+        mock_integrations_service.fetch_templates_from_user.return_value = {}
+        use_case = AssignAgentUseCase(
+            integrations_service=mock_integrations_service,
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+        )
+        mock_create_library_use_case.return_value.execute.return_value = (
+            MagicMock(),
+            MagicMock(),
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            use_case.execute(
+                self.agent,
+                self.project.uuid,
+                uuid.uuid4(),
+                uuid.uuid4(),
+                {"api_key": "test_key"},
+                [],
+            )
+
+        mock_task.delay.assert_called_once_with("teststore")
+
     def test_execute_project_not_found(self):
         random_uuid = uuid.uuid4()
         with self.assertRaises(NotFound):

--- a/retail/api/onboard/usecases/activate_wpp_cloud.py
+++ b/retail/api/onboard/usecases/activate_wpp_cloud.py
@@ -6,6 +6,7 @@ from rest_framework.exceptions import NotFound, ValidationError
 
 from retail.agents.domains.agent_integration.models import IntegratedAgent
 from retail.api.onboard.usecases.dto import ActivateWppCloudDTO
+from retail.projects.agentic_cx_tasks import task_ensure_agentic_cx_script_active
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,7 @@ class ActivateWppCloudUseCase:
             raise ValidationError("ABANDONED_CART_AGENT_UUID is not configured.")
 
         try:
-            integrated_agent = IntegratedAgent.objects.get(
+            integrated_agent = IntegratedAgent.objects.select_related("project").get(
                 agent__uuid=abandoned_cart_uuid,
                 project__uuid=dto.project_uuid,
                 project__is_active=True,
@@ -36,6 +37,10 @@ class ActivateWppCloudUseCase:
 
         integrated_agent.contact_percentage = dto.percentage
         integrated_agent.save(update_fields=["contact_percentage"])
+
+        vtex_account = integrated_agent.project.vtex_account
+        if vtex_account:
+            task_ensure_agentic_cx_script_active.delay(vtex_account)
 
         logger.info(
             f"WPP Cloud abandoned cart activated: "

--- a/retail/api/onboard/usecases/publish_webchat_script.py
+++ b/retail/api/onboard/usecases/publish_webchat_script.py
@@ -7,6 +7,7 @@ from typing import List
 from rest_framework.exceptions import APIException, ValidationError
 
 from retail.api.onboard.usecases.dto import ActivateWebchatDTO
+from retail.projects.agentic_cx_tasks import task_ensure_agentic_cx_script_active
 from retail.services.integrations.service import IntegrationsService
 from retail.services.webchat_push.service import WebchatPublishError, WebchatPushService
 
@@ -63,6 +64,8 @@ class PublishWebchatScriptUseCase:
         logger.info(
             f"Webchat script published successfully for app_uuid={dto.app_uuid} at {uploaded_urls}"
         )
+
+        task_ensure_agentic_cx_script_active.delay(dto.vtex_account)
 
         return PublishWebchatResult(script_urls=uploaded_urls)
 

--- a/retail/api/onboard/usecases/tests/test_activate_wpp_cloud.py
+++ b/retail/api/onboard/usecases/tests/test_activate_wpp_cloud.py
@@ -1,4 +1,5 @@
 from uuid import uuid4
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
@@ -33,6 +34,11 @@ class TestActivateWppCloudUseCase(TestCase):
             is_active=True,
             contact_percentage=0,
         )
+        self._task_patcher = patch(
+            "retail.api.onboard.usecases.activate_wpp_cloud.task_ensure_agentic_cx_script_active"
+        )
+        self.mock_task = self._task_patcher.start()
+        self.addCleanup(self._task_patcher.stop)
         self.use_case = ActivateWppCloudUseCase()
 
     def test_sets_contact_percentage(self):
@@ -46,6 +52,7 @@ class TestActivateWppCloudUseCase(TestCase):
         self.integrated_agent.refresh_from_db()
         self.assertEqual(result.contact_percentage, 10)
         self.assertEqual(self.integrated_agent.contact_percentage, 10)
+        self.mock_task.delay.assert_called_once_with("mystore")
 
     def test_sets_percentage_to_zero(self):
         self.integrated_agent.contact_percentage = 50
@@ -72,6 +79,8 @@ class TestActivateWppCloudUseCase(TestCase):
         with self.assertRaises(NotFound):
             self.use_case.execute(dto)
 
+        self.mock_task.delay.assert_not_called()
+
     def test_raises_not_found_when_agent_inactive(self):
         self.integrated_agent.is_active = False
         self.integrated_agent.save()
@@ -83,6 +92,8 @@ class TestActivateWppCloudUseCase(TestCase):
 
         with self.assertRaises(NotFound):
             self.use_case.execute(dto)
+
+        self.mock_task.delay.assert_not_called()
 
     @override_settings(ABANDONED_CART_AGENT_UUID="")
     def test_raises_validation_error_when_uuid_not_configured(self):

--- a/retail/api/onboard/usecases/tests/test_publish_webchat_script.py
+++ b/retail/api/onboard/usecases/tests/test_publish_webchat_script.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from rest_framework.exceptions import APIException, ValidationError
@@ -13,6 +13,12 @@ from retail.services.webchat_push.service import WebchatPublishError
 
 class TestPublishWebchatScriptUseCase(TestCase):
     def setUp(self):
+        self._task_patcher = patch(
+            "retail.api.onboard.usecases.publish_webchat_script.task_ensure_agentic_cx_script_active"
+        )
+        self.mock_task = self._task_patcher.start()
+        self.addCleanup(self._task_patcher.stop)
+
         self.integrations_service = MagicMock()
         self.webchat_push_service = MagicMock()
         self.usecase = PublishWebchatScriptUseCase(
@@ -52,6 +58,7 @@ class TestPublishWebchatScriptUseCase(TestCase):
             account_id=self.dto.account_id,
             vtex_account=self.dto.vtex_account,
         )
+        self.mock_task.delay.assert_called_once_with(self.dto.vtex_account)
 
     def test_execute_raises_validation_error_when_app_not_found(self):
         self.integrations_service.get_channel_app.return_value = None
@@ -85,6 +92,8 @@ class TestPublishWebchatScriptUseCase(TestCase):
 
         with self.assertRaises(APIException):
             self.usecase.execute(self.dto)
+
+        self.mock_task.delay.assert_not_called()
 
     def test_result_to_dict(self):
         result = PublishWebchatResult(script_urls=["https://example.com/webchat.js"])

--- a/retail/api/vtex_projects/tests/test_check_onboarding_complete.py
+++ b/retail/api/vtex_projects/tests/test_check_onboarding_complete.py
@@ -1,5 +1,6 @@
+from unittest.mock import MagicMock, patch
+
 from django.test import TestCase, override_settings
-from unittest.mock import patch, MagicMock
 
 from retail.api.vtex_projects.usecases.check_onboarding_complete import (
     CheckOnboardingCompleteUseCase,
@@ -7,6 +8,7 @@ from retail.api.vtex_projects.usecases.check_onboarding_complete import (
     INACTIVE_STATUS,
 )
 from retail.internal.test_mixins import TEST_SETTINGS_OVERRIDES
+from retail.projects.usecases.agentic_cx_script import onboarding_complete_cache_key
 
 
 @override_settings(**TEST_SETTINGS_OVERRIDES)
@@ -15,7 +17,10 @@ class CheckOnboardingCompleteUseCaseTest(TestCase):
         from django.core.cache import cache
 
         cache.clear()
-        self.use_case = CheckOnboardingCompleteUseCase()
+        self.mock_eligibility = MagicMock()
+        self.use_case = CheckOnboardingCompleteUseCase(
+            eligibility_use_case=self.mock_eligibility
+        )
         self.vtex_account = "teststore"
 
     def tearDown(self):
@@ -23,43 +28,18 @@ class CheckOnboardingCompleteUseCaseTest(TestCase):
 
         cache.clear()
 
-    def _make_onboarding(self, completed=True):
-        mock = MagicMock()
-        mock.completed = completed
-        return mock
-
-    @patch(
-        "retail.api.vtex_projects.usecases.check_onboarding_complete.ProjectOnboarding.objects"
-    )
-    def test_returns_complete_when_onboarding_finished(self, mock_qs):
-        onboarding = self._make_onboarding(completed=True)
-        mock_qs.get.return_value = onboarding
+    def test_returns_complete_when_eligible(self):
+        self.mock_eligibility.execute.return_value = True
 
         result = self.use_case.execute(self.vtex_account)
 
         self.assertTrue(result.is_complete)
         self.assertIsNone(result.account_id)
         self.assertEqual(result.to_dict(), {"is_complete": True, "accountId": None})
+        self.mock_eligibility.execute.assert_called_once_with(self.vtex_account)
 
-    @patch(
-        "retail.api.vtex_projects.usecases.check_onboarding_complete.ProjectOnboarding.objects"
-    )
-    def test_returns_incomplete_when_not_completed(self, mock_qs):
-        onboarding = self._make_onboarding(completed=False)
-        mock_qs.get.return_value = onboarding
-
-        result = self.use_case.execute(self.vtex_account)
-
-        self.assertFalse(result.is_complete)
-        self.assertIsNone(result.account_id)
-
-    @patch(
-        "retail.api.vtex_projects.usecases.check_onboarding_complete.ProjectOnboarding.objects"
-    )
-    def test_returns_incomplete_when_onboarding_not_found(self, mock_qs):
-        from retail.projects.models import ProjectOnboarding
-
-        mock_qs.get.side_effect = ProjectOnboarding.DoesNotExist
+    def test_returns_incomplete_when_not_eligible(self):
+        self.mock_eligibility.execute.return_value = False
 
         result = self.use_case.execute(self.vtex_account)
 
@@ -77,22 +57,19 @@ class CheckOnboardingCompleteUseCaseTest(TestCase):
 
         self.assertEqual(result, cached_result)
         mock_cache.get.assert_called_once_with(
-            f"onboarding_complete_{self.vtex_account}"
+            onboarding_complete_cache_key(self.vtex_account)
         )
+        self.mock_eligibility.execute.assert_not_called()
 
-    @patch(
-        "retail.api.vtex_projects.usecases.check_onboarding_complete.ProjectOnboarding.objects"
-    )
     @patch("retail.api.vtex_projects.usecases.check_onboarding_complete.cache")
-    def test_caches_result_with_correct_timeout(self, mock_cache, mock_qs):
+    def test_caches_result_with_correct_timeout(self, mock_cache):
         mock_cache.get.return_value = None
-        onboarding = self._make_onboarding(completed=True)
-        mock_qs.get.return_value = onboarding
+        self.mock_eligibility.execute.return_value = True
 
         result = self.use_case.execute(self.vtex_account)
 
         mock_cache.set.assert_called_once_with(
-            f"onboarding_complete_{self.vtex_account}",
+            onboarding_complete_cache_key(self.vtex_account),
             result,
             timeout=CACHE_TIMEOUT,
         )

--- a/retail/api/vtex_projects/usecases/check_onboarding_complete.py
+++ b/retail/api/vtex_projects/usecases/check_onboarding_complete.py
@@ -1,14 +1,12 @@
-import logging
-
 from dataclasses import dataclass
 from typing import Optional
 
 from django.core.cache import cache
 
-from retail.projects.models import ProjectOnboarding
-
-
-logger = logging.getLogger(__name__)
+from retail.projects.usecases.agentic_cx_script import (
+    CheckAgenticCxEligibilityUseCase,
+    onboarding_complete_cache_key,
+)
 
 CACHE_TIMEOUT = 60
 
@@ -29,10 +27,23 @@ INACTIVE_STATUS = OnboardingStatus(is_complete=False, account_id=None)
 
 
 class CheckOnboardingCompleteUseCase:
-    """Checks whether the onboarding process is fully completed for a VTEX account."""
+    """Checks whether the Agentic CX script should be active for a VTEX account.
+
+    Used by the VTEX IO app-install event. The result is a capability
+    check (channel, active agent, or completed onboarding), not the
+    wizard ``completed`` flag alone.
+    """
+
+    def __init__(
+        self,
+        eligibility_use_case: Optional[CheckAgenticCxEligibilityUseCase] = None,
+    ):
+        self._eligibility_use_case = (
+            eligibility_use_case or CheckAgenticCxEligibilityUseCase()
+        )
 
     def execute(self, vtex_account: str) -> OnboardingStatus:
-        cache_key = f"onboarding_complete_{vtex_account}"
+        cache_key = onboarding_complete_cache_key(vtex_account)
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -42,19 +53,9 @@ class CheckOnboardingCompleteUseCase:
         return result
 
     def _check(self, vtex_account: str) -> OnboardingStatus:
-        onboarding = self._get_onboarding(vtex_account)
-        if not onboarding:
-            return INACTIVE_STATUS
+        if self._eligibility_use_case.execute(vtex_account):
+            # accountId is reserved for the VTEX account ID that IO will
+            # provide in the future
+            return OnboardingStatus(is_complete=True, account_id=None)
 
-        if not onboarding.completed:
-            return INACTIVE_STATUS
-
-        # accountId is reserved for the VTEX account ID that IO will provide in the future
-        return OnboardingStatus(is_complete=True, account_id=None)
-
-    def _get_onboarding(self, vtex_account: str) -> Optional[ProjectOnboarding]:
-        try:
-            return ProjectOnboarding.objects.get(vtex_account=vtex_account)
-        except ProjectOnboarding.DoesNotExist:
-            logger.info(f"Onboarding not found for vtex_account={vtex_account}")
-            return None
+        return INACTIVE_STATUS

--- a/retail/projects/agentic_cx_tasks.py
+++ b/retail/projects/agentic_cx_tasks.py
@@ -1,0 +1,19 @@
+from celery import shared_task
+
+from retail.projects.usecases.agentic_cx_script import (
+    EnsureAgenticCxScriptActiveUseCase,
+)
+
+
+def _run_ensure_agentic_cx_script_active(vtex_account: str) -> None:
+    EnsureAgenticCxScriptActiveUseCase().execute(vtex_account)
+
+
+@shared_task(name="task_ensure_agentic_cx_script_active")
+def task_ensure_agentic_cx_script_active(vtex_account: str) -> None:
+    """
+    Ensures the Agentic CX storefront script is active for the account
+    when it is eligible (connected channel, active agent, or completed
+    onboarding).
+    """
+    _run_ensure_agentic_cx_script_active(vtex_account)

--- a/retail/projects/apps.py
+++ b/retail/projects/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class ProjectsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "retail.projects"
+
+    def ready(self):
+        """Register model signals after Django has populated the app registry."""
+        from retail.projects import signals  # noqa: F401

--- a/retail/projects/models.py
+++ b/retail/projects/models.py
@@ -1,14 +1,9 @@
-import logging
 import uuid as uuid_lib
 
 from django.db import models
-from django.db.models.signals import post_save, pre_delete, pre_save
-from django.dispatch import receiver
 from django.core.cache import cache
 
 from retail.agents.shared.cache import IntegratedAgentCacheHandlerRedis
-
-logger = logging.getLogger(__name__)
 
 
 class ActiveProjectManager(models.Manager):
@@ -124,41 +119,3 @@ class ProjectOnboarding(models.Model):
             f"step={self.current_step} progress={self.progress}% "
             f"current_page={self.current_page}, completed={self.completed}"
         )
-
-
-@receiver(pre_save, sender=ProjectOnboarding)
-def snapshot_previous_completed(sender, instance, **kwargs):
-    """
-    Stores the previous 'completed' value on the instance so post_save
-    can detect the False → True transition. Standard Django pattern for
-    field-change detection across pre_save / post_save signals.
-    """
-    if instance.pk:
-        try:
-            previous = ProjectOnboarding.all_objects.get(pk=instance.pk)
-            instance._previous_completed = previous.completed
-        except ProjectOnboarding.DoesNotExist:
-            instance._previous_completed = False
-    else:
-        instance._previous_completed = False
-
-
-@receiver(post_save, sender=ProjectOnboarding)
-def notify_io_on_onboarding_complete(sender, instance, **kwargs):
-    """Dispatches task to activate Agentic CX script when onboarding transitions to completed."""
-    was_completed = getattr(instance, "_previous_completed", False)
-
-    if not was_completed and instance.completed:
-        from retail.projects.tasks import task_activate_agentic_cx_script
-
-        task_activate_agentic_cx_script.delay(instance.vtex_account)
-
-
-@receiver(pre_delete, sender=ProjectOnboarding)
-def log_onboarding_deletion(sender, instance, **kwargs):
-    """Traces unexpected deletions (manual, admin, or CASCADE)."""
-    logger.warning(
-        f"ProjectOnboarding is being deleted: "
-        f"uuid={instance.uuid} vtex_account={instance.vtex_account} "
-        f"project={instance.project_id} progress={instance.progress}"
-    )

--- a/retail/projects/signals.py
+++ b/retail/projects/signals.py
@@ -1,0 +1,47 @@
+import logging
+
+from django.db.models.signals import post_save, pre_delete, pre_save
+from django.dispatch import receiver
+
+from retail.projects import agentic_cx_tasks
+from retail.projects.models import ProjectOnboarding
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(pre_save, sender=ProjectOnboarding)
+def snapshot_previous_completed(sender, instance, **kwargs):
+    """
+    Stores the previous 'completed' value on the instance so post_save
+    can detect the False → True transition. Standard Django pattern for
+    field-change detection across pre_save / post_save signals.
+    """
+    if instance.pk:
+        try:
+            previous = ProjectOnboarding.all_objects.get(pk=instance.pk)
+            instance._previous_completed = previous.completed
+        except ProjectOnboarding.DoesNotExist:
+            instance._previous_completed = False
+    else:
+        instance._previous_completed = False
+
+
+@receiver(post_save, sender=ProjectOnboarding)
+def notify_io_on_onboarding_complete(sender, instance, **kwargs):
+    """Dispatches task to activate Agentic CX script when onboarding transitions to completed."""
+    was_completed = getattr(instance, "_previous_completed", False)
+
+    if not was_completed and instance.completed:
+        agentic_cx_tasks.task_ensure_agentic_cx_script_active.delay(
+            instance.vtex_account
+        )
+
+
+@receiver(pre_delete, sender=ProjectOnboarding)
+def log_onboarding_deletion(sender, instance, **kwargs):
+    """Traces unexpected deletions (manual, admin, or CASCADE)."""
+    logger.warning(
+        f"ProjectOnboarding is being deleted: "
+        f"uuid={instance.uuid} vtex_account={instance.vtex_account} "
+        f"project={instance.project_id} progress={instance.progress}"
+    )

--- a/retail/projects/tasks.py
+++ b/retail/projects/tasks.py
@@ -3,19 +3,19 @@ import logging
 from celery import shared_task
 from django.core.cache import cache
 
+from retail.projects import agentic_cx_tasks
 from retail.projects.models import ProjectOnboarding
+from retail.projects.usecases.content_base_progress_helpers import (
+    STATUS_FAILED,
+    persist_content_base_progress,
+)
 from retail.projects.usecases.mark_onboarding_failed import mark_onboarding_failed
 from retail.projects.usecases.onboarding_orchestrator import OnboardingOrchestrator
 from retail.projects.usecases.pre_crawl_channel import PreCrawlChannelUseCase
 from retail.projects.usecases.save_background_failure import (
     SaveBackgroundFailureUseCase,
 )
-from retail.projects.usecases.content_base_progress_helpers import (
-    STATUS_FAILED,
-    persist_content_base_progress,
-)
 from retail.projects.usecases.upload_nexus_contents import UploadNexusContentsUseCase
-from retail.services.vtex_io.service import VtexIOService
 
 logger = logging.getLogger(__name__)
 
@@ -156,18 +156,22 @@ def task_wait_and_start_crawl(self, vtex_account: str, crawl_url: str) -> None:
     return _run_setup_channel_and_start_crawl(self, vtex_account, crawl_url)
 
 
+task_ensure_agentic_cx_script_active = (
+    agentic_cx_tasks.task_ensure_agentic_cx_script_active
+)
+
+
 @shared_task(name="task_activate_agentic_cx_script")
 def task_activate_agentic_cx_script(vtex_account: str) -> None:
     """
-    Notifies the VTEX IO app that the onboarding is complete
-    and the Agentic CX script can be installed on the storefront.
+    Deprecated alias for ``task_ensure_agentic_cx_script_active``.
+
+    Kept registered under the original Celery task name so in-flight
+    messages queued before the rename keep executing the capability-based
+    activation. New dispatches MUST use
+    ``task_ensure_agentic_cx_script_active`` directly.
     """
-    account_domain = f"{vtex_account}.myvtex.com"
-    VtexIOService().activate_agentic_cx_script(
-        account_domain=account_domain,
-        vtex_account=vtex_account,
-    )
-    logger.info(f"Agentic CX script activated for vtex_account={vtex_account}")
+    agentic_cx_tasks._run_ensure_agentic_cx_script_active(vtex_account)
 
 
 UPLOAD_NEXUS_LOCK_NAME = "upload_nexus_contents"

--- a/retail/projects/tests/test_agentic_cx_dispatch.py
+++ b/retail/projects/tests/test_agentic_cx_dispatch.py
@@ -1,0 +1,225 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase, override_settings
+from rest_framework.exceptions import APIException, NotFound, ValidationError
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.api.onboard.usecases.activate_wpp_cloud import ActivateWppCloudUseCase
+from retail.api.onboard.usecases.dto import ActivateWebchatDTO, ActivateWppCloudDTO
+from retail.api.onboard.usecases.publish_webchat_script import (
+    PublishWebchatScriptUseCase,
+)
+from retail.api.vtex_projects.usecases.check_onboarding_complete import (
+    CheckOnboardingCompleteUseCase,
+    CACHE_TIMEOUT,
+    INACTIVE_STATUS,
+)
+from retail.internal.test_mixins import TEST_SETTINGS_OVERRIDES
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.agentic_cx_script import onboarding_complete_cache_key
+from retail.services.webchat_push.service import WebchatPublishError
+
+
+FAKE_AGENT_UUID = str(uuid4())
+
+
+class TestPublishWebchatScriptDispatchesAgenticCx(TestCase):
+    def setUp(self):
+        self._task_patcher = patch(
+            "retail.api.onboard.usecases.publish_webchat_script.task_ensure_agentic_cx_script_active"
+        )
+        self.mock_task = self._task_patcher.start()
+        self.addCleanup(self._task_patcher.stop)
+
+        self.integrations_service = MagicMock()
+        self.webchat_push_service = MagicMock()
+        self.usecase = PublishWebchatScriptUseCase(
+            integrations_service=self.integrations_service,
+            webchat_push_service=self.webchat_push_service,
+        )
+        self.dto = ActivateWebchatDTO(
+            app_uuid="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            account_id="b1165658e9e54790881952eb99341e51",
+            vtex_account="mystore",
+        )
+
+    def test_dispatches_task_after_successful_publish(self):
+        self.integrations_service.get_channel_app.return_value = {
+            "config": {"script": "https://example.com/wwc.js"}
+        }
+        self.webchat_push_service.publish_webchat_script.return_value = [
+            "https://bucket.s3.amazonaws.com/webchat.js"
+        ]
+
+        result = self.usecase.execute(self.dto)
+
+        self.mock_task.delay.assert_called_once_with("mystore")
+        self.assertEqual(
+            result.to_dict(),
+            {"script_urls": ["https://bucket.s3.amazonaws.com/webchat.js"]},
+        )
+
+    def test_does_not_dispatch_when_publish_fails(self):
+        self.integrations_service.get_channel_app.return_value = {
+            "config": {"script": "https://example.com/wwc.js"}
+        }
+        self.webchat_push_service.publish_webchat_script.side_effect = (
+            WebchatPublishError("S3 error")
+        )
+
+        with self.assertRaises(APIException):
+            self.usecase.execute(self.dto)
+
+        self.mock_task.delay.assert_not_called()
+
+    def test_does_not_dispatch_when_app_has_no_script(self):
+        self.integrations_service.get_channel_app.return_value = {"config": {}}
+
+        with self.assertRaises(ValidationError):
+            self.usecase.execute(self.dto)
+
+        self.mock_task.delay.assert_not_called()
+
+
+@override_settings(ABANDONED_CART_AGENT_UUID=FAKE_AGENT_UUID)
+class TestActivateWppCloudDispatchesAgenticCx(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account="mystore"
+        )
+        self.agent = Agent.objects.create(
+            uuid=FAKE_AGENT_UUID,
+            name="Abandoned Cart",
+            slug="abandoned-cart",
+            is_oficial=True,
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            agent=self.agent,
+            project=self.project,
+            is_active=True,
+            contact_percentage=0,
+        )
+        self._task_patcher = patch(
+            "retail.api.onboard.usecases.activate_wpp_cloud.task_ensure_agentic_cx_script_active"
+        )
+        self.mock_task = self._task_patcher.start()
+        self.addCleanup(self._task_patcher.stop)
+        self.use_case = ActivateWppCloudUseCase()
+
+    def test_dispatches_task_after_activating_agent(self):
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(self.project.uuid),
+            percentage=10,
+        )
+
+        self.use_case.execute(dto)
+
+        self.mock_task.delay.assert_called_once_with("mystore")
+
+    def test_does_not_dispatch_when_project_has_no_vtex_account(self):
+        self.project.vtex_account = ""
+        self.project.save(update_fields=["vtex_account"])
+
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(self.project.uuid),
+            percentage=10,
+        )
+
+        self.use_case.execute(dto)
+
+        self.mock_task.delay.assert_not_called()
+
+    def test_does_not_dispatch_when_integrated_agent_is_missing(self):
+        self.integrated_agent.delete()
+        dto = ActivateWppCloudDTO(
+            project_uuid=str(self.project.uuid),
+            percentage=10,
+        )
+
+        with self.assertRaises(NotFound):
+            self.use_case.execute(dto)
+
+        self.mock_task.delay.assert_not_called()
+
+
+@override_settings(**TEST_SETTINGS_OVERRIDES)
+class TestCheckOnboardingCompleteUsesEligibility(TestCase):
+    def setUp(self):
+        from django.core.cache import cache
+
+        cache.clear()
+        self.mock_eligibility = MagicMock()
+        self.use_case = CheckOnboardingCompleteUseCase(
+            eligibility_use_case=self.mock_eligibility
+        )
+        self.vtex_account = "teststore"
+
+    def tearDown(self):
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_returns_complete_when_eligible(self):
+        self.mock_eligibility.execute.return_value = True
+
+        result = self.use_case.execute(self.vtex_account)
+
+        self.assertTrue(result.is_complete)
+        self.assertIsNone(result.account_id)
+        self.mock_eligibility.execute.assert_called_once_with(self.vtex_account)
+
+    def test_returns_incomplete_when_not_eligible(self):
+        self.mock_eligibility.execute.return_value = False
+
+        result = self.use_case.execute(self.vtex_account)
+
+        self.assertFalse(result.is_complete)
+
+    def test_inactive_status_to_dict(self):
+        self.assertEqual(
+            INACTIVE_STATUS.to_dict(),
+            {"is_complete": False, "accountId": None},
+        )
+
+    @patch("retail.api.vtex_projects.usecases.check_onboarding_complete.cache")
+    def test_returns_cached_result_on_hit(self, mock_cache):
+        cached_result = MagicMock()
+        mock_cache.get.return_value = cached_result
+
+        result = self.use_case.execute(self.vtex_account)
+
+        self.assertEqual(result, cached_result)
+        self.mock_eligibility.execute.assert_not_called()
+
+    @patch("retail.api.vtex_projects.usecases.check_onboarding_complete.cache")
+    def test_caches_result_with_correct_timeout(self, mock_cache):
+        mock_cache.get.return_value = None
+        self.mock_eligibility.execute.return_value = True
+
+        result = self.use_case.execute(self.vtex_account)
+
+        mock_cache.set.assert_called_once_with(
+            onboarding_complete_cache_key(self.vtex_account),
+            result,
+            timeout=CACHE_TIMEOUT,
+        )
+
+    def test_default_constructor_uses_shared_eligibility_rule(self):
+        with patch(
+            "retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active"
+        ):
+            project = Project.objects.create(
+                name="Test", uuid=uuid4(), vtex_account=self.vtex_account
+            )
+            ProjectOnboarding.objects.create(
+                vtex_account=self.vtex_account,
+                project=project,
+                completed=True,
+            )
+
+        result = CheckOnboardingCompleteUseCase().execute(self.vtex_account)
+
+        self.assertTrue(result.is_complete)

--- a/retail/projects/tests/test_check_agentic_cx_eligibility.py
+++ b/retail/projects/tests/test_check_agentic_cx_eligibility.py
@@ -1,0 +1,128 @@
+from uuid import uuid4
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.agentic_cx_script import (
+    CheckAgenticCxEligibilityUseCase,
+)
+
+
+class TestCheckAgenticCxEligibilityUseCase(TestCase):
+    def setUp(self):
+        self._task_patcher = patch(
+            "retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active"
+        )
+        self._task_patcher.start()
+        self.addCleanup(self._task_patcher.stop)
+
+        self.vtex_account = "mystore"
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account=self.vtex_account
+        )
+        self.use_case = CheckAgenticCxEligibilityUseCase()
+
+    def test_eligible_when_onboarding_completed(self):
+        ProjectOnboarding.objects.create(
+            vtex_account=self.vtex_account,
+            project=self.project,
+            completed=True,
+        )
+
+        self.assertTrue(self.use_case.execute(self.vtex_account))
+
+    def test_eligible_when_channel_has_app_uuid(self):
+        ProjectOnboarding.objects.create(
+            vtex_account=self.vtex_account,
+            project=self.project,
+            completed=False,
+            config={"channels": {"wwc": {"app_uuid": "wwc-app-uuid"}}},
+        )
+
+        self.assertTrue(self.use_case.execute(self.vtex_account))
+
+    def test_eligible_when_active_integrated_agent_exists(self):
+        ProjectOnboarding.objects.create(
+            vtex_account=self.vtex_account,
+            project=self.project,
+            completed=False,
+        )
+        agent = Agent.objects.create(
+            name="Abandoned Cart",
+            slug="abandoned-cart",
+            description="",
+            project=self.project,
+        )
+        IntegratedAgent.objects.create(
+            agent=agent,
+            project=self.project,
+            is_active=True,
+        )
+
+        self.assertTrue(self.use_case.execute(self.vtex_account))
+
+    def test_not_eligible_when_channels_hold_only_channel_data(self):
+        ProjectOnboarding.objects.create(
+            vtex_account=self.vtex_account,
+            project=self.project,
+            completed=False,
+            config={
+                "channels": {
+                    "wpp-cloud": {
+                        "channel_data": {
+                            "auth_code": "abc",
+                            "waba_id": "waba-1",
+                        }
+                    }
+                }
+            },
+        )
+
+        self.assertFalse(self.use_case.execute(self.vtex_account))
+
+    def test_not_eligible_when_only_inactive_agent_exists(self):
+        ProjectOnboarding.objects.create(
+            vtex_account=self.vtex_account,
+            project=self.project,
+            completed=False,
+        )
+        agent = Agent.objects.create(
+            name="Abandoned Cart",
+            slug="abandoned-cart",
+            description="",
+            project=self.project,
+        )
+        IntegratedAgent.objects.create(
+            agent=agent,
+            project=self.project,
+            is_active=False,
+        )
+
+        self.assertFalse(self.use_case.execute(self.vtex_account))
+
+    def test_not_eligible_when_onboarding_does_not_exist(self):
+        self.assertFalse(self.use_case.execute(self.vtex_account))
+
+    def test_not_eligible_when_vtex_account_is_empty(self):
+        self.assertFalse(self.use_case.execute(""))
+
+    def test_not_eligible_when_app_uuid_is_blank(self):
+        ProjectOnboarding.objects.create(
+            vtex_account=self.vtex_account,
+            project=self.project,
+            completed=False,
+            config={"channels": {"wwc": {"app_uuid": ""}}},
+        )
+
+        self.assertFalse(self.use_case.execute(self.vtex_account))
+
+    def test_not_eligible_when_project_is_not_linked(self):
+        ProjectOnboarding.objects.create(
+            vtex_account="orphan-store",
+            completed=False,
+        )
+
+        self.assertFalse(self.use_case.execute("orphan-store"))

--- a/retail/projects/tests/test_ensure_agentic_cx_script_active.py
+++ b/retail/projects/tests/test_ensure_agentic_cx_script_active.py
@@ -1,0 +1,105 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.internal.test_mixins import TEST_SETTINGS_OVERRIDES
+from retail.projects.models import Project, ProjectOnboarding
+from retail.projects.usecases.agentic_cx_script import (
+    EnsureAgenticCxScriptActiveUseCase,
+    onboarding_complete_cache_key,
+)
+
+
+@override_settings(**TEST_SETTINGS_OVERRIDES)
+class TestEnsureAgenticCxScriptActiveUseCase(TestCase):
+    def setUp(self):
+        self._task_patcher = patch(
+            "retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active"
+        )
+        self._task_patcher.start()
+        self.addCleanup(self._task_patcher.stop)
+
+        cache.clear()
+        self.vtex_account = "mystore"
+        self.project = Project.objects.create(
+            name="Test", uuid=uuid4(), vtex_account=self.vtex_account
+        )
+        ProjectOnboarding.objects.create(
+            vtex_account=self.vtex_account,
+            project=self.project,
+            completed=True,
+        )
+        self.mock_vtex_io = MagicMock()
+        self.mock_eligibility = MagicMock()
+        self.mock_eligibility.execute.return_value = True
+        self.use_case = EnsureAgenticCxScriptActiveUseCase(
+            vtex_io_service=self.mock_vtex_io,
+            eligibility_use_case=self.mock_eligibility,
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_activates_and_persists_marker(self):
+        self.use_case.execute(self.vtex_account)
+
+        self.mock_vtex_io.activate_agentic_cx_script.assert_called_once_with(
+            account_domain="mystore.myvtex.com",
+            vtex_account="mystore",
+        )
+        self.project.refresh_from_db()
+        marker = self.project.config["agentic_cx_script"]
+        self.assertTrue(marker["active"])
+        self.assertIn("activated_at", marker)
+
+    def test_skips_when_already_marked_active(self):
+        self.project.config = {
+            "agentic_cx_script": {"active": True, "activated_at": "2026-01-01"}
+        }
+        self.project.save(update_fields=["config"])
+
+        self.use_case.execute(self.vtex_account)
+
+        self.mock_vtex_io.activate_agentic_cx_script.assert_not_called()
+        self.mock_eligibility.execute.assert_not_called()
+
+    def test_skips_when_not_eligible(self):
+        self.mock_eligibility.execute.return_value = False
+
+        self.use_case.execute(self.vtex_account)
+
+        self.mock_vtex_io.activate_agentic_cx_script.assert_not_called()
+        self.project.refresh_from_db()
+        self.assertNotIn("agentic_cx_script", self.project.config)
+
+    def test_skips_when_vtex_account_is_empty(self):
+        self.use_case.execute("")
+
+        self.mock_vtex_io.activate_agentic_cx_script.assert_not_called()
+        self.mock_eligibility.execute.assert_not_called()
+
+    def test_activates_without_marker_when_project_is_missing(self):
+        self.project.delete()
+
+        self.use_case.execute(self.vtex_account)
+
+        self.mock_vtex_io.activate_agentic_cx_script.assert_called_once()
+
+    def test_does_not_persist_marker_when_io_call_fails(self):
+        self.mock_vtex_io.activate_agentic_cx_script.side_effect = RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            self.use_case.execute(self.vtex_account)
+
+        self.project.refresh_from_db()
+        self.assertNotIn("agentic_cx_script", self.project.config)
+
+    def test_invalidates_onboarding_complete_cache(self):
+        cache_key = onboarding_complete_cache_key(self.vtex_account)
+        cache.set(cache_key, "cached")
+
+        self.use_case.execute(self.vtex_account)
+
+        self.assertIsNone(cache.get(cache_key))

--- a/retail/projects/tests/test_install_channel_agents.py
+++ b/retail/projects/tests/test_install_channel_agents.py
@@ -23,9 +23,13 @@ class StubAgent(PassiveAgent):
 class TestInstallChannelAgentsUseCase(TestCase):
     def setUp(self):
         self._agentic_patcher = patch(
-            "retail.projects.tasks.task_activate_agentic_cx_script"
+            "retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active"
+        )
+        self._dispatch_patcher = patch(
+            "retail.projects.usecases.install_channel_agents.task_ensure_agentic_cx_script_active"
         )
         self._agentic_patcher.start()
+        self.mock_dispatch_task = self._dispatch_patcher.start()
 
         self.project = Project.objects.create(
             name="Test", uuid=uuid4(), vtex_account="mystore"
@@ -46,6 +50,7 @@ class TestInstallChannelAgentsUseCase(TestCase):
         self.usecase.nexus_service = MagicMock()
 
     def tearDown(self):
+        self._dispatch_patcher.stop()
         self._agentic_patcher.stop()
 
     def _build_dto(self, channel="wpp-cloud", channel_data=None):
@@ -402,3 +407,34 @@ class TestInstallChannelAgentsUseCase(TestCase):
             self.usecase.execute(self._build_dto(channel="wwc", channel_data={}))
 
         self.assertIn("Failed to configure", str(ctx.exception))
+        self.mock_dispatch_task.delay.assert_not_called()
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[StubAgent("uuid-1", "Agent A")],
+    )
+    def test_dispatches_agentic_cx_script_after_successful_install(self, _mock_agents):
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
+            "app_uuid": "wpp-app-uuid",
+            "flow_object_uuid": "wpp-channel-uuid",
+        }
+        self.usecase.nexus_service.list_team_agents.return_value = {"agents": []}
+        self.usecase.nexus_service.integrate_agent.return_value = {"ok": True}
+
+        self.usecase.execute(self._build_dto())
+
+        self.mock_dispatch_task.delay.assert_called_once_with("mystore")
+
+    @patch(
+        "retail.projects.usecases.install_channel_agents.get_channel_agents",
+        return_value=[],
+    )
+    def test_dispatches_agentic_cx_script_when_no_agents_configured(self, _mock_agents):
+        self.usecase.integrations_service.create_wpp_cloud_channel.return_value = {
+            "app_uuid": "wpp-app-uuid",
+            "flow_object_uuid": "wpp-channel-uuid",
+        }
+
+        self.usecase.execute(self._build_dto())
+
+        self.mock_dispatch_task.delay.assert_called_once_with("mystore")

--- a/retail/projects/tests/test_models.py
+++ b/retail/projects/tests/test_models.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 
 from retail.projects.models import ProjectOnboarding
 
-TASK_PATH = "retail.projects.tasks.task_activate_agentic_cx_script"
+TASK_PATH = "retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active"
 
 
 class TestOnboardingCompletedSignal(TestCase):

--- a/retail/projects/tests/test_save_background_failure.py
+++ b/retail/projects/tests/test_save_background_failure.py
@@ -10,7 +10,7 @@ from retail.projects.usecases.save_background_failure import (
 
 class TestSaveBackgroundFailureUseCase(TestCase):
     def setUp(self):
-        with patch("retail.projects.tasks.task_activate_agentic_cx_script"):
+        with patch("retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active"):
             self.onboarding = ProjectOnboarding.objects.create(
                 vtex_account="mystore",
                 completed=True,

--- a/retail/projects/tests/test_start_onboarding.py
+++ b/retail/projects/tests/test_start_onboarding.py
@@ -54,7 +54,7 @@ class TestStartSetupUseCase(TestCase):
         )
 
     @patch("retail.projects.usecases.start_setup.task_setup_channel_and_start_crawl")
-    @patch("retail.projects.tasks.task_activate_agentic_cx_script")
+    @patch("retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active")
     def test_resets_existing_onboarding_on_retry(self, _mock_agentic, mock_task):
         """When an onboarding already exists, should reset transient fields."""
         ProjectOnboarding.objects.create(

--- a/retail/projects/tests/test_tasks.py
+++ b/retail/projects/tests/test_tasks.py
@@ -337,32 +337,44 @@ class TestTaskConfigureNexusDeprecatedAlias(TestCase):
         mock_release.assert_called_once_with("upload_nexus_contents", "mystore")
 
 
-class TestTaskActivateAgenticCxScript(TestCase):
-    @patch("retail.projects.tasks.VtexIOService")
-    def test_calls_service_with_correct_params(self, mock_service_cls):
-        mock_service = MagicMock()
-        mock_service_cls.return_value = mock_service
+class TestTaskEnsureAgenticCxScriptActive(TestCase):
+    @patch("retail.projects.agentic_cx_tasks.EnsureAgenticCxScriptActiveUseCase")
+    def test_new_task_delegates_to_use_case(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case_cls.return_value = mock_use_case
+
+        from retail.projects.agentic_cx_tasks import (
+            task_ensure_agentic_cx_script_active,
+        )
+
+        task_ensure_agentic_cx_script_active("teststore")
+
+        mock_use_case.execute.assert_called_once_with("teststore")
+
+    @patch("retail.projects.agentic_cx_tasks.EnsureAgenticCxScriptActiveUseCase")
+    def test_deprecated_alias_delegates_to_use_case(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case_cls.return_value = mock_use_case
 
         from retail.projects.tasks import task_activate_agentic_cx_script
 
         task_activate_agentic_cx_script("teststore")
 
-        mock_service.activate_agentic_cx_script.assert_called_once_with(
-            account_domain="teststore.myvtex.com",
-            vtex_account="teststore",
-        )
+        mock_use_case.execute.assert_called_once_with("teststore")
 
-    @patch("retail.projects.tasks.VtexIOService")
-    def test_propagates_service_exception(self, mock_service_cls):
+    @patch("retail.projects.agentic_cx_tasks.EnsureAgenticCxScriptActiveUseCase")
+    def test_propagates_use_case_exception(self, mock_use_case_cls):
         from retail.clients.exceptions import CustomAPIException
 
-        mock_service = MagicMock()
-        mock_service.activate_agentic_cx_script.side_effect = CustomAPIException(
+        mock_use_case = MagicMock()
+        mock_use_case.execute.side_effect = CustomAPIException(
             detail="Connection refused"
         )
-        mock_service_cls.return_value = mock_service
+        mock_use_case_cls.return_value = mock_use_case
 
-        from retail.projects.tasks import task_activate_agentic_cx_script
+        from retail.projects.agentic_cx_tasks import (
+            task_ensure_agentic_cx_script_active,
+        )
 
         with self.assertRaises(CustomAPIException):
-            task_activate_agentic_cx_script("teststore")
+            task_ensure_agentic_cx_script_active("teststore")

--- a/retail/projects/tests/test_views.py
+++ b/retail/projects/tests/test_views.py
@@ -278,7 +278,7 @@ class TestOnboardingPatchView(TestCase):
         )
 
     @auth_bypass()
-    @patch("retail.projects.tasks.task_activate_agentic_cx_script")
+    @patch("retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active")
     def test_patches_completed_field(self, _mock_task, _mock_auth):
         response = self.client.patch(
             "/api/onboard/mystore/",
@@ -303,7 +303,7 @@ class TestOnboardingPatchView(TestCase):
         self.assertEqual(self.onboarding.current_page, "setup_channel")
 
     @auth_bypass()
-    @patch("retail.projects.tasks.task_activate_agentic_cx_script")
+    @patch("retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active")
     def test_partial_patch_only_completed(self, _mock_task, _mock_auth):
         self.onboarding.current_page = "initial_page"
         self.onboarding.save()
@@ -320,7 +320,7 @@ class TestOnboardingPatchView(TestCase):
         self.assertEqual(self.onboarding.current_page, "initial_page")
 
     @auth_bypass(vtex_account="unknown")
-    @patch("retail.projects.tasks.task_activate_agentic_cx_script")
+    @patch("retail.projects.agentic_cx_tasks.task_ensure_agentic_cx_script_active")
     def test_returns_404_for_unknown_vtex_account(self, _mock_task, _mock_auth):
         response = self.client.patch(
             "/api/onboard/unknown/",

--- a/retail/projects/usecases/agentic_cx_script.py
+++ b/retail/projects/usecases/agentic_cx_script.py
@@ -1,0 +1,144 @@
+import logging
+from typing import Optional
+
+from django.core.cache import cache
+from django.utils import timezone
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.projects.models import Project, ProjectOnboarding
+from retail.services.vtex_io.service import VtexIOService
+
+logger = logging.getLogger(__name__)
+
+ONBOARDING_COMPLETE_CACHE_KEY_PREFIX = "onboarding_complete_"
+
+
+def onboarding_complete_cache_key(vtex_account: str) -> str:
+    return f"{ONBOARDING_COMPLETE_CACHE_KEY_PREFIX}{vtex_account}"
+
+
+class CheckAgenticCxEligibilityUseCase:
+    """Decides whether the Agentic CX storefront script should be active.
+
+    Eligibility is a capability check, not a wizard-completion check:
+    the account needs the script as soon as it has a connected channel,
+    an active integrated agent, or a completed onboarding.
+    """
+
+    def execute(self, vtex_account: str) -> bool:
+        if not vtex_account:
+            return False
+
+        onboarding = self._get_onboarding(vtex_account)
+        if onboarding is None:
+            return False
+
+        if onboarding.completed:
+            return True
+
+        if self._has_connected_channel(onboarding):
+            return True
+
+        return self._has_active_integrated_agent(onboarding)
+
+    def _get_onboarding(self, vtex_account: str) -> Optional[ProjectOnboarding]:
+        try:
+            return ProjectOnboarding.objects.select_related("project").get(
+                vtex_account=vtex_account
+            )
+        except ProjectOnboarding.DoesNotExist:
+            logger.info(f"Onboarding not found for vtex_account={vtex_account}")
+            return None
+
+    @staticmethod
+    def _has_connected_channel(onboarding: ProjectOnboarding) -> bool:
+        channels = (onboarding.config or {}).get("channels") or {}
+        return any(
+            isinstance(channel_config, dict) and bool(channel_config.get("app_uuid"))
+            for channel_config in channels.values()
+        )
+
+    @staticmethod
+    def _has_active_integrated_agent(onboarding: ProjectOnboarding) -> bool:
+        if onboarding.project_id is None:
+            return False
+
+        return IntegratedAgent.objects.filter(
+            project_id=onboarding.project_id,
+            is_active=True,
+        ).exists()
+
+
+class EnsureAgenticCxScriptActiveUseCase:
+    """Idempotently activates the Agentic CX script on the VTEX IO app."""
+
+    def __init__(
+        self,
+        vtex_io_service: Optional[VtexIOService] = None,
+        eligibility_use_case: Optional[CheckAgenticCxEligibilityUseCase] = None,
+    ):
+        self._vtex_io_service = vtex_io_service or VtexIOService()
+        self._eligibility_use_case = (
+            eligibility_use_case or CheckAgenticCxEligibilityUseCase()
+        )
+
+    def execute(self, vtex_account: str) -> None:
+        if not vtex_account:
+            logger.warning("Skipping Agentic CX script activation: empty vtex_account")
+            return
+
+        project = self._get_project(vtex_account)
+        if self._is_already_active(project):
+            logger.info(
+                f"Agentic CX script already marked active for "
+                f"vtex_account={vtex_account}"
+            )
+            return
+
+        if not self._eligibility_use_case.execute(vtex_account):
+            logger.info(
+                f"Account is not eligible for Agentic CX script "
+                f"activation: vtex_account={vtex_account}"
+            )
+            return
+
+        self._vtex_io_service.activate_agentic_cx_script(
+            account_domain=f"{vtex_account}.myvtex.com",
+            vtex_account=vtex_account,
+        )
+        self._persist_active_marker(project, vtex_account)
+        cache.delete(onboarding_complete_cache_key(vtex_account))
+
+        logger.info(f"Agentic CX script activated for vtex_account={vtex_account}")
+
+    def _get_project(self, vtex_account: str) -> Optional[Project]:
+        try:
+            return Project.objects.get(vtex_account=vtex_account)
+        except Project.DoesNotExist:
+            return None
+
+    @staticmethod
+    def _is_already_active(project: Optional[Project]) -> bool:
+        if project is None:
+            return False
+        marker = (project.config or {}).get("agentic_cx_script") or {}
+        return marker.get("active") is True
+
+    def _persist_active_marker(
+        self, project: Optional[Project], vtex_account: str
+    ) -> None:
+        if project is None:
+            logger.warning(
+                f"No project found for vtex_account={vtex_account}; "
+                f"script was activated without a local marker"
+            )
+            return
+
+        config = dict(project.config or {})
+        config["agentic_cx_script"] = {
+            "active": True,
+            "activated_at": timezone.now().isoformat(),
+        }
+        project.config = config
+        project.save(update_fields=["config"])
+        project.clear_cache()

--- a/retail/projects/usecases/install_channel_agents.py
+++ b/retail/projects/usecases/install_channel_agents.py
@@ -5,6 +5,7 @@ from retail.clients.integrations.client import IntegrationsClient
 from retail.clients.nexus.client import NexusClient
 from retail.interfaces.clients.integrations.interface import IntegrationsClientInterface
 from retail.interfaces.clients.nexus.client import NexusClientInterface
+from retail.projects.agentic_cx_tasks import task_ensure_agentic_cx_script_active
 from retail.projects.models import ProjectOnboarding
 from retail.projects.usecases.configure_wwc import (
     WWC_CREATION_CONFIG,
@@ -39,8 +40,7 @@ class ChannelInstaller(Protocol):
         project_uuid: str,
         channel_data: dict,
         language: str,
-    ) -> dict:
-        ...
+    ) -> dict: ...
 
 
 class WWCChannelInstaller:
@@ -164,6 +164,7 @@ class InstallChannelAgentsUseCase:
                 f"No agents configured for channel '{dto.channel}', "
                 f"skipping integration."
             )
+            task_ensure_agentic_cx_script_active.delay(dto.vtex_account)
             return
 
         integrated_uuids = get_integrated_agent_uuids(project_uuid, self.nexus_service)
@@ -176,6 +177,7 @@ class InstallChannelAgentsUseCase:
         )
 
         self._integrate_agents(agents, context, integrated_uuids)
+        task_ensure_agentic_cx_script_active.delay(dto.vtex_account)
 
     def _load_onboarding(self, vtex_account: str) -> ProjectOnboarding:
         """Loads and validates the onboarding record has a linked project."""

--- a/retail/swagger.py
+++ b/retail/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Gallery API Documentation",
-        default_version="v5.53.0",
+        default_version="v5.54.0",
         description="Documentation of the Gallery APIs",
     ),
     public=True,


### PR DESCRIPTION
## Agentic CX Script Activation — Capability-Based Eligibility

- Introduced `CheckAgenticCxEligibilityUseCase` in `retail/projects/usecases/agentic_cx_script.py` to determine whether the Agentic CX storefront script should be active for a VTEX account. Eligibility is granted when the account has a connected channel (an `app_uuid` in onboarding config), an active integrated agent, or a completed onboarding — replacing the previous check that only looked at the wizard `completed` flag.
- Introduced `EnsureAgenticCxScriptActiveUseCase` to idempotently activate the script via `VtexIOService`, persist an `agentic_cx_script` marker on the `Project.config`, and invalidate the onboarding-complete cache after activation.
- Added `task_ensure_agentic_cx_script_active` as a new Celery task in `retail/projects/agentic_cx_tasks.py`, delegating to `EnsureAgenticCxScriptActiveUseCase`. The existing `task_activate_agentic_cx_script` is kept as a deprecated alias so in-flight queued messages continue to execute correctly.
- Updated `AssignAgentUseCase` to dispatch `task_ensure_agentic_cx_script_active` via `transaction.on_commit` after a new `IntegratedAgent` is created, when the project has a `vtex_account`.
- Updated `ActivateWppCloudUseCase` to dispatch the task after updating `contact_percentage`, and added `select_related("project")` to avoid an extra query.
- Updated `PublishWebchatScriptUseCase` to dispatch the task after a successful webchat script publish.
- Updated `InstallChannelAgentsUseCase` to dispatch the task after channel agent installation completes, including the early-return path when no agents are configured.
- Refactored `CheckOnboardingCompleteUseCase` to delegate its eligibility check to `CheckAgenticCxEligibilityUseCase` instead of querying `ProjectOnboarding.completed` directly, and extracted `onboarding_complete_cache_key` as a shared helper.
- Moved `ProjectOnboarding` signals (`snapshot_previous_completed`, `notify_io_on_onboarding_complete`, `log_onboarding_deletion`) out of `models.py` into a dedicated `retail/projects/signals.py`, registered via `ProjectsConfig.ready()`. The `notify_io_on_onboarding_complete` signal now dispatches `task_ensure_agentic_cx_script_active` instead of the deprecated task.
- Added tests covering eligibility rules, idempotent activation, cache invalidation, marker persistence, and task dispatch across all updated entry points.