### PR TITLE
feat: Add abandoned-cart send-time restriction endpoint

### DIFF
--- a/retail/agents/api/urls.py
+++ b/retail/agents/api/urls.py
@@ -21,6 +21,7 @@ from retail.agents.domains.agent_integration.views import (
     PaymentRecoveryHookConfigView,
     PaymentRecoveryWebhookView,
     TemplateLanguagesView,
+    MessageTimeRestrictionView,
 )
 from retail.agents.domains.agent_webhook.views import AgentWebhookView
 from retail.webhooks.vtex.views.abandoned_cart_webhook import AbandonedCartWebhookView
@@ -65,6 +66,11 @@ urlpatterns = [
         "delivered-order-tracking/<uuid:pk>/",
         DeliveredOrderTrackingWebhookView.as_view(),
         name="delivered-order-tracking-webhook",
+    ),
+    path(
+        "assigneds/<uuid:pk>/abandoned-cart/message-time-restriction/",
+        MessageTimeRestrictionView.as_view(),
+        name="abandoned-cart-message-time-restriction",
     ),
     path(
         "assigneds/<uuid:pk>/payment-recovery/hook-config/",

--- a/retail/agents/domains/agent_integration/serializers.py
+++ b/retail/agents/domains/agent_integration/serializers.py
@@ -1,4 +1,7 @@
+from typing import Dict
+
 from rest_framework import serializers
+from rest_framework.fields import Field
 
 from retail.templates.serializers import ReadTemplateSerializer
 from retail.agents.domains.agent_management.usecases.push import PushAgentUseCase
@@ -7,6 +10,9 @@ from retail.agents.domains.agent_integration.services.payment_recovery_hook impo
 )
 from retail.agents.domains.agent_integration.usecases.payment_recovery import (
     DEFAULT_DELAY_MINUTES,
+)
+from retail.agents.domains.agent_integration.usecases.message_time_restriction import (
+    project_message_time_restriction,
 )
 from retail.agents.shared.webhook_urls import build_integrated_agent_webhook_url
 
@@ -72,6 +78,53 @@ class AbandonedCartConfigSerializer(PartialUpdateSerializer):
         min_value=1,
         max_value=168,  # Max 7 days
     )
+
+
+class TimePeriodSerializer(serializers.Serializer):
+    """Closed send window in 24-hour HH:MM format.
+
+    ``from`` is a reserved Python keyword, so both fields are declared
+    in ``get_fields`` to keep the JSON contract identical to the stored
+    ``message_time_restriction`` shape consumed at dispatch time.
+    """
+
+    _HH_MM_PATTERN = r"^([01]\d|2[0-3]):[0-5]\d$"
+
+    def get_fields(self) -> Dict[str, Field]:
+        return {"from": self._hh_mm_field(), "to": self._hh_mm_field()}
+
+    @classmethod
+    def _hh_mm_field(cls) -> serializers.RegexField:
+        return serializers.RegexField(
+            regex=cls._HH_MM_PATTERN,
+            error_messages={"invalid": "Enter a time in HH:MM 24-hour format."},
+        )
+
+    def validate(self, attrs: Dict[str, str]) -> Dict[str, str]:
+        if attrs["from"] >= attrs["to"]:
+            raise serializers.ValidationError({"to": "Must be later than from."})
+        return attrs
+
+
+class MessageTimeRestrictionPeriodsSerializer(serializers.Serializer):
+    """Send windows for weekdays (Mon-Fri) and Saturdays. Sunday never sends."""
+
+    weekdays = TimePeriodSerializer()
+    saturdays = TimePeriodSerializer()
+
+
+class MessageTimeRestrictionSerializer(serializers.Serializer):
+    """Full replace payload for abandoned-cart send-time restriction."""
+
+    is_active = serializers.BooleanField()
+    periods = MessageTimeRestrictionPeriodsSerializer()
+
+
+class MessageTimeRestrictionReadSerializer(serializers.Serializer):
+    """Read projection; ``periods`` is null when the restriction is unset."""
+
+    is_active = serializers.BooleanField()
+    periods = MessageTimeRestrictionPeriodsSerializer(allow_null=True)
 
 
 class PaymentRecoveryConfigSerializer(PartialUpdateSerializer):
