### PR TITLE
feat: Route order-status and PIX webhooks to origin sub-accounts

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -51,6 +51,7 @@ from retail.agents.domains.agent_integration.services.payment_recovery_hook impo
     build_payment_recovery_hook_payload,
 )
 from retail.vtex.usecases.proxy_vtex import ProxyVtexUsecase
+from retail.vtex.usecases.sync_vtex_sub_accounts import SyncVtexSubAccountsUseCase
 from retail.services.vtex_io.service import VtexIOService
 
 logger = logging.getLogger(__name__)
@@ -91,10 +92,14 @@ class AssignAgentUseCase:
         integrations_service: Optional[IntegrationsServiceInterface] = None,
         fetch_country_phone_code_usecase: Optional[FetchCountryPhoneCodeUseCase] = None,
         meta_service: Optional[MetaServiceInterface] = None,
+        sync_vtex_sub_accounts_usecase: Optional[SyncVtexSubAccountsUseCase] = None,
     ):
         self.integrations_service = integrations_service or IntegrationsService()
         self.fetch_country_phone_code_usecase = (
             fetch_country_phone_code_usecase or FetchCountryPhoneCodeUseCase()
+        )
+        self.sync_vtex_sub_accounts_usecase = (
+            sync_vtex_sub_accounts_usecase or SyncVtexSubAccountsUseCase()
         )
         self._meta_service = meta_service
 
@@ -135,6 +140,17 @@ class AssignAgentUseCase:
             return Project.objects.get(uuid=project_uuid)
         except Project.DoesNotExist:
             raise NotFound(f"Project not found: {project_uuid}")
+
+    def _sync_vtex_sub_accounts(self, project: Project) -> None:
+        """Refresh multistore metadata; never blocks agent assignment."""
+        try:
+            self.sync_vtex_sub_accounts_usecase.execute(project)
+        except Exception as exc:
+            logger.warning(
+                f"[AssignAgent] vtex_sub_accounts_sync_failed: "
+                f"project={project.uuid} vtex_account={project.vtex_account} "
+                f"error={exc}"
+            )
 
     def _create_integrated_agent(
         self,
@@ -708,6 +724,7 @@ class AssignAgentUseCase:
         The initial_template_language is automatically detected from VTEX tenant locale.
         """
         project = self._get_project(project_uuid)
+        self._sync_vtex_sub_accounts(project)
         self._validate_credentials(agent, credentials)
 
         templates = agent.templates.all()

--- a/retail/agents/domains/agent_integration/usecases/payment_recovery.py
+++ b/retail/agents/domains/agent_integration/usecases/payment_recovery.py
@@ -1,15 +1,19 @@
 import logging
 from decimal import Decimal
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Tuple
 from uuid import UUID
 
 from rest_framework.exceptions import NotFound, ValidationError
 
 from retail.agents.domains.agent_execution.services.logger import ExecutionLoggerService
 from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_webhook.usecases.base_agent_webhook import (
+    BaseAgentWebhookUseCase,
+)
 from retail.agents.domains.agent_webhook.usecases.order_status import (
     AgentOrderStatusUpdateUsecase,
 )
+from retail.agents.shared.cache import AgentRole
 from retail.agents.shared.vtex_order_value import (
     fetch_order_amount_details,
     propagate_order_amount_to_execution_log,
@@ -17,7 +21,15 @@ from retail.agents.shared.vtex_order_value import (
 from retail.interfaces.services.execution_logger import (
     ExecutionLoggerServiceInterface,
 )
+from retail.projects.models import Project
 from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.usecases.resolve_order_origin_account import (
+    ResolveOrderOriginAccountUseCase,
+)
+from retail.vtex.usecases.resolve_order_origin_project import (
+    ProjectLookup,
+    ResolveOrderOriginProjectUseCase,
+)
 from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 
 logger = logging.getLogger(__name__)
@@ -33,6 +45,9 @@ class PaymentRecoveryWebhookUseCase:
         self,
         vtex_io_service: Optional[VtexIOService] = None,
         exec_logger: Optional[ExecutionLoggerServiceInterface] = None,
+        origin_account_resolver: Optional[ResolveOrderOriginAccountUseCase] = None,
+        project_resolver: Optional[ResolveOrderOriginProjectUseCase] = None,
+        agent_lookup: Optional[BaseAgentWebhookUseCase] = None,
     ):
         """Initialize the use case with its VTEX IO dependency.
 
@@ -42,11 +57,21 @@ class PaymentRecoveryWebhookUseCase:
             exec_logger: Optional execution logger for agent-logs tracing.
                 When omitted, a default ``ExecutionLoggerService`` is used
                 (relies on the active execution contextvar when present).
+            origin_account_resolver: OMS hostname lookup. When omitted, built
+                with the same ``vtex_io_service`` so amount and origin share
+                one injected client.
+            project_resolver: Resolves the origin project from OMS hostname.
+            agent_lookup: Looks up the payment-recovery agent on a project.
         """
         self.vtex_io_service = vtex_io_service or VtexIOService()
         self.exec_logger: ExecutionLoggerServiceInterface = (
             exec_logger or ExecutionLoggerService()
         )
+        self.project_resolver = project_resolver or ResolveOrderOriginProjectUseCase(
+            origin_account_resolver=origin_account_resolver
+            or ResolveOrderOriginAccountUseCase(vtex_io_service=self.vtex_io_service)
+        )
+        self.agent_lookup = agent_lookup or BaseAgentWebhookUseCase()
 
     def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
         """Retrieve an active integrated agent by UUID.
@@ -150,10 +175,15 @@ class PaymentRecoveryWebhookUseCase:
         webhook_data: Dict[str, Any],
         vtex_account: str,
     ) -> Dict[str, str]:
-        """Build an OrderStatusDTO and delegate to AgentOrderStatusUpdateUsecase.
+        """Adapt the PIX hook into the shared order-event dispatcher.
 
-        The DTO is built with ``currentState="payment-pending"``. The raw
-        VTEX state (often ``"unknow"``) is stored as ``lastState``
+        Payment recovery has no separate lambda pipeline. The hook is
+        converted to ``OrderStatusDTO`` with ``currentState="payment-pending"``
+        and handed to ``AgentOrderStatusUpdateUsecase.execute`` together with
+        the payment-recovery ``IntegratedAgent``. That use case does not look
+        up the order-status agent; it dispatches whoever is passed in.
+
+        The raw VTEX state (often ``"unknow"``) is stored as ``lastState``
         while ``currentState`` is hardcoded because the payment recovery
         hook only fires for orders awaiting payment.
 
@@ -176,6 +206,35 @@ class PaymentRecoveryWebhookUseCase:
             vtex_account=vtex_account,
             log_prefix="[PAYMENT_RECOVERY]",
         )
+
+        logger.info(
+            f"[PAYMENT_RECOVERY] converting_state: "
+            f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
+            f"mapped_state=payment-pending data={webhook_data}"
+        )
+
+        order_status_dto = OrderStatusDTO(
+            recorder={},
+            domain="OrdersDocumentUpdated",
+            orderId=order_id,
+            currentState="payment-pending",
+            lastState=webhook_data.get("State"),
+            currentChangeDate=webhook_data.get("CurrentChange"),
+            lastChangeDate=webhook_data.get("LastChange"),
+            vtexAccount=vtex_account,
+        )
+
+        dispatch_usecase = AgentOrderStatusUpdateUsecase(
+            exec_logger=self.exec_logger,
+            vtex_io_service=self.vtex_io_service,
+        )
+        integrated_agent, vtex_account = self._resolve_origin_agent(
+            ingress_agent=integrated_agent,
+            dto=order_status_dto,
+            lookup_project=dispatch_usecase.get_project_by_vtex_account,
+        )
+        order_status_dto.vtexAccount = vtex_account
+        agent_uuid = integrated_agent.uuid
 
         if self._is_below_minimum_order_value(
             integrated_agent,
@@ -206,28 +265,7 @@ class PaymentRecoveryWebhookUseCase:
                 "message": "Order value below configured minimum",
             }
 
