### PR TITLE
fix: Ignore pre-cart VTEX orders in purchase detection

### DIFF
--- a/retail/webhooks/vtex/services_cart_abandonment_unified.py
+++ b/retail/webhooks/vtex/services_cart_abandonment_unified.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from decimal import Decimal
 from typing import Any, Dict, Optional, Tuple, Union
@@ -7,7 +8,7 @@ from uuid import UUID
 from django.utils import timezone
 from django.conf import settings
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 
 from retail.agents.domains.agent_execution.services.logger import ExecutionLoggerService
 from retail.agents.domains.agent_integration.models import IntegratedAgent
@@ -46,6 +47,16 @@ from retail.vtex.usecases.clone_order_form import (
 
 # VTEX order statuses that count as a finalized purchase.
 PURCHASED_ORDER_STATUSES = frozenset({"invoiced"})
+
+# OMS List Orders via the generic VTEX IO proxy. per_page max is 100;
+# VTEX caps listing at 30 pages (~3000 orders per date window).
+OMS_LIST_ORDERS_PATH = "/api/oms/pvt/orders"
+OMS_LIST_PAGE_SIZE = 100
+OMS_LIST_MAX_PAGES = 30
+
+# VTEX may emit more than six fractional-second digits; fromisoformat
+# rejects that on some Python versions.
+_VTEX_DATETIME_FRACTION = re.compile(r"(\.\d{6})\d+(?=[Z+-]|$)")
 
 # Lookback window aligned with the Cart cleanup task TTL.
 ORDER_FORM_DEDUPLICATION_WINDOW = timedelta(days=15)
@@ -232,12 +243,11 @@ class CartAbandonmentService(BaseVtexUseCase):
                 f"items_count={len(cart_items)}"
             )
 