@@ -145,6 +198,9 @@ class ReadIntegratedAgentSerializer(serializers.Serializer):
     abandoned_cart_config = serializers.SerializerMethodField(
         "get_abandoned_cart_config"
     )
+    message_time_restriction = serializers.SerializerMethodField(
+        "get_message_time_restriction"
+    )
     payment_recovery_config = serializers.SerializerMethodField(
         "get_payment_recovery_config"
     )
@@ -206,6 +262,10 @@ class ReadIntegratedAgentSerializer(serializers.Serializer):
                 "notification_cooldown_hours"
             ),
         }
+
+    def get_message_time_restriction(self, obj):
+        """Project the abandoned-cart send-time window from agent config."""
+        return project_message_time_restriction(obj.config)
 
     def get_payment_recovery_config(self, obj):
         """Get payment recovery (PIX) configuration from agent config."""

--- a/retail/agents/domains/agent_integration/tests/test_serializers.py
+++ b/retail/agents/domains/agent_integration/tests/test_serializers.py
@@ -26,6 +26,8 @@ from django.test import SimpleTestCase, override_settings
 from retail.agents.domains.agent_integration.serializers import (
     AbandonedCartConfigSerializer,
     DeliveredOrderTrackingEnableSerializer,
+    MessageTimeRestrictionReadSerializer,
+    MessageTimeRestrictionSerializer,
     ReadIntegratedAgentSerializer,
     RetrieveIntegratedAgentQueryParamsSerializer,
     TemplateLanguageSerializer,
@@ -215,6 +217,120 @@ class UpdateIntegratedAgentSerializerTests(SimpleTestCase):
         self.assertIn("abandoned_cart_config", serializer.errors)
 
 
+VALID_TIME_RESTRICTION = {
+    "is_active": True,
+    "periods": {
+        "weekdays": {"from": "08:00", "to": "20:00"},
+        "saturdays": {"from": "10:00", "to": "12:00"},
+    },
+}
+
+
+class MessageTimeRestrictionSerializerTests(SimpleTestCase):
+    def test_valid_payload_round_trips(self):
+        serializer = MessageTimeRestrictionSerializer(data=VALID_TIME_RESTRICTION)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data, VALID_TIME_RESTRICTION)
+
+    def test_is_active_is_required(self):
+        data = {"periods": VALID_TIME_RESTRICTION["periods"]}
+        serializer = MessageTimeRestrictionSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("is_active", serializer.errors)
+
+    def test_periods_are_required(self):
+        serializer = MessageTimeRestrictionSerializer(data={"is_active": False})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("periods", serializer.errors)
+
+    def test_weekdays_are_required(self):
+        data = {
+            "is_active": True,
+            "periods": {"saturdays": {"from": "10:00", "to": "12:00"}},
+        }
+        serializer = MessageTimeRestrictionSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("weekdays", serializer.errors["periods"])
+
+    def test_saturdays_are_required(self):
+        data = {
+            "is_active": True,
+            "periods": {"weekdays": {"from": "08:00", "to": "20:00"}},
+        }
+        serializer = MessageTimeRestrictionSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("saturdays", serializer.errors["periods"])
+
+    def test_rejects_invalid_time_format(self):
+        data = {
+            "is_active": True,
+            "periods": {
+                "weekdays": {"from": "8:00", "to": "20:00"},
+                "saturdays": {"from": "10:00", "to": "12:00"},
+            },
+        }
+        serializer = MessageTimeRestrictionSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("from", serializer.errors["periods"]["weekdays"])
+
+    def test_rejects_hour_out_of_range(self):
+        data = {
+            "is_active": True,
+            "periods": {
+                "weekdays": {"from": "08:00", "to": "24:00"},
+                "saturdays": {"from": "10:00", "to": "12:00"},
+            },
+        }
+        serializer = MessageTimeRestrictionSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("to", serializer.errors["periods"]["weekdays"])
+
+    def test_rejects_from_equal_to_to(self):
+        data = {
+            "is_active": True,
+            "periods": {
+                "weekdays": {"from": "08:00", "to": "08:00"},
+                "saturdays": {"from": "10:00", "to": "12:00"},
+            },
+        }
+        serializer = MessageTimeRestrictionSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("to", serializer.errors["periods"]["weekdays"])
+
+    def test_rejects_from_later_than_to(self):
+        data = {
+            "is_active": True,
+            "periods": {
+                "weekdays": {"from": "20:00", "to": "08:00"},
+                "saturdays": {"from": "10:00", "to": "12:00"},
+            },
+        }
+        serializer = MessageTimeRestrictionSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("to", serializer.errors["periods"]["weekdays"])
+
+    def test_inactive_payload_still_requires_valid_periods(self):
+        data = {
+            "is_active": False,
+            "periods": VALID_TIME_RESTRICTION["periods"],
+        }
+        serializer = MessageTimeRestrictionSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertFalse(serializer.validated_data["is_active"])
+
+
+class MessageTimeRestrictionReadSerializerTests(SimpleTestCase):
+    def test_projects_null_periods_when_unset(self):
+        serializer = MessageTimeRestrictionReadSerializer(
+            {"is_active": False, "periods": None}
+        )
+        self.assertEqual(serializer.data, {"is_active": False, "periods": None})
+
+    def test_projects_full_restriction(self):
+        serializer = MessageTimeRestrictionReadSerializer(VALID_TIME_RESTRICTION)
+        self.assertEqual(serializer.data, VALID_TIME_RESTRICTION)
+
+
 def _integrated_agent(**overrides):
     """Duck-typed integrated-agent stub used by the read serializer."""
     defaults = dict(
@@ -381,6 +497,38 @@ class ReadIntegratedAgentSerializerTests(SimpleTestCase):
                 "abandonment_time_minutes": 45,
                 "minimum_cart_value": 20.0,
                 "notification_cooldown_hours": 12,
+            },
+        )
+
+    def test_message_time_restriction_returns_inactive_when_absent(self):
+        obj = _integrated_agent(config={})
+        data = ReadIntegratedAgentSerializer(obj).data
+        self.assertEqual(
+            data["message_time_restriction"],
+            {"is_active": False, "periods": None},
+        )
+
+    def test_message_time_restriction_projects_stored_block(self):
+        obj = _integrated_agent(
+            config={
+                "message_time_restriction": {
+                    "is_active": True,
+                    "periods": {
+                        "weekdays": {"from": "08:00", "to": "20:00"},
+                        "saturdays": {"from": "10:00", "to": "12:00"},
+                    },
+                }
+            }
+        )
+        data = ReadIntegratedAgentSerializer(obj).data
+        self.assertEqual(
+            data["message_time_restriction"],
+            {
+                "is_active": True,
+                "periods": {
+                    "weekdays": {"from": "08:00", "to": "20:00"},
+                    "saturdays": {"from": "10:00", "to": "12:00"},
+                },
             },
         )
 