-        logger.info(
-            f"[PAYMENT_RECOVERY] converting_state: "
-            f"vtex_account={vtex_account} agent_uuid={agent_uuid} "
-            f"mapped_state=payment-pending data={webhook_data}"
-        )
-
-        order_status_dto = OrderStatusDTO(
-            recorder={},
-            domain="OrdersDocumentUpdated",
-            orderId=order_id,
-            currentState="payment-pending",
-            lastState=webhook_data.get("State"),
-            currentChangeDate=webhook_data.get("CurrentChange"),
-            lastChangeDate=webhook_data.get("LastChange"),
-            vtexAccount=vtex_account,
-        )
-
-        order_status_usecase = AgentOrderStatusUpdateUsecase(
-            exec_logger=self.exec_logger,
-            vtex_io_service=self.vtex_io_service,
-        )
-        order_status_usecase.execute(
+        dispatch_usecase.execute(
             integrated_agent,
             order_status_dto,
             order_amount_details=order_details,
@@ -243,6 +281,55 @@ class PaymentRecoveryWebhookUseCase:
             "status": "success",
             "message": "Payment recovery notification processed",
         }
+
+    def _resolve_origin_agent(
+        self,
+        ingress_agent: IntegratedAgent,
+        dto: OrderStatusDTO,
+        lookup_project: ProjectLookup,
+    ) -> Tuple[IntegratedAgent, str]:
+        """Return the payment-recovery agent of the order's origin sub-account.
+
+        When the origin project has no active payment-recovery agent, keep the
+        ingress agent so the event is not dropped.
+        """
+        ingress_project = ingress_agent.project
+        target_project = self.project_resolver.execute(
+            dto=dto,
+            ingress_project=ingress_project,
+            lookup_project=lookup_project,
+        )
+        if self._is_same_project(target_project, ingress_project):
+            return ingress_agent, ingress_project.vtex_account
+
+        target_agent = self.agent_lookup.get_integrated_agent_if_exists(
+            target_project, AgentRole.PAYMENT_RECOVERY
+        )
+        if target_agent is None:
+            logger.warning(
+                f"[PAYMENT_RECOVERY] origin_agent_not_found: "
+                f"ingress={ingress_project.vtex_account} "
+                f"origin={target_project.vtex_account} "
+                f"order_id={dto.orderId} ingress_agent={ingress_agent.uuid}"
+            )
+            return ingress_agent, ingress_project.vtex_account
+
+        logger.info(
+            f"[PAYMENT_RECOVERY] routed_by_hostname: "
+            f"ingress={ingress_project.vtex_account} "
+            f"origin={target_project.vtex_account} "
+            f"ingress_agent={ingress_agent.uuid} target_agent={target_agent.uuid} "
+            f"order_id={dto.orderId}"
+        )
+        return target_agent, target_project.vtex_account
+
+    @staticmethod
+    def _is_same_project(project: Project, other: Project) -> bool:
+        if project is other:
+            return True
+        project_uuid = getattr(project, "uuid", None)
+        other_uuid = getattr(other, "uuid", None)
+        return project_uuid is not None and project_uuid == other_uuid
 
     def _is_below_minimum_order_value(
         self,

--- a/retail/agents/tests/usecases/test_assign_abandoned_cart_button_url.py
+++ b/retail/agents/tests/usecases/test_assign_abandoned_cart_button_url.py
@@ -25,6 +25,7 @@ class AssignAbandonedCartButtonUrlTest(TestCase):
         )
         self.use_case = AssignAgentUseCase(
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
         )
         self.project = Project.objects.create(
             uuid=uuid.uuid4(),

--- a/retail/agents/tests/usecases/test_assign_agent.py
+++ b/retail/agents/tests/usecases/test_assign_agent.py
@@ -29,8 +29,10 @@ class AssignAgentUseCaseTest(TestCase):
             meta_language="pt_BR",
             vtex_locale="pt-BR",
         )
+        self.mock_sync_sub_accounts = MagicMock()
         self.use_case = AssignAgentUseCase(
-            fetch_country_phone_code_usecase=self.mock_fetch_phone_code
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
         self.project = Project.objects.create(
             uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
@@ -255,6 +257,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         integrated_agent = IntegratedAgent.objects.create(
@@ -311,6 +314,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         integrated_agent = IntegratedAgent.objects.create(
@@ -376,6 +380,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         integrated_agent = IntegratedAgent.objects.create(
@@ -442,6 +447,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         integrated_agent = IntegratedAgent.objects.create(
@@ -544,6 +550,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         mock_use_case_instance = mock_create_library_use_case.return_value
@@ -564,6 +571,12 @@ class AssignAgentUseCaseTest(TestCase):
         self.assertEqual(integrated_agent.agent, self.agent)
         self.assertEqual(integrated_agent.project, self.project)
         self.assertTrue(integrated_agent.is_active)
+        self.mock_sync_sub_accounts.execute.assert_called_once_with(self.project)
+
+    def test_sync_vtex_sub_accounts_does_not_raise(self):
+        self.mock_sync_sub_accounts.execute.side_effect = Exception("vtex down")
+        self.use_case._sync_vtex_sub_accounts(self.project)
+        self.mock_sync_sub_accounts.execute.assert_called_once_with(self.project)
 
     def test_execute_project_not_found(self):
         random_uuid = uuid.uuid4()
@@ -594,6 +607,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         use_case.execute(
@@ -627,6 +641,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         mock_use_case_instance = mock_create_library_use_case.return_value
@@ -824,6 +839,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case_with_mock = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         integrated_agent = IntegratedAgent.objects.create(
@@ -854,6 +870,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         valid_template = PreApprovedTemplate.objects.create(
@@ -966,6 +983,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         mock_template = MagicMock()
@@ -1014,6 +1032,7 @@ class AssignAgentUseCaseTest(TestCase):
         use_case = AssignAgentUseCase(
             integrations_service=mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=self.mock_sync_sub_accounts,
         )
 
         invalid_template1 = PreApprovedTemplate.objects.create(

--- a/retail/agents/tests/usecases/test_assign_direct_send.py
+++ b/retail/agents/tests/usecases/test_assign_direct_send.py
@@ -124,6 +124,7 @@ class AssignDirectSendBaseTest(TestCase):
             integrations_service=self.integrations_service,
             fetch_country_phone_code_usecase=self.fetch_country_phone_code,
             meta_service=self.meta_service,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
         )
 
 

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -24,6 +24,7 @@ class ResolveContactPercentageTest(TestCase):
         self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
         self.use_case = AssignAgentUseCase(
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
         )
         self.project = Project.objects.create(
             uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
@@ -99,6 +100,7 @@ class AssignPaymentRecoveryBuildConfigTest(TestCase):
         )
         self.use_case = AssignAgentUseCase(
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
         )
         self.project = Project.objects.create(
             uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
@@ -140,6 +142,7 @@ class AssignPaymentRecoveryTemplateTest(TestCase):
         )
         self.use_case = AssignAgentUseCase(
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
         )
         self.project = Project.objects.create(
             uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
@@ -253,6 +256,7 @@ class AssignPaymentRecoveryHookTest(TestCase):
         )
         self.use_case = AssignAgentUseCase(
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
         )
         self.project = Project.objects.create(
             uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
@@ -350,6 +354,7 @@ class GetReservedDisplayNamesTest(TestCase):
         self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
         self.use_case = AssignAgentUseCase(
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
         )
         self.project = Project.objects.create(
             uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"
@@ -414,6 +419,7 @@ class CreateTemplatesSkipReservedDisplayNamesTest(TestCase):
         self.use_case = AssignAgentUseCase(
             integrations_service=self.mock_integrations_service,
             fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
         )
         self.project = Project.objects.create(
             uuid=uuid.uuid4(), name="Test Project", vtex_account="teststore"

--- a/retail/agents/tests/usecases/test_payment_recovery_subaccount_routing.py
+++ b/retail/agents/tests/usecases/test_payment_recovery_subaccount_routing.py
@@ -1,0 +1,158 @@
+"""Simulate PIX recovery routing from the hub hook to the origin store."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.payment_recovery import (
+    PaymentRecoveryWebhookUseCase,
+)
+from retail.agents.domains.agent_management.models import Agent
+from retail.projects.models import Project
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.tests.fakes import FakeVtexIOClient
+
+
+PAYMENT_RECOVERY_AGENT_UUID = uuid4()
+HUB_ACCOUNT = "columbiamx"
+ORIGIN_ACCOUNT = "martimx"
+ORDER_ID = "v123-01"
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "payment-recovery-subaccount-routing-tests",
+        }
+    },
+    PAYMENT_RECOVERY_AGENT_UUID=str(PAYMENT_RECOVERY_AGENT_UUID),
+)
+class PaymentRecoverySubaccountRoutingTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
+
+        self.hub = Project.objects.create(
+            uuid=uuid4(),
+            name="Columbia",
+            vtex_account=HUB_ACCOUNT,
+            config={
+                "vtex_config": {
+                    "vtex_sub_accounts": [HUB_ACCOUNT, ORIGIN_ACCOUNT, "diablosrojosmx"]
+                }
+            },
+        )
+        self.origin = Project.objects.create(
+            uuid=uuid4(),
+            name="Marti",
+            vtex_account=ORIGIN_ACCOUNT,
+        )
+        official_agent = Agent.objects.create(
+            uuid=PAYMENT_RECOVERY_AGENT_UUID,
+            name="Payment Recovery",
+            slug="payment-recovery",
+            description="official",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.hub,
+            is_oficial=True,
+            credentials={},
+        )
+        self.ingress_agent = IntegratedAgent.objects.create(
+            agent=official_agent,
+            project=self.hub,
+            channel_uuid=uuid4(),
+            is_active=True,
+            config={"payment_recovery": {"hook_created": True}},
+        )
+        self.origin_agent = IntegratedAgent.objects.create(
+            agent=official_agent,
+            project=self.origin,
+            channel_uuid=uuid4(),
+            is_active=True,
+            config={"payment_recovery": {"hook_created": True}},
+        )
+        self.webhook_data = {
+            "OrderId": ORDER_ID,
+            "State": "payment-pending",
+            "CurrentChange": "2026-08-19T00:00:00Z",
+            "LastChange": "2026-08-19T00:00:00Z",
+        }
+        self.oms_client = FakeVtexIOClient(hostname=HUB_ACCOUNT, order_id=ORDER_ID)
+        self.use_case = PaymentRecoveryWebhookUseCase(
+            vtex_io_service=VtexIOService(client=self.oms_client),
+            exec_logger=MagicMock(),
+        )
+
+    def _oms_hostname(self, hostname: str) -> None:
+        self.oms_client.hostname = hostname
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery."
+        "AgentOrderStatusUpdateUsecase.execute"
+    )
+    def test_dispatches_origin_store_agent_when_hostname_is_subaccount(
+        self, mock_execute
+    ):
+        self._oms_hostname(ORIGIN_ACCOUNT)
+
+        result = self.use_case.process_webhook_notification(
+            self.ingress_agent, self.webhook_data
+        )
+
+        self.assertEqual(result["status"], "success")
+        mock_execute.assert_called_once()
+        dispatched_agent, dto = mock_execute.call_args.args
+        self.assertEqual(dispatched_agent.uuid, self.origin_agent.uuid)
+        self.assertEqual(dispatched_agent.project_id, self.origin.id)
+        self.assertEqual(dto.vtexAccount, ORIGIN_ACCOUNT)
+        self.assertEqual(
+            self.oms_client.proxy_calls,
+            [
+                {
+                    "account_domain": f"{HUB_ACCOUNT}.myvtex.com",
+                    "vtex_account": HUB_ACCOUNT,
+                    "method": "GET",
+                    "path": f"/api/oms/pvt/orders/{ORDER_ID}",
+                }
+            ],
+        )
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery."
+        "AgentOrderStatusUpdateUsecase.execute"
+    )
+    def test_keeps_ingress_agent_when_hostname_matches_ingress_account(
+        self, mock_execute
+    ):
+        self._oms_hostname(HUB_ACCOUNT)
+
+        self.use_case.process_webhook_notification(
+            self.ingress_agent, self.webhook_data
+        )
+
+        dispatched_agent, dto = mock_execute.call_args.args
+        self.assertEqual(dispatched_agent.uuid, self.ingress_agent.uuid)
+        self.assertEqual(dto.vtexAccount, HUB_ACCOUNT)
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.payment_recovery."
+        "AgentOrderStatusUpdateUsecase.execute"
+    )
+    def test_falls_back_to_ingress_agent_when_origin_has_no_payment_recovery(
+        self, mock_execute
+    ):
+        self.origin_agent.is_active = False
+        self.origin_agent.save(update_fields=["is_active"])
+        self._oms_hostname(ORIGIN_ACCOUNT)
+
+        self.use_case.process_webhook_notification(
+            self.ingress_agent, self.webhook_data
+        )
+
+        dispatched_agent, dto = mock_execute.call_args.args
+        self.assertEqual(dispatched_agent.uuid, self.ingress_agent.uuid)
+        self.assertEqual(dto.vtexAccount, HUB_ACCOUNT)

--- a/retail/vtex/sub_accounts.py
+++ b/retail/vtex/sub_accounts.py
@@ -1,0 +1,73 @@
+"""Shared helpers for VTEX sub-account detection."""
+
+from typing import Any, Dict, List, Optional
+
+from retail.projects.models import Project
+
+VTEX_CONFIG_KEY = "vtex_config"
+VTEX_SUB_ACCOUNTS_KEY = "vtex_sub_accounts"
+LEGACY_VTEX_STORES_KEY = "vtex_stores"
+# License Manager endpoint; VTEX names this resource "stores".
+VTEX_ACCOUNT_STORES_PATH = "/api/vlm/account/stores"
+
+ORDER_ORIGIN_CACHE_KEY_PREFIX = "order_origin_account"
+ORDER_ORIGIN_CACHE_TIMEOUT_SECONDS = 3600
+
+
+def _vtex_config(project: Project) -> Dict[str, Any]:
+    config = getattr(project, "config", None)
+    if not isinstance(config, dict):
+        return {}
+    vtex_config = config.get(VTEX_CONFIG_KEY)
+    if not isinstance(vtex_config, dict):
+        return {}
+    return vtex_config
+
+
+def _account_names_from_config_list(raw: Any) -> List[str]:
+    if not isinstance(raw, list):
+        return []
+
+    names: List[str] = []
+    for item in raw:
+        if isinstance(item, str) and item:
+            names.append(item)
+            continue
+        if isinstance(item, dict):
+            name = item.get("name")
+            if isinstance(name, str) and name:
+                names.append(name)
+    return names
+
+
+def read_vtex_sub_accounts(project: Project) -> List[str]:
+    """Return stored VTEX sub-account names from ``project.config``.
+
+    Prefers ``vtex_sub_accounts``. Also reads the previous ``vtex_stores``
+    key (names or ``{name, hosts}`` objects) so already-synced projects
+    keep working until the next sync.
+    """
+    vtex_config = _vtex_config(project)
+    names = _account_names_from_config_list(vtex_config.get(VTEX_SUB_ACCOUNTS_KEY))
+    if names:
+        return names
+    return _account_names_from_config_list(vtex_config.get(LEGACY_VTEX_STORES_KEY))
+
+
+def project_has_multiple_vtex_accounts(project: Project) -> bool:
+    """Return True when more than one VTEX sub-account was persisted."""
+    return len(read_vtex_sub_accounts(project)) > 1
+
+
+def origin_account_from_hostname(
+    hostname: str, account_names: Optional[List[str]] = None
+) -> str:
+    """Return the stored sub-account name that matches OMS ``hostname``."""
+    if not hostname:
+        return hostname
+
+    normalized = hostname.strip().lower()
+    for name in account_names or []:
+        if name.strip().lower() == normalized:
+            return name
+    return hostname

--- a/retail/vtex/tasks.py
+++ b/retail/vtex/tasks.py
@@ -17,6 +17,9 @@ from retail.broadcasts.usecases.mark_broadcast_converted import (
 from retail.vtex.models import Cart
 from retail.vtex.usecases.cart_abandonment import CartAbandonmentUseCase
 from retail.vtex.usecases.handle_purchase_event import HandlePurchaseEventUseCase
+from retail.vtex.usecases.resolve_order_origin_project import (
+    ResolveOrderOriginProjectUseCase,
+)
 from retail.webhooks.vtex.usecases.order_status import OrderStatusUseCase
 from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 
@@ -146,6 +149,18 @@ def task_order_status_update(order_update_data: dict):
                 f"[ORDER_STATUS] project_not_found: vtex_account={vtex_account}"
             )
             return
+
+        project = ResolveOrderOriginProjectUseCase().execute(
+            dto=order_status_dto,
+            ingress_project=project,
+            lookup_project=use_case.get_project_by_vtex_account,
+        )
+        if (
+            project.vtex_account
+            and project.vtex_account != order_status_dto.vtexAccount
+        ):
+            order_status_dto.vtexAccount = project.vtex_account
+            vtex_account = project.vtex_account
 
         if is_payment_approved(current_state):
             logger.info(

--- a/retail/vtex/tests/fakes.py
+++ b/retail/vtex/tests/fakes.py
@@ -1,0 +1,95 @@
+"""In-memory VTEX IO client with OMS-shaped payloads.
+
+Production code already follows ``client or VtexIOClient``. Tests inject
+this fake at that seam:
+
+    VtexIOService(client=FakeVtexIOClient(hostname="martimx"))
+
+Responses match the subset of ``GET /api/oms/pvt/orders/{orderId}`` that
+origin routing and payment-recovery amount lookup actually read.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+_UNSET = object()
+
+
+def oms_order_payload(
+    *,
+    order_id: str = "v123-01",
+    hostname: str = "martimx",
+    value: int = 15000,
+) -> Dict[str, Any]:
+    """Return a faithful subset of a VTEX OMS order document."""
+    return {
+        "orderId": order_id,
+        "hostname": hostname,
+        "merchantName": hostname,
+        "value": value,
+        "status": "payment-pending",
+        "origin": "Marketplace",
+        "storePreferencesData": {"currencyCode": "MXN"},
+    }
+
+
+class FakeVtexIOClient:
+    """Stand-in for ``VtexIOClient`` used by ``VtexIOService``."""
+
+    def __init__(
+        self,
+        *,
+        hostname: str = "martimx",
+        order_id: str = "v123-01",
+        order_value_cents: int = 15000,
+        proxy_error: Optional[BaseException] = None,
+        proxy_response: Any = _UNSET,
+    ) -> None:
+        self.hostname = hostname
+        self.order_id = order_id
+        self.order_value_cents = order_value_cents
+        self.proxy_error = proxy_error
+        self.proxy_response = proxy_response
+        self.proxy_calls: List[Dict[str, Any]] = []
+
+    def get_order_details_by_id(
+        self, account_domain: str, vtex_account: str, order_id: str
+    ) -> dict:
+        return oms_order_payload(
+            order_id=order_id,
+            hostname=self.hostname,
+            value=self.order_value_cents,
+        )
+
+    def proxy_vtex(
+        self,
+        account_domain: str,
+        vtex_account: str,
+        method: str,
+        path: str,
+        headers: dict = None,
+        data: Union[dict, list] = None,
+        params: dict = None,
+    ) -> Any:
+        self.proxy_calls.append(
+            {
+                "account_domain": account_domain,
+                "vtex_account": vtex_account,
+                "method": method,
+                "path": path,
+            }
+        )
+        if self.proxy_error is not None:
+            raise self.proxy_error
+        if self.proxy_response is not _UNSET:
+            return self.proxy_response
+
+        expected_path = f"/api/oms/pvt/orders/{self.order_id}"
+        if path != expected_path:
+            raise AssertionError(
+                f"unexpected OMS path {path!r}, expected {expected_path!r}"
+            )
+        return oms_order_payload(
+            order_id=self.order_id,
+            hostname=self.hostname,
+            value=self.order_value_cents,
+        )

--- a/retail/vtex/tests/test_order_status_subaccount_routing.py
+++ b/retail/vtex/tests/test_order_status_subaccount_routing.py
@@ -1,0 +1,140 @@
+"""Simulate order-status routing from the hub account to the origin store."""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.agents.domains.agent_webhook.usecases.order_status import (
+    AgentOrderStatusUpdateUsecase,
+)
+from retail.projects.models import Project
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.tests.fakes import FakeVtexIOClient
+
+
+ORDER_STATUS_AGENT_UUID = uuid4()
+HUB_ACCOUNT = "columbiamx"
+ORIGIN_ACCOUNT = "martimx"
+ORDER_ID = "v123-01"
+
+
+def _order_update_data(vtex_account: str = HUB_ACCOUNT) -> dict:
+    return {
+        "recorder": {},
+        "domain": "Marketplace",
+        "orderId": ORDER_ID,
+        "currentState": "ready-for-handling",
+        "lastState": "payment-approved",
+        "currentChangeDate": "2026-08-19T00:00:00Z",
+        "lastChangeDate": "2026-08-19T00:00:00Z",
+        "vtexAccount": vtex_account,
+    }
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "order-status-subaccount-routing-tests",
+        }
+    },
+    ORDER_STATUS_AGENT_UUID=str(ORDER_STATUS_AGENT_UUID),
+)
+class OrderStatusSubaccountRoutingTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
+
+        self.hub = Project.objects.create(
+            uuid=uuid4(),
+            name="Columbia",
+            vtex_account=HUB_ACCOUNT,
+            config={
+                "vtex_config": {
+                    "vtex_sub_accounts": [HUB_ACCOUNT, ORIGIN_ACCOUNT, "diablosrojosmx"]
+                }
+            },
+        )
+        self.origin = Project.objects.create(
+            uuid=uuid4(),
+            name="Marti",
+            vtex_account=ORIGIN_ACCOUNT,
+        )
+        official_agent = Agent.objects.create(
+            uuid=ORDER_STATUS_AGENT_UUID,
+            name="Order Status",
+            slug="order-status",
+            description="official",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.hub,
+            is_oficial=True,
+            credentials={},
+        )
+        self.ingress_agent = IntegratedAgent.objects.create(
+            agent=official_agent,
+            project=self.hub,
+            channel_uuid=uuid4(),
+            is_active=True,
+        )
+        self.origin_agent = IntegratedAgent.objects.create(
+            agent=official_agent,
+            project=self.origin,
+            channel_uuid=uuid4(),
+            is_active=True,
+        )
+
+    def _vtex_io_with_oms(self, hostname: str) -> VtexIOService:
+        self.oms_client = FakeVtexIOClient(hostname=hostname, order_id=ORDER_ID)
+        return VtexIOService(client=self.oms_client)
+
+    @patch("retail.vtex.tasks.task_mark_broadcast_converted")
+    @patch("retail.agents.domains.agent_execution.task_helpers.ExecutionLoggerService")
+    @patch.object(AgentOrderStatusUpdateUsecase, "execute")
+    @patch("retail.vtex.usecases.resolve_order_origin_account.VtexIOService")
+    def test_dispatches_origin_store_agent_when_hostname_is_subaccount(
+        self, mock_vtex_io_cls, mock_execute, _mock_logger_factory, _mock_conversion
+    ):
+        from retail.vtex.tasks import task_order_status_update
+
+        mock_vtex_io_cls.return_value = self._vtex_io_with_oms(ORIGIN_ACCOUNT)
+
+        task_order_status_update(_order_update_data())
+
+        mock_execute.assert_called_once()
+        dispatched_agent, dto = mock_execute.call_args.args
+        self.assertEqual(dispatched_agent.uuid, self.origin_agent.uuid)
+        self.assertEqual(dispatched_agent.project_id, self.origin.id)
+        self.assertEqual(dto.vtexAccount, ORIGIN_ACCOUNT)
+        self.assertEqual(
+            self.oms_client.proxy_calls,
+            [
+                {
+                    "account_domain": f"{HUB_ACCOUNT}.myvtex.com",
+                    "vtex_account": HUB_ACCOUNT,
+                    "method": "GET",
+                    "path": f"/api/oms/pvt/orders/{ORDER_ID}",
+                }
+            ],
+        )
+
+    @patch("retail.vtex.tasks.task_mark_broadcast_converted")
+    @patch("retail.agents.domains.agent_execution.task_helpers.ExecutionLoggerService")
+    @patch.object(AgentOrderStatusUpdateUsecase, "execute")
+    @patch("retail.vtex.usecases.resolve_order_origin_account.VtexIOService")
+    def test_keeps_ingress_agent_when_hostname_matches_ingress_account(
+        self, mock_vtex_io_cls, mock_execute, _mock_logger_factory, _mock_conversion
+    ):
+        from retail.vtex.tasks import task_order_status_update
+
+        mock_vtex_io_cls.return_value = self._vtex_io_with_oms(HUB_ACCOUNT)
+
+        task_order_status_update(_order_update_data())
+
+        mock_execute.assert_called_once()
+        dispatched_agent, dto = mock_execute.call_args.args
+        self.assertEqual(dispatched_agent.uuid, self.ingress_agent.uuid)
+        self.assertEqual(dto.vtexAccount, HUB_ACCOUNT)

--- a/retail/vtex/tests/test_task_order_status_update.py
+++ b/retail/vtex/tests/test_task_order_status_update.py
@@ -157,7 +157,9 @@ class TaskOrderStatusUpdateTests(TestCase):
 
         execution_uuid = uuid4()
         mock_logger = MagicMock()
-        mock_logger.log_webhook_received.side_effect = _mock_log_webhook_received(execution_uuid)
+        mock_logger.log_webhook_received.side_effect = _mock_log_webhook_received(
+            execution_uuid
+        )
         mock_logger_factory.return_value = mock_logger
 
         project = MagicMock(uuid=uuid4())
@@ -239,7 +241,9 @@ class TaskOrderStatusUpdateTests(TestCase):
 
         execution_uuid = uuid4()
         mock_logger = MagicMock()
-        mock_logger.log_webhook_received.side_effect = _mock_log_webhook_received(execution_uuid)
+        mock_logger.log_webhook_received.side_effect = _mock_log_webhook_received(
+            execution_uuid
+        )
         mock_logger_factory.return_value = mock_logger
 
         project = MagicMock(uuid=uuid4())
@@ -269,7 +273,9 @@ class TaskOrderStatusUpdateTests(TestCase):
 
         execution_uuid = uuid4()
         mock_logger = MagicMock()
-        mock_logger.log_webhook_received.side_effect = _mock_log_webhook_received(execution_uuid)
+        mock_logger.log_webhook_received.side_effect = _mock_log_webhook_received(
+            execution_uuid
+        )
         mock_logger_factory.return_value = mock_logger
 
         project = MagicMock(uuid=uuid4())
@@ -308,3 +314,37 @@ class TaskOrderStatusUpdateTests(TestCase):
         task_order_status_update(_build_order_update_data())
 
         mock_logger.log_execution_error.assert_not_called()
+
+    @patch("retail.vtex.tasks.ResolveOrderOriginProjectUseCase")
+    @patch("retail.vtex.tasks.AgentOrderStatusUpdateUsecase")
+    @patch("retail.agents.domains.agent_execution.task_helpers.ExecutionLoggerService")
+    def test_dispatches_to_project_returned_by_hostname_router(
+        self, mock_logger_factory, mock_use_case_cls, mock_router_cls
+    ):
+        from retail.vtex.tasks import task_order_status_update
+
+        mock_logger = MagicMock()
+        mock_logger.log_webhook_received.side_effect = _mock_log_webhook_received(
+            uuid4()
+        )
+        mock_logger_factory.return_value = mock_logger
+
+        hub = MagicMock(uuid=uuid4(), vtex_account="columbiamx")
+        target = MagicMock(uuid=uuid4(), vtex_account="martimx")
+        agent = MagicMock(uuid=uuid4())
+
+        mock_use_case = MagicMock()
+        mock_use_case.get_project_by_vtex_account.return_value = hub
+        mock_use_case.get_integrated_agent_if_exists.return_value = agent
+        mock_use_case_cls.return_value = mock_use_case
+
+        mock_router = MagicMock()
+        mock_router.execute.return_value = target
+        mock_router_cls.return_value = mock_router
+
+        order_data = _build_order_update_data()
+        task_order_status_update(order_data)
+
+        mock_use_case.get_integrated_agent_if_exists.assert_called_once_with(target)
+        dto = mock_use_case.execute.call_args.args[1]
+        self.assertEqual(dto.vtexAccount, "martimx")

--- a/retail/vtex/tests/usecases/test_resolve_order_origin_account.py
+++ b/retail/vtex/tests/usecases/test_resolve_order_origin_account.py
@@ -1,0 +1,79 @@
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.projects.models import Project
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.tests.fakes import FakeVtexIOClient
+from retail.vtex.usecases.resolve_order_origin_account import (
+    ResolveOrderOriginAccountUseCase,
+)
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "order-origin-account-tests",
+        }
+    }
+)
+class ResolveOrderOriginAccountUseCaseTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.addCleanup(cache.clear)
+        self.project = Project.objects.create(
+            uuid=uuid4(),
+            name="Columbia",
+            vtex_account="columbiamx",
+            config={
+                "vtex_config": {
+                    "vtex_sub_accounts": ["columbiamx", "martimx"],
+                }
+            },
+        )
+        self.oms_client = FakeVtexIOClient(hostname="martimx", order_id="v123-01")
+        self.usecase = ResolveOrderOriginAccountUseCase(
+            vtex_io_service=VtexIOService(client=self.oms_client)
+        )
+
+    def test_returns_store_name_from_hostname(self):
+        result = self.usecase.execute("v123-01", "columbiamx", self.project)
+
+        self.assertEqual(result, "martimx")
+        self.assertEqual(
+            self.oms_client.proxy_calls,
+            [
+                {
+                    "account_domain": "columbiamx.myvtex.com",
+                    "vtex_account": "columbiamx",
+                    "method": "GET",
+                    "path": "/api/oms/pvt/orders/v123-01",
+                }
+            ],
+        )
+
+    def test_caches_origin_account(self):
+        first = self.usecase.execute("v123-01", "columbiamx", self.project)
+        second = self.usecase.execute("v123-01", "columbiamx", self.project)
+
+        self.assertEqual(first, "martimx")
+        self.assertEqual(second, "martimx")
+        self.assertEqual(len(self.oms_client.proxy_calls), 1)
+
+    def test_returns_none_when_lookup_fails(self):
+        self.oms_client.proxy_error = Exception("oms down")
+        self.assertIsNone(self.usecase.execute("v123-01", "columbiamx", self.project))
+
+    def test_returns_none_when_hostname_missing(self):
+        self.oms_client.proxy_response = {"orderId": "v123-01"}
+        self.assertIsNone(self.usecase.execute("v123-01", "columbiamx", self.project))
+
+    def test_returns_none_when_order_id_missing(self):
+        self.assertIsNone(self.usecase.execute("", "columbiamx", self.project))
+        self.assertEqual(self.oms_client.proxy_calls, [])
+
+    def test_returns_none_for_non_dict_response(self):
+        self.oms_client.proxy_response = []
+        self.assertIsNone(self.usecase.execute("v123-01", "columbiamx", self.project))

--- a/retail/vtex/tests/usecases/test_resolve_order_origin_project.py
+++ b/retail/vtex/tests/usecases/test_resolve_order_origin_project.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project
+from retail.vtex.usecases.resolve_order_origin_project import (
+    ResolveOrderOriginProjectUseCase,
+)
+from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
+
+
+def _dto(vtex_account: str = "columbiamx") -> OrderStatusDTO:
+    return OrderStatusDTO(
+        recorder={},
+        domain="Marketplace",
+        orderId="v123-01",
+        currentState="invoiced",
+        lastState="payment-approved",
+        currentChangeDate="2026-08-19T00:00:00Z",
+        lastChangeDate="2026-08-19T00:00:00Z",
+        vtexAccount=vtex_account,
+    )
+
+
+class ResolveOrderOriginProjectUseCaseTest(TestCase):
+    def setUp(self):
+        self.ingress = Project.objects.create(
+            uuid=uuid4(),
+            name="Columbia",
+            vtex_account="columbiamx",
+            config={"vtex_config": {"vtex_sub_accounts": ["columbiamx", "martimx"]}},
+        )
+        self.target = Project.objects.create(
+            uuid=uuid4(),
+            name="Marti",
+            vtex_account="martimx",
+        )
+        self.origin_account_resolver = MagicMock()
+        self.usecase = ResolveOrderOriginProjectUseCase(
+            origin_account_resolver=self.origin_account_resolver
+        )
+        self.lookup = MagicMock()
+
+    def test_skips_oms_when_project_has_single_account(self):
+        self.ingress.config = {}
+        self.ingress.save(update_fields=["config"])
+
+        result = self.usecase.execute(_dto(), self.ingress, self.lookup)
+
+        self.assertEqual(result, self.ingress)
+        self.origin_account_resolver.execute.assert_not_called()
+        self.lookup.assert_not_called()
+
+    def test_routes_to_origin_project(self):
+        self.origin_account_resolver.execute.return_value = "martimx"
+        self.lookup.return_value = self.target
+
+        result = self.usecase.execute(_dto(), self.ingress, self.lookup)
+
+        self.assertEqual(result, self.target)
+        self.origin_account_resolver.execute.assert_called_once_with(
+            order_id="v123-01",
+            ingress_vtex_account="columbiamx",
+            ingress_project=self.ingress,
+        )
+        self.lookup.assert_called_once_with("martimx")
+
+    def test_keeps_ingress_when_hostname_matches_ingress_account(self):
+        self.origin_account_resolver.execute.return_value = "columbiamx"
+
+        result = self.usecase.execute(_dto(), self.ingress, self.lookup)
+
+        self.assertEqual(result, self.ingress)
+        self.lookup.assert_not_called()
+
+    def test_falls_back_to_ingress_when_origin_project_missing(self):
+        self.origin_account_resolver.execute.return_value = "martimx"
+        self.lookup.return_value = None
+
+        result = self.usecase.execute(_dto(), self.ingress, self.lookup)
+
+        self.assertEqual(result, self.ingress)
+
+    def test_falls_back_to_ingress_when_oms_fails(self):
+        self.origin_account_resolver.execute.return_value = None
+
+        result = self.usecase.execute(_dto(), self.ingress, self.lookup)
+
+        self.assertEqual(result, self.ingress)
+        self.lookup.assert_not_called()

--- a/retail/vtex/tests/usecases/test_sync_vtex_sub_accounts.py
+++ b/retail/vtex/tests/usecases/test_sync_vtex_sub_accounts.py
@@ -1,0 +1,146 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project
+from retail.vtex.sub_accounts import (
+    VTEX_CONFIG_KEY,
+    origin_account_from_hostname,
+    project_has_multiple_vtex_accounts,
+    read_vtex_sub_accounts,
+)
+from retail.vtex.usecases.sync_vtex_sub_accounts import SyncVtexSubAccountsUseCase
+
+
+COLUMBIA_STORES_RESPONSE = [
+    {"id": 14576, "name": "columbiamx", "hosts": ["columbia.mx"]},
+    {"id": 160813, "name": "diablosrojosmx", "hosts": ["tiendadiablos.mx"]},
+    {"id": 10301, "name": "martimx", "hosts": ["marti.mx"]},
+]
+
+
+class ProjectHasMultipleVtexAccountsTest(TestCase):
+    def test_true_when_more_than_one_sub_account_is_stored(self):
+        project = Project(
+            config={VTEX_CONFIG_KEY: {"vtex_sub_accounts": ["columbiamx", "martimx"]}}
+        )
+        self.assertTrue(project_has_multiple_vtex_accounts(project))
+
+    def test_false_when_missing_or_single_account(self):
+        self.assertFalse(project_has_multiple_vtex_accounts(Project(config={})))
+        self.assertFalse(
+            project_has_multiple_vtex_accounts(
+                Project(config={VTEX_CONFIG_KEY: {"vtex_sub_accounts": ["martimx"]}})
+            )
+        )
+        self.assertFalse(project_has_multiple_vtex_accounts(MagicMock(config="x")))
+
+    def test_read_sub_accounts_returns_names_only(self):
+        project = Project(config={VTEX_CONFIG_KEY: {"vtex_sub_accounts": ["martimx"]}})
+        self.assertEqual(read_vtex_sub_accounts(project), ["martimx"])
+        self.assertEqual(read_vtex_sub_accounts(Project(config={})), [])
+
+    def test_read_sub_accounts_accepts_legacy_vtex_stores_key(self):
+        project = Project(
+            config={
+                VTEX_CONFIG_KEY: {
+                    "vtex_stores": [
+                        {"name": "columbiamx", "hosts": ["columbia.mx"]},
+                        {"name": "martimx", "hosts": ["marti.mx"]},
+                    ]
+                }
+            }
+        )
+        self.assertEqual(read_vtex_sub_accounts(project), ["columbiamx", "martimx"])
+        self.assertTrue(project_has_multiple_vtex_accounts(project))
+
+
+class OriginAccountFromHostnameTest(TestCase):
+    def test_matches_stored_account_name(self):
+        self.assertEqual(
+            origin_account_from_hostname(
+                "martimx", ["columbiamx", "diablosrojosmx", "martimx"]
+            ),
+            "martimx",
+        )
+
+    def test_falls_back_to_hostname_when_unknown(self):
+        self.assertEqual(
+            origin_account_from_hostname("other", ["columbiamx", "martimx"]),
+            "other",
+        )
+
+    def test_empty_hostname_is_returned(self):
+        self.assertEqual(origin_account_from_hostname(""), "")
+
+
+class SyncVtexSubAccountsUseCaseTest(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            uuid=uuid4(),
+            name="Columbia",
+            vtex_account="columbiamx",
+            config={"vtex_config": {"vtex_store_type": "io"}},
+        )
+        self.mock_vtex_io = MagicMock()
+        self.usecase = SyncVtexSubAccountsUseCase(vtex_io_service=self.mock_vtex_io)
+
+    def test_persists_sub_account_names_and_keeps_existing_vtex_config(self):
+        self.mock_vtex_io.proxy_vtex.return_value = COLUMBIA_STORES_RESPONSE
+
+        result = self.usecase.execute(self.project)
+
+        self.assertTrue(result.has_multiple_vtex_accounts)
+        self.assertEqual(
+            list(result.sub_accounts), ["columbiamx", "diablosrojosmx", "martimx"]
+        )
+        self.project.refresh_from_db()
+        vtex_config = self.project.config["vtex_config"]
+        self.assertEqual(vtex_config["vtex_store_type"], "io")
+        self.assertEqual(
+            vtex_config["vtex_sub_accounts"],
+            ["columbiamx", "diablosrojosmx", "martimx"],
+        )
+        self.assertNotIn("has_multiple_vtex_accounts", vtex_config)
+        self.assertNotIn("vtex_stores", vtex_config)
+        self.mock_vtex_io.proxy_vtex.assert_called_once_with(
+            account_domain="columbiamx.myvtex.com",
+            vtex_account="columbiamx",
+            method="GET",
+            path="/api/vlm/account/stores",
+        )
+
+    def test_single_account_is_not_treated_as_multiple(self):
+        self.mock_vtex_io.proxy_vtex.return_value = [COLUMBIA_STORES_RESPONSE[0]]
+
+        result = self.usecase.execute(self.project)
+
+        self.assertFalse(result.has_multiple_vtex_accounts)
+        self.project.refresh_from_db()
+        self.assertEqual(
+            self.project.config["vtex_config"]["vtex_sub_accounts"], ["columbiamx"]
+        )
+
+    def test_no_vtex_account_returns_none(self):
+        project = Project.objects.create(uuid=uuid4(), name="No VTEX", vtex_account="")
+        self.assertIsNone(self.usecase.execute(project))
+        self.mock_vtex_io.proxy_vtex.assert_not_called()
+
+    def test_proxy_failure_returns_none(self):
+        self.mock_vtex_io.proxy_vtex.side_effect = Exception("timeout")
+        self.assertIsNone(self.usecase.execute(self.project))
+
+    def test_unexpected_payload_returns_none(self):
+        self.mock_vtex_io.proxy_vtex.return_value = {"error": "forbidden"}
+        self.assertIsNone(self.usecase.execute(self.project))
+
+    def test_skips_items_without_name(self):
+        self.mock_vtex_io.proxy_vtex.return_value = [
+            {"id": 1},
+            COLUMBIA_STORES_RESPONSE[0],
+            "bad",
+        ]
+        result = self.usecase.execute(self.project)
+        self.assertFalse(result.has_multiple_vtex_accounts)
+        self.assertEqual(result.sub_accounts, ("columbiamx",))

--- a/retail/vtex/usecases/resolve_order_origin_account.py
+++ b/retail/vtex/usecases/resolve_order_origin_account.py
@@ -1,0 +1,101 @@
+"""Resolve the VTEX sub-account that originated an order."""
+
+import logging
+from typing import Optional
+
+from django.core.cache import cache
+
+from retail.projects.models import Project
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.sub_accounts import (
+    ORDER_ORIGIN_CACHE_KEY_PREFIX,
+    ORDER_ORIGIN_CACHE_TIMEOUT_SECONDS,
+    origin_account_from_hostname,
+    read_vtex_sub_accounts,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ResolveOrderOriginAccountUseCase:
+    """Read OMS ``hostname`` using the account that received the webhook."""
+
+    def __init__(self, vtex_io_service: Optional[VtexIOService] = None):
+        self.vtex_io_service = vtex_io_service or VtexIOService()
+
+    def execute(
+        self,
+        order_id: str,
+        ingress_vtex_account: str,
+        ingress_project: Optional[Project] = None,
+    ) -> Optional[str]:
+        """Return the origin sub-account name for ``order_id``, or None on failure.
+
+        Args:
+            order_id: VTEX order id from the webhook.
+            ingress_vtex_account: Account that received the webhook.
+            ingress_project: Project of that account, used to map hostname
+                to a persisted sub-account name.
+        """
+        if not order_id or not ingress_vtex_account:
+            return None
+
+        cache_key = f"{ORDER_ORIGIN_CACHE_KEY_PREFIX}_{ingress_vtex_account}_{order_id}"
+        cached = cache.get(cache_key)
+        if cached:
+            return cached
+
+        hostname = self._fetch_hostname(order_id, ingress_vtex_account)
+        if not hostname:
+            return None
+
+        account_names = (
+            read_vtex_sub_accounts(ingress_project)
+            if ingress_project is not None
+            else []
+        )
+        origin_account = origin_account_from_hostname(hostname, account_names)
+
+        cache.set(cache_key, origin_account, timeout=ORDER_ORIGIN_CACHE_TIMEOUT_SECONDS)
+        logger.info(
+            f"[ORDER_STATUS] order_origin_resolved: order_id={order_id} "
+            f"ingress_account={ingress_vtex_account} hostname={hostname} "
+            f"origin_account={origin_account}"
+        )
+        return origin_account
+
+    def _fetch_hostname(
+        self, order_id: str, ingress_vtex_account: str
+    ) -> Optional[str]:
+        account_domain = f"{ingress_vtex_account}.myvtex.com"
+        path = f"/api/oms/pvt/orders/{order_id}"
+        try:
+            response = self.vtex_io_service.proxy_vtex(
+                account_domain=account_domain,
+                vtex_account=ingress_vtex_account,
+                method="GET",
+                path=path,
+            )
+        except Exception as exc:
+            logger.warning(
+                f"[ORDER_STATUS] order_origin_lookup_failed: "
+                f"ingress_account={ingress_vtex_account} order_id={order_id} "
+                f"error={exc}"
+            )
+            return None
+
+        if not isinstance(response, dict):
+            logger.warning(
+                f"[ORDER_STATUS] order_origin_unexpected_response: "
+                f"ingress_account={ingress_vtex_account} order_id={order_id}"
+            )
+            return None
+
+        hostname = response.get("hostname")
+        if not isinstance(hostname, str) or not hostname.strip():
+            logger.warning(
+                f"[ORDER_STATUS] order_origin_missing_hostname: "
+                f"ingress_account={ingress_vtex_account} order_id={order_id}"
+            )
+            return None
+        return hostname.strip()

--- a/retail/vtex/usecases/resolve_order_origin_project.py
+++ b/retail/vtex/usecases/resolve_order_origin_project.py
@@ -1,0 +1,72 @@
+"""Route an order webhook from the ingress project to the origin project."""
+
+import logging
+from typing import Callable, Optional
+
+from retail.projects.models import Project
+from retail.vtex.sub_accounts import project_has_multiple_vtex_accounts
+from retail.vtex.usecases.resolve_order_origin_account import (
+    ResolveOrderOriginAccountUseCase,
+)
+from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
+
+logger = logging.getLogger(__name__)
+
+ProjectLookup = Callable[[str], Optional[Project]]
+
+
+class ResolveOrderOriginProjectUseCase:
+    """Pick the project that should process an order webhook.
+
+    When the ingress project has a single VTEX account, it is returned
+    unchanged (no extra OMS call).
+    """
+
+    def __init__(
+        self,
+        origin_account_resolver: Optional[ResolveOrderOriginAccountUseCase] = None,
+    ):
+        self.origin_account_resolver = (
+            origin_account_resolver or ResolveOrderOriginAccountUseCase()
+        )
+
+    def execute(
+        self,
+        dto: OrderStatusDTO,
+        ingress_project: Project,
+        lookup_project: ProjectLookup,
+    ) -> Project:
+        """Return the destination project for ``dto``.
+
+        Args:
+            dto: Incoming order payload.
+            ingress_project: Project resolved from the account that received
+                the webhook.
+            lookup_project: Callable that finds a project by ``vtex_account``.
+        """
+        if not project_has_multiple_vtex_accounts(ingress_project):
+            return ingress_project
+
+        origin_account = self.origin_account_resolver.execute(
+            order_id=dto.orderId,
+            ingress_vtex_account=dto.vtexAccount,
+            ingress_project=ingress_project,
+        )
+        if not origin_account or origin_account == dto.vtexAccount:
+            return ingress_project
+
+        target = lookup_project(origin_account)
+        if target is None:
+            logger.warning(
+                f"[ORDER_STATUS] origin_project_not_found: "
+                f"ingress={dto.vtexAccount} origin={origin_account} "
+                f"order_id={dto.orderId} ingress_project={ingress_project.uuid}"
+            )
+            return ingress_project
+
+        logger.info(
+            f"[ORDER_STATUS] routed_by_hostname: ingress={dto.vtexAccount} "
+            f"origin={origin_account} ingress_project={ingress_project.uuid} "
+            f"target_project={target.uuid} order_id={dto.orderId}"
+        )
+        return target

--- a/retail/vtex/usecases/sync_vtex_sub_accounts.py
+++ b/retail/vtex/usecases/sync_vtex_sub_accounts.py
@@ -1,0 +1,123 @@
+"""Detect VTEX sub-accounts and persist the names on the project."""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple
+
+from retail.projects.models import Project
+from retail.services.vtex_io.service import VtexIOService
+from retail.vtex.sub_accounts import (
+    LEGACY_VTEX_STORES_KEY,
+    VTEX_ACCOUNT_STORES_PATH,
+    VTEX_CONFIG_KEY,
+    VTEX_SUB_ACCOUNTS_KEY,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class VtexSubAccountsSyncResult:
+    """Sub-account names returned by License Manager for one project."""
+
+    sub_accounts: Tuple[str, ...]
+
+    @property
+    def has_multiple_vtex_accounts(self) -> bool:
+        return len(self.sub_accounts) > 1
+
+
+class SyncVtexSubAccountsUseCase:
+    """Fetch ``GET /api/vlm/account/stores`` and store the names on the project.
+
+    Fail-safe: infrastructure errors are logged and return ``None`` so agent
+    assignment never fails because this check is unavailable.
+    """
+
+    def __init__(self, vtex_io_service: Optional[VtexIOService] = None):
+        self.vtex_io_service = vtex_io_service or VtexIOService()
+
+    def execute(self, project: Project) -> Optional[VtexSubAccountsSyncResult]:
+        """Fetch License Manager names and write them on ``project.config``.
+
+        Args:
+            project: Project whose ``vtex_account`` is queried.
+
+        Returns:
+            The parsed result, or None when the project has no account or
+            the VTEX call fails.
+        """
+        sub_accounts = self.fetch_sub_accounts(project)
+        if sub_accounts is None:
+            return None
+
+        result = VtexSubAccountsSyncResult(sub_accounts=tuple(sub_accounts))
+        self._persist(project, result)
+        return result
+
+    def fetch_sub_accounts(self, project: Project) -> Optional[List[str]]:
+        """Return License Manager account names, or None on skip/failure."""
+        vtex_account = project.vtex_account
+        if not vtex_account:
+            logger.info(
+                f"[VTEX_SUB_ACCOUNTS] skipped_no_account: project={project.uuid}"
+            )
+            return None
+
+        account_domain = f"{vtex_account}.myvtex.com"
+        try:
+            logger.info(
+                f"[VTEX_SUB_ACCOUNTS] fetching: "
+                f"project={project.uuid} vtex_account={vtex_account}"
+            )
+            response = self.vtex_io_service.proxy_vtex(
+                account_domain=account_domain,
+                vtex_account=vtex_account,
+                method="GET",
+                path=VTEX_ACCOUNT_STORES_PATH,
+            )
+        except Exception as exc:
+            logger.error(
+                f"[VTEX_SUB_ACCOUNTS] fetch_failed: "
+                f"project={project.uuid} vtex_account={vtex_account} error={exc}"
+            )
+            return None
+
+        sub_accounts = self._parse_account_names(response)
+        if sub_accounts is None:
+            logger.warning(
+                f"[VTEX_SUB_ACCOUNTS] unexpected_response: "
+                f"project={project.uuid} vtex_account={vtex_account}"
+            )
+            return None
+
+        logger.info(
+            f"[VTEX_SUB_ACCOUNTS] resolved: "
+            f"project={project.uuid} vtex_account={vtex_account} "
+            f"account_count={len(sub_accounts)} "
+            f"has_multiple={len(sub_accounts) > 1}"
+        )
+        return sub_accounts
+
+    def _parse_account_names(self, response: Any) -> Optional[List[str]]:
+        if not isinstance(response, list):
+            return None
+
+        names: List[str] = []
+        for item in response:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            if isinstance(name, str) and name:
+                names.append(name)
+        return names
+
+    def _persist(self, project: Project, result: VtexSubAccountsSyncResult) -> None:
+        config = dict(project.config or {})
+        vtex_config = dict(config.get(VTEX_CONFIG_KEY) or {})
+        vtex_config.pop("has_multiple_vtex_accounts", None)
+        vtex_config.pop(LEGACY_VTEX_STORES_KEY, None)
+        vtex_config[VTEX_SUB_ACCOUNTS_KEY] = list(result.sub_accounts)
+        config[VTEX_CONFIG_KEY] = vtex_config
+        project.config = config
+        project.save(update_fields=["config"])


### PR DESCRIPTION
## What

Detect VTEX multi-store on agent assign and persist sub-account names on the project. When an order-status or payment-recovery webhook arrives on the ingress account, resolve the origin store from OMS hostname using ingress credentials and dispatch the matching agent on that project. PIX falls back to the ingress agent when the origin has no payment-recovery agent. Abandoned cart is unchanged.

## Why

Stores that share one Admin receive child-store orders on the hub webhook. Without origin routing, order-status and PIX recovery run on the wrong project and the wrong agent.