-            # Check orders by email (email already validated above)
-            orders = self._fetch_orders_by_email(cart, client_email)
+            orders = self._fetch_orders_placed_after_cart(cart, client_email)
             orders_count = len(orders.get("list", []))
             logger.info(
-                f"[CART_SERVICE] Orders fetched by email: {log_context} "
-                f"email={client_email} orders_found={orders_count}"
+                f"[CART_SERVICE] Orders fetched after cart creation: {log_context} "
+                f"orders_found={orders_count}"
             )
 
             self._evaluate_orders(
@@ -367,24 +377,80 @@ class CartAbandonmentService(BaseVtexUseCase):
         cart.config["cart_items"] = order_form.get("items", [])
         cart.save()
 
-    def _fetch_orders_by_email(self, cart: Cart, email: str) -> dict:
-        """
-        Fetch orders associated with a given email.
+    def _fetch_orders_placed_after_cart(self, cart: Cart, email: str) -> dict:
+        """List OMS orders placed after the cart row was created.
 
-        Args:
-            cart (Cart): The cart instance.
-            email (str): The client email address.
-
-        Returns:
-            dict: List of orders associated with the email.
+        Uses ``POST /_v/proxy-vtex`` so this service owns the OMS query
+        (date range, page size, pagination) instead of
+        ``/orders-by-email``, which ignores ``f_creationDate`` and only
+        returns the first page.
         """
         project_uuid = str(cart.project.uuid)
-        orders = self.vtex_io_service.get_order_details(
-            account_domain=self._get_account_domain(project_uuid),
-            vtex_account=cart.project.vtex_account,
-            user_email=email,
-        )
-        return orders or {"list": []}
+        account_domain = self._get_account_domain(project_uuid)
+        vtex_account = cart.project.vtex_account
+        date_from = self._to_oms_utc(cart.created_on)
+        date_to = self._to_oms_utc(timezone.now())
+
+        orders: list = []
+        page = 1
+        while page <= OMS_LIST_MAX_PAGES:
+            response = (
+                self.vtex_io_service.proxy_vtex(
+                    account_domain=account_domain,
+                    vtex_account=vtex_account,
+                    method="GET",
+                    path=OMS_LIST_ORDERS_PATH,
+                    params=self._build_orders_list_params(
+                        email, date_from, date_to, page
+                    ),
+                )
+                or {}
+            )
+            orders.extend(response.get("list") or [])
+            if page >= self._oms_total_pages(response):
+                break
+            page += 1
+        else:
+            logger.warning(
+                f"[CART_SERVICE] OMS list pagination hit max pages "
+                f"cart_uuid={cart.uuid} max_pages={OMS_LIST_MAX_PAGES}"
+            )
+
+        return {"list": orders}
+
+    @staticmethod
+    def _build_orders_list_params(
+        email: str, date_from: str, date_to: str, page: int
+    ) -> dict:
+        """Build unencoded OMS List Orders query params.
+
+        ``f_creationDate`` must not be pre-percent-encoded: the IO proxy
+        encodes ``params`` once. ``q`` is OMS text search (same as
+        ``/orders-by-email``), not an exact email match.
+        """
+        return {
+            "q": email,
+            "orderBy": "creationDate,desc",
+            "page": str(page),
+            "per_page": str(OMS_LIST_PAGE_SIZE),
+            "f_creationDate": f"creationDate:[{date_from} TO {date_to}]",
+        }
+
+    @staticmethod
+    def _to_oms_utc(value: datetime) -> str:
+        """Format a datetime as the UTC ISO string OMS date filters expect."""
+        if timezone.is_naive(value):
+            value = timezone.make_aware(value, dt_timezone.utc)
+        return value.astimezone(dt_timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    @staticmethod
+    def _oms_total_pages(response: dict) -> int:
+        raw_pages = (response.get("paging") or {}).get("pages")
+        try:
+            pages = int(raw_pages)
+        except (TypeError, ValueError):
+            return 1
+        return pages if pages > 0 else 1
 
     def _evaluate_orders(
         self,
@@ -423,14 +489,31 @@ class CartAbandonmentService(BaseVtexUseCase):
             )
             return
 
-        recent_orders = orders.get("list", [])[:5]
-        invoiced_orders = self._filter_invoiced_orders(recent_orders)
+        orders_after_cart = self._filter_orders_created_after_cart(
+            orders.get("list", []), cart
+        )
+        if not orders_after_cart:
+            logger.info(
+                f"[CART_SERVICE] No orders created after the cart: {log_context} "
+                f"orders_returned={len(orders.get('list', []))} "
+                f"action=mark_as_abandoned reason=no_orders_created_after_cart"
+            )
+            self._mark_cart_as_abandoned(
+                cart,
+                order_form,
+                client_profile,
+                integration_config,
+                execution_uuid=execution_uuid,
+            )
+            return
+
+        invoiced_orders = self._filter_invoiced_orders(orders_after_cart)
 
         if not invoiced_orders:
             logger.info(
                 f"[CART_SERVICE] No invoiced orders among recent ones: {log_context} "
-                f"recent_orders_checked={len(recent_orders)} "
-                f"recent_statuses={[o.get('status') for o in recent_orders]} "
+                f"recent_orders_checked={len(orders_after_cart)} "
+                f"recent_statuses={[o.get('status') for o in orders_after_cart]} "
                 f"action=mark_as_abandoned reason=no_purchased_status_found"
             )
             self._mark_cart_as_abandoned(
@@ -1361,6 +1444,69 @@ class CartAbandonmentService(BaseVtexUseCase):
         return False
 
     @staticmethod
+    def _parse_vtex_datetime(raw_value: object) -> Optional[datetime]:
+        """Parse a VTEX ISO-8601 timestamp into an aware ``datetime``.
+
+        Returns ``None`` when the value is missing or not parseable.
+        """
+        if not raw_value or not isinstance(raw_value, str):
+            return None
+
+        normalized = raw_value.strip().replace("Z", "+00:00")
+        normalized = _VTEX_DATETIME_FRACTION.sub(r"\1", normalized)
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+
+        if timezone.is_naive(parsed):
+            return timezone.make_aware(parsed, dt_timezone.utc)
+        return parsed
+
+    @staticmethod
+    def _order_was_created_after_cart(
+        order: dict, cart_created_on: datetime
+    ) -> Optional[bool]:
+        """Return whether ``order`` was created after ``cart_created_on``.
+
+        ``None`` means ``creationDate`` is missing or unparseable, so the
+        caller must not treat the order as older than the cart.
+        """
+        created_on = CartAbandonmentService._parse_vtex_datetime(
+            order.get("creationDate")
+        )
+        if created_on is None:
+            return None
+
+        if timezone.is_naive(cart_created_on):
+            cart_created_on = timezone.make_aware(cart_created_on, dt_timezone.utc)
+        return created_on > cart_created_on
+
+    def _filter_orders_created_after_cart(self, orders: list, cart: Cart) -> list:
+        """Keep orders placed after the cart row was created.
+
+        OMS List Orders is already queried with ``f_creationDate``, but
+        the range is inclusive and ``q`` is a text search. This local
+        cut drops any leftover order whose ``creationDate`` is not
+        strictly after ``cart.created_on``.
+        """
+        kept: list = []
+        skipped = 0
+        for order in orders:
+            created_after = self._order_was_created_after_cart(order, cart.created_on)
+            if created_after is False:
+                skipped += 1
+                continue
+            kept.append(order)
+
+        logger.info(
+            f"[CART_SERVICE] Filtered orders created after cart "
+            f"cart_uuid={cart.uuid} kept={len(kept)} "
+            f"skipped_older_than_cart={skipped} returned={len(orders)}"
+        )
+        return kept
+
+    @staticmethod
     def _filter_invoiced_orders(recent_orders: list) -> list:
         """Return the subset of ``recent_orders`` whose status is in ``PURCHASED_ORDER_STATUSES``."""
         return [
@@ -1421,17 +1567,29 @@ class CartAbandonmentService(BaseVtexUseCase):
                 logger.info(f"Fetching details for order {order_id}")
                 order_details = self._fetch_order_details_by_id(cart, order_id)
                 if order_details:
+                    created_after_cart = self._order_was_created_after_cart(
+                        order_details, cart.created_on
+                    )
                     recent_orders_details.append(
                         {
                             "orderId": order_id,
                             "orderFormId": order_details.get("orderFormId"),
                             "status": order_details.get("status")
                             or order_meta.get("status"),
+                            "creationDate": order_details.get("creationDate"),
                             "items": order_details.get("itemMetadata", {}).get(
                                 "Items", []
                             ),
                         }
                     )
+
+                    if created_after_cart is False:
+                        logger.info(
+                            f"[CART_SERVICE] Skipping order created before cart "
+                            f"order_id={order_id} cart_uuid={cart.uuid} "
+                            f"creationDate={order_details.get('creationDate')}"
+                        )
+                        continue
 
                     if self._compare_cart_items_with_order_items(cart, order_details):
                         logger.info(
@@ -1507,29 +1665,15 @@ class CartAbandonmentService(BaseVtexUseCase):
             bool: True if there's any overlap between cart and order items.
         """
         cart_items = cart.config.get("cart_items", [])
-        order_items = order_details.get("itemMetadata", {}).get("Items", [])
-
-        if not cart_items or not order_items:
+        cart_item_ids = {str(item["id"]) for item in cart_items if item.get("id")}
+        order_item_ids = self._extract_order_sku_ids(order_details)
+        if not cart_item_ids or not order_item_ids:
             logger.info(
-                f"Cart or order items empty - cart: {len(cart_items)}, order: {len(order_items)}"
+                f"Cart or order items empty - cart: {len(cart_item_ids)}, "
+                f"order: {len(order_item_ids)}"
             )
             return False
 
-        # Create sets of item IDs for comparison
-        cart_item_ids = set()
-        order_item_ids = set()
-
-        # Extract IDs from cart items
-        for item in cart_items:
-            if item.get("id"):
-                cart_item_ids.add(str(item["id"]))
-
-        # Extract IDs from order items (from itemMetadata.Items)
-        for item in order_items:
-            if item.get("Id"):  # Note: order items use "Id" (capital I)
-                order_item_ids.add(str(item["Id"]))
-
-        # Check for matching products between cart and recent orders
         matching_products = cart_item_ids.intersection(order_item_ids)
 
         if matching_products:
@@ -1540,6 +1684,26 @@ class CartAbandonmentService(BaseVtexUseCase):
 
         logger.info("No matching products found in recent orders")
         return False
+
+    @staticmethod
+    def _extract_order_sku_ids(order_details: dict) -> set:
+        """Return SKU ids from the order, preferring line items.
+
+        ``items[].id`` is the purchased SKU. ``itemMetadata.Items[].Id``
+        is kept as fallback because some OMS payloads omit ``items``.
+        """
+        sku_ids = {
+            str(item["id"])
+            for item in order_details.get("items") or []
+            if item.get("id")
+        }
+        if sku_ids:
+            return sku_ids
+        return {
+            str(item["Id"])
+            for item in (order_details.get("itemMetadata") or {}).get("Items") or []
+            if item.get("Id")
+        }
 
     @staticmethod
     def _parse_item_quantity(item: dict) -> int:

--- a/retail/webhooks/vtex/tests/test_cart_abandonment_status_filter.py
+++ b/retail/webhooks/vtex/tests/test_cart_abandonment_status_filter.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import User
@@ -8,6 +9,9 @@ from retail.features.models import Feature, IntegratedFeature
 from retail.projects.models import Project
 from retail.vtex.models import Cart
 from retail.webhooks.vtex.services_cart_abandonment_unified import (
+    OMS_LIST_MAX_PAGES,
+    OMS_LIST_ORDERS_PATH,
+    OMS_LIST_PAGE_SIZE,
     PURCHASED_ORDER_STATUSES,
     CartAbandonmentService,
 )
@@ -111,13 +115,19 @@ class EvaluateOrdersStatusFilteringTests(TestCase):
             "clientPreferencesData": {"locale": "pt-BR"},
         }
 