--- a/retail/agents/domains/agent_integration/usecases/message_time_restriction.py
+++ b/retail/agents/domains/agent_integration/usecases/message_time_restriction.py
@@ -1,0 +1,112 @@
+import logging
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from rest_framework.exceptions import NotFound
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.shared.cache import (
+    IntegratedAgentCacheHandler,
+    IntegratedAgentCacheHandlerRedis,
+)
+
+logger = logging.getLogger(__name__)
+
+MESSAGE_TIME_RESTRICTION_KEY = "message_time_restriction"
+
+
+def project_message_time_restriction(
+    config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Return the public send-time restriction shape from an agent config."""
+    restriction = (config or {}).get(MESSAGE_TIME_RESTRICTION_KEY)
+    if not restriction:
+        return {"is_active": False, "periods": None}
+
+    return {
+        "is_active": bool(restriction.get("is_active", False)),
+        "periods": restriction.get("periods"),
+    }
+
+
+class MessageTimeRestrictionUseCase:
+    """Persist abandoned-cart send-time windows on an integrated agent.
+
+    The stored JSON matches the shape ``CartTimeRestrictionService`` already
+    reads at dispatch time: ``config.message_time_restriction`` at the
+    agent root (not nested under ``abandoned_cart``).
+    """
+
+    def __init__(
+        self,
+        cache_handler: Optional[IntegratedAgentCacheHandler] = None,
+    ) -> None:
+        self.cache_handler = cache_handler or IntegratedAgentCacheHandlerRedis()
+
+    def get_integrated_agent(self, integrated_agent_uuid: UUID) -> IntegratedAgent:
+        """Retrieve an active integrated agent by UUID.
+
+        Args:
+            integrated_agent_uuid: Public UUID of the integrated agent.
+
+        Returns:
+            The matching active integrated agent.
+
+        Raises:
+            NotFound: If no active integrated agent exists with the given UUID.
+        """
+        try:
+            return IntegratedAgent.objects.select_related("project", "agent").get(
+                uuid=integrated_agent_uuid, is_active=True
+            )
+        except IntegratedAgent.DoesNotExist:
+            raise NotFound(f"Integrated agent not found {integrated_agent_uuid}")
+
+    def get_restriction(self, integrated_agent: IntegratedAgent) -> Dict[str, Any]:
+        """Return the current send-time restriction, or an inactive empty shape."""
+        return project_message_time_restriction(integrated_agent.config)
+
+    def upsert_restriction(
+        self,
+        integrated_agent: IntegratedAgent,
+        data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Replace the send-time restriction with a validated full payload."""
+        restriction = {
+            "is_active": data["is_active"],
+            "periods": {
+                "weekdays": dict(data["periods"]["weekdays"]),
+                "saturdays": dict(data["periods"]["saturdays"]),
+            },
+        }
+        self._write_config(integrated_agent, restriction)
+        logger.info(
+            f"Updated message time restriction for agent {integrated_agent.uuid}: "
+            f"is_active={restriction['is_active']}"
+        )
+        return self.get_restriction(integrated_agent)
+
+    def delete_restriction(self, integrated_agent: IntegratedAgent) -> None:
+        """Remove the send-time restriction key so dispatch uses the default countdown."""
+        config = dict(integrated_agent.config or {})
+        if MESSAGE_TIME_RESTRICTION_KEY not in config:
+            return
+
+        config.pop(MESSAGE_TIME_RESTRICTION_KEY)
+        integrated_agent.config = config
+        integrated_agent.save(update_fields=["config"])
+        self.cache_handler.invalidate_all_for(integrated_agent)
+        logger.info(
+            f"Removed message time restriction for agent {integrated_agent.uuid}"
+        )
+
+    def _write_config(
+        self,
+        integrated_agent: IntegratedAgent,
+        restriction: Dict[str, Any],
+    ) -> None:
+        config = dict(integrated_agent.config or {})
+        config[MESSAGE_TIME_RESTRICTION_KEY] = restriction
+        integrated_agent.config = config
+        integrated_agent.save(update_fields=["config"])
+        self.cache_handler.invalidate_all_for(integrated_agent)

--- a/retail/agents/domains/agent_integration/views.py
+++ b/retail/agents/domains/agent_integration/views.py
@@ -25,6 +25,8 @@ from retail.agents.domains.agent_integration.serializers import (
     PaymentRecoveryHookConfigSerializer,
     PaymentRecoveryHookConfigReadSerializer,
     TemplateLanguageSerializer,
+    MessageTimeRestrictionSerializer,
+    MessageTimeRestrictionReadSerializer,
 )
 from retail.agents.domains.agent_integration.utils import TEMPLATE_LANGUAGES
 from retail.agents.domains.agent_integration.usecases.assign import AssignAgentUseCase
@@ -54,6 +56,9 @@ from retail.agents.domains.agent_integration.usecases.payment_recovery import (
 )
 from retail.agents.domains.agent_integration.usecases.payment_recovery_hook_config import (
     PaymentRecoveryHookConfigUseCase,
+)
+from retail.agents.domains.agent_integration.usecases.message_time_restriction import (
+    MessageTimeRestrictionUseCase,
 )
 
 from retail.internal.permissions import HasProjectPermission, HasWeniProjectPermission
@@ -403,6 +408,54 @@ class PaymentRecoveryHookConfigView(WeniAuthMixin, APIView):
         )
         response_serializer = PaymentRecoveryHookConfigReadSerializer(config_data)
         return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+
+class MessageTimeRestrictionView(WeniAuthMixin, APIView):
+    """Abandoned-cart send-time restriction for the IO frontend.
+
+    Called with the operator JWT: ``RetailAuthentication`` resolves user
+    and project from the token (not from ``Project-Uuid`` / ``user_email``
+    query params). Connect contributor or moderator is required.
+    """
+
+    permission_classes = [
+        IsWeniAuthenticated,
+        HasWeniProjectPermission,
+        IsIntegratedAgentFromProject,
+    ]
+
+    def _authorized_agent(self, request: Request, pk: UUID):
+        use_case = MessageTimeRestrictionUseCase()
+        integrated_agent = use_case.get_integrated_agent(pk)
+        self.check_object_permissions(request, integrated_agent)
+        return use_case, integrated_agent
+
+    def get(self, request: Request, pk: UUID) -> Response:
+        """Return the current send-time restriction for an integrated agent."""
+        use_case, integrated_agent = self._authorized_agent(request, pk)
+        serializer = MessageTimeRestrictionReadSerializer(
+            use_case.get_restriction(integrated_agent)
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def put(self, request: Request, pk: UUID) -> Response:
+        """Create or replace the send-time restriction for an integrated agent."""
+        use_case, integrated_agent = self._authorized_agent(request, pk)
+
+        serializer = MessageTimeRestrictionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        result = use_case.upsert_restriction(
+            integrated_agent, serializer.validated_data
+        )
+        response_serializer = MessageTimeRestrictionReadSerializer(result)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request: Request, pk: UUID) -> Response:
+        """Remove the send-time restriction so dispatch uses the default countdown."""
+        use_case, integrated_agent = self._authorized_agent(request, pk)
+        use_case.delete_restriction(integrated_agent)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class PaymentRecoveryWebhookView(APIView):