-    def _build_order_details(self, order_id, items):
-        return {
+    def _iso(self, delta: timedelta) -> str:
+        return (self.cart.created_on + delta).isoformat()
+
+    def _build_order_details(self, order_id, items, creation_date=None):
+        details = {
             "orderId": order_id,
             "orderFormId": f"of-{order_id}",
             "status": "invoiced",
             "itemMetadata": {"Items": items},
         }
+        if creation_date is not None:
+            details["creationDate"] = creation_date
+        return details
 
     def test_only_non_invoiced_orders_marks_cart_as_abandoned(self):
         """If all recent orders are not invoiced, cart must be notified."""
@@ -233,3 +243,369 @@ class EvaluateOrdersStatusFilteringTests(TestCase):
         self.assertEqual(len(recent_orders_checked), 1)
         self.assertEqual(recent_orders_checked[0]["orderId"], "order-1")
         self.assertEqual(recent_orders_checked[0]["status"], "invoiced")
+
+    def test_invoiced_order_before_cart_creation_does_not_mark_purchased(self):
+        """SKU overlap on an order older than the cart must not block the send.
+
+        Reproduces the gigavc false positive: a 2025 invoiced order sharing
+        the cart SKU was treated as a conversion of a later orderForm.
+        """
+        old_creation = self._iso(timedelta(days=-365))
+        orders = {
+            "list": [
+                {
+                    "orderId": "order-2025",
+                    "status": "invoiced",
+                    "creationDate": old_creation,
+                }
+            ]
+        }
+        self.service.vtex_io_service.get_order_details_by_id.return_value = (
+            self._build_order_details(
+                "order-2025", [{"Id": "sku-1"}], creation_date=old_creation
+            )
+        )
+
+        with patch.object(self.service, "_mark_cart_as_abandoned") as mock_mark:
+            self.service._evaluate_orders(
+                cart=self.cart,
+                orders=orders,
+                order_form=self._build_order_form(),
+                client_profile={"email": "buyer@example.com"},
+                integration_config=self.integrated_feature,
+            )
+
+        mock_mark.assert_called_once()
+        self.service.vtex_io_service.get_order_details_by_id.assert_not_called()
+        self.cart.refresh_from_db()
+        self.assertNotEqual(self.cart.status, "purchased")
+
+    def test_invoiced_order_after_cart_creation_with_matching_sku_marks_purchased(
+        self,
+    ):
+        """A matching invoiced order placed after the cart must still block."""
+        new_creation = self._iso(timedelta(hours=2))
+        orders = {
+            "list": [
+                {
+                    "orderId": "order-new",
+                    "status": "invoiced",
+                    "creationDate": new_creation,
+                }
+            ]
+        }
+        self.service.vtex_io_service.get_order_details_by_id.return_value = (
+            self._build_order_details(
+                "order-new", [{"Id": "sku-1"}], creation_date=new_creation
+            )
+        )
+
+        with patch.object(self.service, "_mark_cart_as_abandoned") as mock_mark:
+            self.service._evaluate_orders(
+                cart=self.cart,
+                orders=orders,
+                order_form=self._build_order_form(),
+                client_profile={"email": "buyer@example.com"},
+                integration_config=self.integrated_feature,
+            )
+
+        mock_mark.assert_not_called()
+        self.cart.refresh_from_db()
+        self.assertEqual(self.cart.status, "purchased")
+
+    def test_date_filter_runs_before_recent_orders_window(self):
+        """Pre-cart invoiced orders must not hide a later matching purchase.
+
+        Five invoiced orders older than the cart plus one post-cart
+        matching order must still mark the cart as purchased.
+        """
+        old_creation = self._iso(timedelta(days=-200))
+        new_creation = self._iso(timedelta(hours=3))
+        older_orders = [
+            {
+                "orderId": f"order-old-{index}",
+                "status": "invoiced",
+                "creationDate": old_creation,
+            }
+            for index in range(5)
+        ]
+        orders = {
+            "list": older_orders
+            + [
+                {
+                    "orderId": "order-new",
+                    "status": "invoiced",
+                    "creationDate": new_creation,
+                }
+            ]
+        }
+        self.service.vtex_io_service.get_order_details_by_id.return_value = (
+            self._build_order_details(
+                "order-new", [{"Id": "sku-1"}], creation_date=new_creation
+            )
+        )
+
+        with patch.object(self.service, "_mark_cart_as_abandoned") as mock_mark:
+            self.service._evaluate_orders(
+                cart=self.cart,
+                orders=orders,
+                order_form=self._build_order_form(),
+                client_profile={"email": "buyer@example.com"},
+                integration_config=self.integrated_feature,
+            )
+
+        mock_mark.assert_not_called()
+        self.service.vtex_io_service.get_order_details_by_id.assert_called_once_with(
+            account_domain="test.myvtex.com",
+            vtex_account="test-account",
+            order_id="order-new",
+        )
+        self.cart.refresh_from_db()
+        self.assertEqual(self.cart.status, "purchased")
+
+    def test_details_creation_date_before_cart_skips_sku_match(self):
+        """List items without a date still drop out when details are older."""
+        old_creation = self._iso(timedelta(days=-365))
+        orders = {
+            "list": [
+                {"orderId": "order-undated", "status": "invoiced"},
+            ]
+        }
+        self.service.vtex_io_service.get_order_details_by_id.return_value = (
+            self._build_order_details(
+                "order-undated", [{"Id": "sku-1"}], creation_date=old_creation
+            )
+        )
+
+        with patch.object(self.service, "_mark_cart_as_abandoned") as mock_mark:
+            self.service._evaluate_orders(
+                cart=self.cart,
+                orders=orders,
+                order_form=self._build_order_form(),
+                client_profile={"email": "buyer@example.com"},
+                integration_config=self.integrated_feature,
+            )
+
+        mock_mark.assert_called_once()
+        self.cart.refresh_from_db()
+        self.assertNotEqual(self.cart.status, "purchased")
+        recent_orders_checked = self.cart.config.get("recent_orders_checked", [])
+        self.assertEqual(recent_orders_checked[0]["creationDate"], old_creation)
+
+
+class FilterOrdersCreatedAfterCartTests(TestCase):
+    """Unit tests for the local creationDate cut."""
+
+    def setUp(self):
+        self.feature = Feature.objects.create(
+            can_vtex_integrate=True, code="abandoned_cart"
+        )
+        self.user = User.objects.create()
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(), vtex_account="test-account"
+        )
+        self.integrated_feature = IntegratedFeature.objects.create(
+            feature=self.feature,
+            project=self.project,
+            user=self.user,
+            config={},
+        )
+        self.cart = Cart.objects.create(
+            order_form_id="order-form-1",
+            phone_number="5511999999999",
+            project=self.project,
+            integrated_feature=self.integrated_feature,
+            config={},
+        )
+        self.service = CartAbandonmentService()
+
+    def test_drops_orders_created_before_the_cart(self):
+        older = (self.cart.created_on - timedelta(days=10)).isoformat()
+        newer = (self.cart.created_on + timedelta(hours=1)).isoformat()
+        orders = [
+            {"orderId": "old", "creationDate": older},
+            {"orderId": "new", "creationDate": newer},
+            {"orderId": "undated"},
+        ]
+
+        kept = self.service._filter_orders_created_after_cart(orders, self.cart)
+
+        self.assertEqual(
+            [order["orderId"] for order in kept],
+            ["new", "undated"],
+        )
+
+    def test_parse_vtex_datetime_accepts_z_suffix_and_extra_fraction(self):
+        parsed = CartAbandonmentService._parse_vtex_datetime(
+            "2025-03-15T12:30:00.1234567Z"
+        )
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.year, 2025)
+        self.assertEqual(parsed.month, 3)
+        self.assertEqual(parsed.day, 15)
+        self.assertIsNotNone(parsed.tzinfo)
+
+    def test_parse_vtex_datetime_returns_none_for_invalid_values(self):
+        self.assertIsNone(CartAbandonmentService._parse_vtex_datetime(None))
+        self.assertIsNone(CartAbandonmentService._parse_vtex_datetime(""))
+        self.assertIsNone(CartAbandonmentService._parse_vtex_datetime("not-a-date"))
+        self.assertIsNone(CartAbandonmentService._parse_vtex_datetime(123))
+
+    def test_to_oms_utc_converts_naive_datetime_to_utc_zulu(self):
+        naive = datetime(2026, 8, 24, 12, 30, 45, 123456)
+        self.assertEqual(
+            CartAbandonmentService._to_oms_utc(naive),
+            "2026-08-24T12:30:45.000Z",
+        )
+
+    def test_oms_total_pages_defaults_to_one_when_paging_missing(self):
+        self.assertEqual(CartAbandonmentService._oms_total_pages({}), 1)
+        self.assertEqual(
+            CartAbandonmentService._oms_total_pages({"paging": {"pages": "x"}}),
+            1,
+        )
+        self.assertEqual(
+            CartAbandonmentService._oms_total_pages({"paging": {"pages": 3}}),
+            3,
+        )
+
+
+class FetchOrdersPlacedAfterCartTests(TestCase):
+    """OMS list via ``proxy_vtex``: date filter, pagination, no SKU on list."""
+
+    def setUp(self):
+        self.feature = Feature.objects.create(
+            can_vtex_integrate=True, code="abandoned_cart"
+        )
+        self.user = User.objects.create()
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(), vtex_account="test-account"
+        )
+        self.integrated_feature = IntegratedFeature.objects.create(
+            feature=self.feature,
+            project=self.project,
+            user=self.user,
+            config={},
+        )
+        self.cart = Cart.objects.create(
+            order_form_id="order-form-1",
+            phone_number="5511999999999",
+            project=self.project,
+            integrated_feature=self.integrated_feature,
+            config={"cart_items": [{"id": "sku-1"}]},
+        )
+        self.service = CartAbandonmentService()
+        self.service.vtex_io_service = MagicMock()
+        self.service._get_account_domain = MagicMock(return_value="test.myvtex.com")
+
+    def test_proxy_query_filters_by_email_and_creation_date(self):
+        self.service.vtex_io_service.proxy_vtex.return_value = {
+            "list": [],
+            "paging": {"pages": 1},
+        }
+
+        result = self.service._fetch_orders_placed_after_cart(
+            self.cart, "buyer@example.com"
+        )
+
+        self.assertEqual(result, {"list": []})
+        self.service.vtex_io_service.proxy_vtex.assert_called_once()
+        kwargs = self.service.vtex_io_service.proxy_vtex.call_args.kwargs
+        self.assertEqual(kwargs["method"], "GET")
+        self.assertEqual(kwargs["path"], OMS_LIST_ORDERS_PATH)
+        self.assertEqual(kwargs["account_domain"], "test.myvtex.com")
+        self.assertEqual(kwargs["vtex_account"], "test-account")
+        params = kwargs["params"]
+        self.assertEqual(params["q"], "buyer@example.com")
+        self.assertEqual(params["orderBy"], "creationDate,desc")
+        self.assertEqual(params["page"], "1")
+        self.assertEqual(params["per_page"], str(OMS_LIST_PAGE_SIZE))
+        date_from = CartAbandonmentService._to_oms_utc(self.cart.created_on)
+        self.assertTrue(
+            params["f_creationDate"].startswith(f"creationDate:[{date_from} TO ")
+        )
+        self.assertTrue(params["f_creationDate"].endswith("]"))
+        self.assertNotIn("%", params["f_creationDate"])
+
+    def test_paginates_until_last_page(self):
+        self.service.vtex_io_service.proxy_vtex.side_effect = [
+            {
+                "list": [{"orderId": "order-1", "status": "invoiced"}],
+                "paging": {"pages": 2},
+            },
+            {
+                "list": [{"orderId": "order-2", "status": "invoiced"}],
+                "paging": {"pages": 2},
+            },
+        ]
+
+        result = self.service._fetch_orders_placed_after_cart(
+            self.cart, "buyer@example.com"
+        )
+
+        self.assertEqual(
+            [order["orderId"] for order in result["list"]],
+            ["order-1", "order-2"],
+        )
+        self.assertEqual(self.service.vtex_io_service.proxy_vtex.call_count, 2)
+        pages = [
+            call.kwargs["params"]["page"]
+            for call in self.service.vtex_io_service.proxy_vtex.call_args_list
+        ]
+        self.assertEqual(pages, ["1", "2"])
+
+    def test_stops_at_oms_page_cap(self):
+        self.service.vtex_io_service.proxy_vtex.return_value = {
+            "list": [{"orderId": "order-x"}],
+            "paging": {"pages": OMS_LIST_MAX_PAGES + 5},
+        }
+
+        result = self.service._fetch_orders_placed_after_cart(
+            self.cart, "buyer@example.com"
+        )
+
+        self.assertEqual(
+            self.service.vtex_io_service.proxy_vtex.call_count, OMS_LIST_MAX_PAGES
+        )
+        self.assertEqual(len(result["list"]), OMS_LIST_MAX_PAGES)
+
+    def test_matching_sku_on_items_id_marks_purchased(self):
+        """Prefer ``items[].id`` over itemMetadata when both are present."""
+        new_creation = (self.cart.created_on + timedelta(hours=1)).isoformat()
+        orders = {
+            "list": [
+                {
+                    "orderId": "order-new",
+                    "status": "invoiced",
+                    "creationDate": new_creation,
+                }
+            ]
+        }
+        self.service.vtex_io_service.get_order_details_by_id.return_value = {
+            "orderId": "order-new",
+            "orderFormId": "of-order-new",
+            "status": "invoiced",
+            "creationDate": new_creation,
+            "items": [{"id": "sku-1"}],
+            "itemMetadata": {"Items": [{"Id": "sku-other"}]},
+        }
+
+        with patch.object(self.service, "_mark_cart_as_abandoned") as mock_mark:
+            self.service._evaluate_orders(
+                cart=self.cart,
+                orders=orders,
+                order_form={"items": [{"id": "sku-1"}]},
+                client_profile={"email": "buyer@example.com"},
+                integration_config=self.integrated_feature,
+            )
+
+        mock_mark.assert_not_called()
+        self.cart.refresh_from_db()
+        self.assertEqual(self.cart.status, "purchased")
+
+    def test_extract_order_sku_ids_falls_back_to_item_metadata(self):
+        sku_ids = CartAbandonmentService._extract_order_sku_ids(
+            {"itemMetadata": {"Items": [{"Id": "sku-meta"}]}}
+        )
+        self.assertEqual(sku_ids, {"sku-meta"})


### PR DESCRIPTION
## What

Abandoned-cart purchase detection now lists OMS orders through `POST /_v/proxy-vtex` (`GET /api/oms/pvt/orders`) with `q`, an unencoded `f_creationDate` range from `cart.created_on` to now, `per_page=100`, and pagination up to 30 pages. Results are cut locally to `creationDate > cart.created_on`, then restricted to `invoiced`. The previous last-5-orders window is gone. SKU overlap still uses `GET /order-by-id`, preferring `items[].id` and falling back to `itemMetadata.Items[].Id`.

## Why

An invoiced order from a previous year that shared a cart SKU was treated as a conversion of a later abandoned orderForm, so the notification was skipped. Only purchases placed after the cart row exists should block the send.