--- a/retail/agents/tests/usecases/test_message_time_restriction.py
+++ b/retail/agents/tests/usecases/test_message_time_restriction.py
@@ -1,0 +1,160 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+from rest_framework.exceptions import NotFound
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.message_time_restriction import (
+    MESSAGE_TIME_RESTRICTION_KEY,
+    MessageTimeRestrictionUseCase,
+)
+from retail.agents.shared.cache import IntegratedAgentCacheHandler
+
+
+VALID_RESTRICTION = {
+    "is_active": True,
+    "periods": {
+        "weekdays": {"from": "08:00", "to": "20:00"},
+        "saturdays": {"from": "10:00", "to": "12:00"},
+    },
+}
+
+
+class MessageTimeRestrictionUseCaseTest(TestCase):
+    def setUp(self):
+        self.integrated_agent = MagicMock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid4()
+        self.integrated_agent.config = {}
+        self.mock_cache_handler = MagicMock(spec=IntegratedAgentCacheHandler)
+        self.use_case = MessageTimeRestrictionUseCase(
+            cache_handler=self.mock_cache_handler,
+        )
+
+    def test_get_restriction_returns_inactive_when_absent(self):
+        result = self.use_case.get_restriction(self.integrated_agent)
+        self.assertEqual(result, {"is_active": False, "periods": None})
+
+    def test_get_restriction_returns_inactive_when_config_is_none(self):
+        self.integrated_agent.config = None
+        result = self.use_case.get_restriction(self.integrated_agent)
+        self.assertEqual(result, {"is_active": False, "periods": None})
+
+    def test_get_restriction_returns_stored_block(self):
+        self.integrated_agent.config = {MESSAGE_TIME_RESTRICTION_KEY: VALID_RESTRICTION}
+        result = self.use_case.get_restriction(self.integrated_agent)
+        self.assertEqual(result, VALID_RESTRICTION)
+
+    def test_get_integrated_agent_not_found(self):
+        with self.assertRaises(NotFound):
+            self.use_case.get_integrated_agent(uuid4())
+
+    def test_upsert_restriction_persists_canonical_shape_and_invalidates_cache(self):
+        result = self.use_case.upsert_restriction(
+            self.integrated_agent, VALID_RESTRICTION
+        )
+
+        self.assertEqual(
+            self.integrated_agent.config[MESSAGE_TIME_RESTRICTION_KEY],
+            VALID_RESTRICTION,
+        )
+        self.assertEqual(result, VALID_RESTRICTION)
+        self.integrated_agent.save.assert_called_once_with(update_fields=["config"])
+        self.mock_cache_handler.invalidate_all_for.assert_called_once_with(
+            self.integrated_agent
+        )
+
+    def test_upsert_restriction_preserves_sibling_config_keys(self):
+        self.integrated_agent.config = {
+            "abandoned_cart": {"header_image_type": "no_image"}
+        }
+
+        self.use_case.upsert_restriction(self.integrated_agent, VALID_RESTRICTION)
+
+        self.assertEqual(
+            self.integrated_agent.config["abandoned_cart"]["header_image_type"],
+            "no_image",
+        )
+        self.assertEqual(
+            self.integrated_agent.config[MESSAGE_TIME_RESTRICTION_KEY],
+            VALID_RESTRICTION,
+        )
+
+    def test_upsert_restriction_replaces_previous_value(self):
+        self.integrated_agent.config = {
+            MESSAGE_TIME_RESTRICTION_KEY: {
+                "is_active": False,
+                "periods": {
+                    "weekdays": {"from": "09:00", "to": "18:00"},
+                    "saturdays": {"from": "09:00", "to": "12:00"},
+                },
+            }
+        }
+        updated = {
+            "is_active": True,
+            "periods": {
+                "weekdays": {"from": "07:00", "to": "19:00"},
+                "saturdays": {"from": "08:00", "to": "13:00"},
+            },
+        }
+
+        self.use_case.upsert_restriction(self.integrated_agent, updated)
+
+        self.assertEqual(
+            self.integrated_agent.config[MESSAGE_TIME_RESTRICTION_KEY],
+            updated,
+        )
+
+    def test_upsert_restriction_initializes_config_when_none(self):
+        self.integrated_agent.config = None
+
+        self.use_case.upsert_restriction(self.integrated_agent, VALID_RESTRICTION)
+
+        self.assertEqual(
+            self.integrated_agent.config[MESSAGE_TIME_RESTRICTION_KEY],
+            VALID_RESTRICTION,
+        )
+
+    def test_upsert_restriction_persists_inactive_with_periods(self):
+        inactive = {
+            "is_active": False,
+            "periods": VALID_RESTRICTION["periods"],
+        }
+
+        result = self.use_case.upsert_restriction(self.integrated_agent, inactive)
+
+        self.assertEqual(
+            self.integrated_agent.config[MESSAGE_TIME_RESTRICTION_KEY],
+            inactive,
+        )
+        self.assertEqual(result, inactive)
+
+    def test_delete_restriction_removes_key_and_invalidates_cache(self):
+        self.integrated_agent.config = {
+            "abandoned_cart": {"header_image_type": "first_item"},
+            MESSAGE_TIME_RESTRICTION_KEY: VALID_RESTRICTION,
+        }
+
+        self.use_case.delete_restriction(self.integrated_agent)
+
+        self.assertNotIn(MESSAGE_TIME_RESTRICTION_KEY, self.integrated_agent.config)
+        self.assertEqual(
+            self.integrated_agent.config["abandoned_cart"]["header_image_type"],
+            "first_item",
+        )
+        self.integrated_agent.save.assert_called_once_with(update_fields=["config"])
+        self.mock_cache_handler.invalidate_all_for.assert_called_once_with(
+            self.integrated_agent
+        )
+
+    def test_delete_restriction_is_noop_when_key_absent(self):
+        self.use_case.delete_restriction(self.integrated_agent)
+
+        self.integrated_agent.save.assert_not_called()
+        self.mock_cache_handler.invalidate_all_for.assert_not_called()
+
+    def test_cache_handler_defaults_to_redis_implementation(self):
+        use_case = MessageTimeRestrictionUseCase()
+        from retail.agents.shared.cache import IntegratedAgentCacheHandlerRedis
+
+        self.assertIsInstance(use_case.cache_handler, IntegratedAgentCacheHandlerRedis)

--- a/retail/agents/tests/views/test_message_time_restriction_view.py
+++ b/retail/agents/tests/views/test_message_time_restriction_view.py
@@ -1,0 +1,160 @@
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.internal.test_mixins import (
+    BaseTestMixin,
+    ConnectServicePermissionScenarios,
+    with_test_settings,
+)
+from retail.projects.models import Project
+
+User = get_user_model()
+
+VALID_PAYLOAD = {
+    "is_active": True,
+    "periods": {
+        "weekdays": {"from": "08:00", "to": "20:00"},
+        "saturdays": {"from": "10:00", "to": "12:00"},
+    },
+}
+
+
+@with_test_settings
+class MessageTimeRestrictionViewTest(BaseTestMixin, APITestCase):
+    """JWT operator path used by the IO frontend (user + project on the token)."""
+
+    def setUp(self):
+        super().setUp()
+        self.project = Project.objects.create(name="Project 1", uuid=uuid4())
+        self.agent = Agent.objects.create(
+            uuid=uuid4(),
+            name="Abandoned cart",
+            slug="abandoned-cart",
+            description="Abandoned cart",
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.project,
+            config={},
+        )
+        self.url = reverse(
+            "abandoned-cart-message-time-restriction",
+            args=[str(self.integrated_agent.uuid)],
+        )
+        self.user = User.objects.create_user(
+            username="testuser", password="12345", email="test@example.com"
+        )
+        self.start_retail_auth(
+            project_uuid=self.project.uuid,
+            user_email=self.user.email,
+            token_type="jwt",
+            is_internal=False,
+        )
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions=ConnectServicePermissionScenarios.CONTRIBUTOR_PERMISSIONS,
+        )
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.MessageTimeRestrictionUseCase"
+    )
+    def test_get_returns_restriction(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case.get_integrated_agent.return_value = self.integrated_agent
+        mock_use_case.get_restriction.return_value = VALID_PAYLOAD
+        mock_use_case_cls.return_value = mock_use_case
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), VALID_PAYLOAD)
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.MessageTimeRestrictionUseCase"
+    )
+    def test_get_returns_inactive_when_unset(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case.get_integrated_agent.return_value = self.integrated_agent
+        mock_use_case.get_restriction.return_value = {
+            "is_active": False,
+            "periods": None,
+        }
+        mock_use_case_cls.return_value = mock_use_case
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"is_active": False, "periods": None})
+
+    def test_get_returns_404_when_agent_missing(self):
+        missing_url = reverse(
+            "abandoned-cart-message-time-restriction",
+            args=[str(uuid4())],
+        )
+
+        response = self.client.get(missing_url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_rejects_unauthenticated_request(self):
+        self.set_retail_auth(authenticated=False)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_get_rejects_viewer_role(self):
+        self.setup_connect_service_mock(
+            status_code=200,
+            permissions=ConnectServicePermissionScenarios.NO_PERMISSIONS,
+        )
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.MessageTimeRestrictionUseCase"
+    )
+    def test_put_upserts_restriction(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case.get_integrated_agent.return_value = self.integrated_agent
+        mock_use_case.upsert_restriction.return_value = VALID_PAYLOAD
+        mock_use_case_cls.return_value = mock_use_case
+
+        response = self.client.put(self.url, data=VALID_PAYLOAD, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_use_case.upsert_restriction.assert_called_once_with(
+            self.integrated_agent,
+            VALID_PAYLOAD,
+        )
+        self.assertEqual(response.json(), VALID_PAYLOAD)
+
+    def test_put_rejects_invalid_payload(self):
+        response = self.client.put(self.url, data={"is_active": True}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("periods", response.json())
+
+    @patch(
+        "retail.agents.domains.agent_integration.views.MessageTimeRestrictionUseCase"
+    )
+    def test_delete_removes_restriction(self, mock_use_case_cls):
+        mock_use_case = MagicMock()
+        mock_use_case.get_integrated_agent.return_value = self.integrated_agent
+        mock_use_case_cls.return_value = mock_use_case
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        mock_use_case.delete_restriction.assert_called_once_with(self.integrated_agent)


### PR DESCRIPTION
## What

Expose GET/PUT/DELETE on `/api/v3/agents/assigneds/{uuid}/abandoned-cart/message-time-restriction/` so the IO frontend can create, replace, or remove the abandoned-cart send-time window. Auth is the unified Weni JWT path (`RetailAuthentication`): operator identity and project come from the token. Writes persist `IntegratedAgent.config.message_time_restriction` in the shape `CartTimeRestrictionService` already reads at dispatch. PUT is a full replace; DELETE drops the key. The same projection is included on GET assigned.

## Why

The send-time window existed only as a config blob consumed at dispatch, with no operator-facing API for the IO frontend to add, change, or remove it.