### PR TITLE
feat: Add `check-url` endpoint to preflight crawl URL reachability via Crawler MS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+# 5.55.0
+- feat: Add check-url endpoint to preflight crawl URL reachability via Crawler MS
+- feat: Add abandoned-cart send-time restriction endpoint
+
 # 5.54.0
-- fix: Ignore pre-cart VTEX orders in purchase detection
+- feat: Integrate Agentic CX script activation into onboarding and agent assignment processes
 
 # 5.53.0
 - fix: Ignore pre-cart VTEX orders in purchase detection

--- a/retail/clients/crawler/client.py
+++ b/retail/clients/crawler/client.py
@@ -64,3 +64,24 @@ class CrawlerClient(RequestClient, CrawlerClientInterface):
             params={"store_url": store_url},
         )
         return response.json()
+
+    def check_url(self, crawl_url: str) -> Dict:
+        """
+        Probes whether a URL is reachable the same way a crawl would fetch it.
+
+        Args:
+            crawl_url: The store URL to check (must start with http:// or https://).
+
+        Returns:
+            Dict with ``reachable`` and ``resolved_url``.
+        """
+        url = f"{self.base_url}/api/check-url"
+        payload = {"crawl_url": crawl_url}
+
+        response = self.make_request(
+            url,
+            method="POST",
+            json=payload,
+            timeout=55,
+        )
+        return response.json()

--- a/retail/interfaces/clients/crawler/client.py
+++ b/retail/interfaces/clients/crawler/client.py
@@ -34,3 +34,15 @@ class CrawlerClientInterface(Protocol):
             (one of: faststore, vtex_io, legacy, unknown).
         """
         ...
+
+    def check_url(self, crawl_url: str) -> Dict:
+        """
+        Probes whether a URL is reachable the same way a crawl would fetch it.
+
+        Args:
+            crawl_url: The store URL to check (must start with http:// or https://).
+
+        Returns:
+            Dict with ``reachable`` and ``resolved_url``.
+        """
+        ...

--- a/retail/projects/serializer.py
+++ b/retail/projects/serializer.py
@@ -94,6 +94,12 @@ class ContentBaseProgressSerializer(serializers.Serializer):
     progress = serializers.IntegerField(read_only=True)
 
 
+class CheckUrlSerializer(serializers.Serializer):
+    """Serializer to validate the check-url request."""
+
+    crawl_url = serializers.URLField(required=True)
+
+
 class ProjectOnboardingSerializer(serializers.Serializer):
     """Serializer for the ProjectOnboarding status response."""
 

--- a/retail/projects/tests/test_check_url.py
+++ b/retail/projects/tests/test_check_url.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from retail.projects.usecases.check_url import CheckUrlResult, CheckUrlUseCase
+from retail.projects.usecases.onboarding_dto import CheckUrlDTO
+
+
+class TestCheckUrlUseCase(TestCase):
+    def setUp(self):
+        self.mock_crawler_service = MagicMock()
+        self.usecase = CheckUrlUseCase(crawler_client=MagicMock())
+        self.usecase.crawler_service = self.mock_crawler_service
+        self.dto = CheckUrlDTO(
+            vtex_account="mystore",
+            crawl_url="https://www.mystore.com.br/",
+        )
+
+    def test_returns_valid_when_crawler_reports_reachable(self):
+        self.mock_crawler_service.check_url.return_value = {
+            "reachable": True,
+            "resolved_url": "https://www.mystore.com.br/",
+        }
+
+        result = self.usecase.execute(self.dto)
+
+        self.assertEqual(
+            result,
+            CheckUrlResult(valid=True, crawl_url="https://www.mystore.com.br/"),
+        )
+        self.mock_crawler_service.check_url.assert_called_once_with(
+            "https://www.mystore.com.br/"
+        )
+
+    def test_uses_original_url_when_resolved_url_missing(self):
+        self.mock_crawler_service.check_url.return_value = {"reachable": True}
+
+        result = self.usecase.execute(self.dto)
+
+        self.assertEqual(
+            result,
+            CheckUrlResult(valid=True, crawl_url="https://www.mystore.com.br/"),
+        )
+
+    def test_returns_invalid_when_crawler_reports_unreachable(self):
+        self.mock_crawler_service.check_url.return_value = {
+            "reachable": False,
+            "resolved_url": "https://www.mystore.com.br/",
+        }
+
+        result = self.usecase.execute(self.dto)
+
+        self.assertEqual(result, CheckUrlResult(valid=False))
+
+    def test_returns_unavailable_when_crawler_comms_fail(self):
+        self.mock_crawler_service.check_url.return_value = None
+
+        result = self.usecase.execute(self.dto)
+
+        self.assertEqual(result, CheckUrlResult(valid=False, unavailable=True))
+
+
+class TestCheckUrlResult(TestCase):
+    def test_to_dict_when_valid(self):
+        result = CheckUrlResult(valid=True, crawl_url="https://www.mystore.com.br/")
+        self.assertEqual(
+            result.to_dict(),
+            {"valid": True, "crawl_url": "https://www.mystore.com.br/"},
+        )
+        self.assertEqual(result.http_status, 200)
+
+    def test_to_dict_when_unreachable(self):
+        result = CheckUrlResult(valid=False)
+        self.assertEqual(result.to_dict(), {"valid": False})
+        self.assertEqual(result.http_status, 200)
+
+    def test_to_dict_when_unavailable(self):
+        result = CheckUrlResult(valid=False, unavailable=True)
+        self.assertEqual(
+            result.to_dict(),
+            {"valid": False, "error": "unavailable"},
+        )
+        self.assertEqual(result.http_status, 502)

--- a/retail/projects/tests/test_check_url.py
+++ b/retail/projects/tests/test_check_url.py
@@ -72,7 +72,7 @@ class TestCheckUrlResult(TestCase):
     def test_to_dict_when_unreachable(self):
         result = CheckUrlResult(valid=False)
         self.assertEqual(result.to_dict(), {"valid": False})
-        self.assertEqual(result.http_status, 200)
+        self.assertEqual(result.http_status, 400)
 
     def test_to_dict_when_unavailable(self):
         result = CheckUrlResult(valid=False, unavailable=True)

--- a/retail/projects/tests/test_views.py
+++ b/retail/projects/tests/test_views.py
@@ -7,6 +7,7 @@ from weni_commons.auth import WeniAuthContext, WeniAuthUser
 
 from retail.projects.models import Project, ProjectOnboarding
 from retail.projects.serializer import OnboardingPatchSerializer
+from retail.projects.usecases.check_url import CheckUrlResult
 from retail.projects.usecases.install_channel_agents import InstallChannelAgentsError
 
 
@@ -119,6 +120,79 @@ class TestStartSetupView(TestCase):
         self.assertEqual(last_failure["stage"], "start_setup_validation")
         self.assertEqual(last_failure["payload"], payload)
         self.assertIn("channel_data", last_failure["errors"])
+
+
+class TestCheckUrlView(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    @auth_bypass()
+    @patch("retail.projects.views.CheckUrlUseCase")
+    def test_returns_200_when_valid(self, mock_usecase_cls, _mock_auth):
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = CheckUrlResult(
+            valid=True,
+            crawl_url="https://www.mystore.com.br/",
+        )
+        mock_usecase_cls.return_value = mock_instance
+
+        response = self.client.post(
+            "/api/onboard/mystore/check-url/",
+            {"crawl_url": "https://www.mystore.com.br/"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"valid": True, "crawl_url": "https://www.mystore.com.br/"},
+        )
+        mock_instance.execute.assert_called_once()
+
+    @auth_bypass()
+    @patch("retail.projects.views.CheckUrlUseCase")
+    def test_returns_200_when_invalid(self, mock_usecase_cls, _mock_auth):
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = CheckUrlResult(valid=False)
+        mock_usecase_cls.return_value = mock_instance
+
+        response = self.client.post(
+            "/api/onboard/mystore/check-url/",
+            {"crawl_url": "https://www.mystore.com.br/"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"valid": False})
+
+    @auth_bypass()
+    @patch("retail.projects.views.CheckUrlUseCase")
+    def test_returns_502_when_crawler_unavailable(self, mock_usecase_cls, _mock_auth):
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = CheckUrlResult(
+            valid=False,
+            unavailable=True,
+        )
+        mock_usecase_cls.return_value = mock_instance
+
+        response = self.client.post(
+            "/api/onboard/mystore/check-url/",
+            {"crawl_url": "https://www.mystore.com.br/"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.json(), {"valid": False, "error": "unavailable"})
+
+    @auth_bypass()
+    def test_returns_400_when_crawl_url_missing(self, _mock_auth):
+        response = self.client.post(
+            "/api/onboard/mystore/check-url/",
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
 
 
 class TestCrawlerWebhookView(TestCase):

--- a/retail/projects/tests/test_views.py
+++ b/retail/projects/tests/test_views.py
@@ -151,7 +151,7 @@ class TestCheckUrlView(TestCase):
 
     @auth_bypass()
     @patch("retail.projects.views.CheckUrlUseCase")
-    def test_returns_200_when_invalid(self, mock_usecase_cls, _mock_auth):
+    def test_returns_400_when_invalid(self, mock_usecase_cls, _mock_auth):
         mock_instance = MagicMock()
         mock_instance.execute.return_value = CheckUrlResult(valid=False)
         mock_usecase_cls.return_value = mock_instance
@@ -162,7 +162,7 @@ class TestCheckUrlView(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"valid": False})
 
     @auth_bypass()

--- a/retail/projects/urls.py
+++ b/retail/projects/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
         name="onboarding-start-setup",
     ),
     path(
+        "onboard/<str:vtex_account>/check-url/",
+        project_views.CheckUrlView.as_view(),
+        name="onboarding-check-url",
+    ),
+    path(
         "onboard/<uuid:onboarding_uuid>/webhook/",
         project_views.CrawlerWebhookView.as_view(),
         name="onboarding-crawler-webhook",

--- a/retail/projects/usecases/check_url.py
+++ b/retail/projects/usecases/check_url.py
@@ -1,0 +1,74 @@
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from retail.clients.crawler.client import CrawlerClient
+from retail.interfaces.clients.crawler.client import CrawlerClientInterface
+from retail.projects.usecases.onboarding_dto import CheckUrlDTO
+from retail.services.crawler.service import CrawlerService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CheckUrlResult:
+    """Outcome of a crawl-URL reachability check."""
+
+    valid: bool
+    crawl_url: Optional[str] = None
+    unavailable: bool = False
+
+    def to_dict(self) -> dict:
+        if self.unavailable:
+            return {"valid": False, "error": "unavailable"}
+        if self.valid:
+            return {"valid": True, "crawl_url": self.crawl_url}
+        return {"valid": False}
+
+    @property
+    def http_status(self) -> int:
+        return 502 if self.unavailable else 200
+
+
+class CheckUrlUseCase:
+    """
+    Proxies a reachability check to the Crawler MS.
+
+    Distinguishes crawler-comms failure (``unavailable``) from a reachable
+    check that returned ``reachable: false``, so the front-end can show
+    different copy.
+    """
+
+    def __init__(self, crawler_client: CrawlerClientInterface = None):
+        self.crawler_service = CrawlerService(
+            crawler_client=crawler_client or CrawlerClient()
+        )
+
+    def execute(self, dto: CheckUrlDTO) -> CheckUrlResult:
+        logger.info(
+            f"Checking crawl url for vtex_account={dto.vtex_account} "
+            f"crawl_url={dto.crawl_url}"
+        )
+
+        response = self.crawler_service.check_url(dto.crawl_url)
+
+        if response is None:
+            logger.error(
+                f"Crawler check-url unavailable for "
+                f"vtex_account={dto.vtex_account} crawl_url={dto.crawl_url}"
+            )
+            return CheckUrlResult(valid=False, unavailable=True)
+
+        if response.get("reachable"):
+            resolved = response.get("resolved_url") or dto.crawl_url
+            logger.info(
+                f"Crawl url reachable for vtex_account={dto.vtex_account} "
+                f"resolved_url={resolved}"
+            )
+            return CheckUrlResult(valid=True, crawl_url=resolved)
+
+        logger.info(
+            f"Crawl url unreachable for vtex_account={dto.vtex_account} "
+            f"crawl_url={dto.crawl_url}"
+        )
+        return CheckUrlResult(valid=False)

--- a/retail/projects/usecases/check_url.py
+++ b/retail/projects/usecases/check_url.py
@@ -27,16 +27,20 @@ class CheckUrlResult:
 
     @property
     def http_status(self) -> int:
-        return 502 if self.unavailable else 200
+        if self.unavailable:
+            return 502
+        if self.valid:
+            return 200
+        return 400
 
 
 class CheckUrlUseCase:
     """
     Proxies a reachability check to the Crawler MS.
 
-    Distinguishes crawler-comms failure (``unavailable``) from a reachable
-    check that returned ``reachable: false``, so the front-end can show
-    different copy.
+    Distinguishes crawler-comms failure (``unavailable``, HTTP 502) from a
+    check that returned ``reachable: false`` (HTTP 400), so the front-end
+    can show different copy.
     """
 
     def __init__(self, crawler_client: CrawlerClientInterface = None):

--- a/retail/projects/usecases/onboarding_dto.py
+++ b/retail/projects/usecases/onboarding_dto.py
@@ -24,6 +24,14 @@ class StartSetupDTO:
 
 
 @dataclass(frozen=True)
+class CheckUrlDTO:
+    """Data sent by the front-end to preflight a crawl URL."""
+
+    vtex_account: str
+    crawl_url: str
+
+
+@dataclass(frozen=True)
 class InstallChannelAgentsDTO:
     """Data sent to install agents for a new channel on an existing onboarding."""
 

--- a/retail/projects/views.py
+++ b/retail/projects/views.py
@@ -22,6 +22,7 @@ from retail.projects.serializer import (
     OnboardingPatchSerializer,
     ProjectOnboardingSerializer,
     ContentBaseProgressSerializer,
+    CheckUrlSerializer,
 )
 from retail.projects.usecases.get_project_vtex_account import (
     GetProjectVtexAccountUseCase,
@@ -35,6 +36,7 @@ from retail.projects.usecases.onboarding_dto import (
     CrawlerWebhookDTO,
     InstallChannelAgentsDTO,
     RequestOnboardingSupportDTO,
+    CheckUrlDTO,
 )
 from retail.projects.usecases.project_vtex import ProjectVtexConfigUseCase
 from retail.projects.usecases.request_onboarding_support import (
@@ -44,6 +46,7 @@ from retail.projects.usecases.save_onboarding_failure import (
     SaveOnboardingFailureUseCase,
 )
 from retail.projects.usecases.start_setup import StartSetupUseCase
+from retail.projects.usecases.check_url import CheckUrlUseCase
 from retail.projects.usecases.get_content_base_progress import (
     GetContentBaseProgressUseCase,
 )
@@ -158,6 +161,26 @@ class StartSetupView(WeniAuthMixin, APIView):
         StartSetupUseCase().execute(dto)
 
         return Response({"status": "started"}, status=status.HTTP_201_CREATED)
+
+
+class CheckUrlView(WeniAuthMixin, APIView):
+    """
+    Preflights a crawl URL by asking the Crawler MS whether it is reachable.
+
+    Does not start onboarding or enqueue a crawl.
+    """
+
+    def post(self, request, vtex_account: str) -> Response:
+        account = self.auth.vtex_account
+        serializer = CheckUrlSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dto = CheckUrlDTO(
+            vtex_account=account,
+            crawl_url=serializer.validated_data["crawl_url"],
+        )
+        result = CheckUrlUseCase().execute(dto)
+        return Response(result.to_dict(), status=result.http_status)
 
 
 class CrawlerWebhookView(APIView):

--- a/retail/services/crawler/service.py
+++ b/retail/services/crawler/service.py
@@ -68,11 +68,19 @@ class CrawlerService:
             crawl_url: The store URL to check.
 
         Returns:
-            Dict with ``reachable`` and ``resolved_url``, or None on failure.
+            Dict with ``reachable`` and ``resolved_url``, or None on
+            crawler-comms failure. HTTP 4xx from the crawler is a URL
+            rejection, not a comms failure, and is returned as
+            ``{"reachable": False}``.
         """
         try:
             return self.crawler_client.check_url(crawl_url)
         except CustomAPIException as e:
+            if 400 <= e.status_code < 500:
+                logger.info(
+                    f"Crawler rejected crawl_url={crawl_url} with status {e.status_code}"
+                )
+                return {"reachable": False}
             logger.error(
                 f"Error {e.status_code} checking url for crawl_url={crawl_url}: {e}"
             )

--- a/retail/services/crawler/service.py
+++ b/retail/services/crawler/service.py
@@ -59,3 +59,21 @@ class CrawlerService:
                 f"for store_url={store_url}: {e}"
             )
             return None
+
+    def check_url(self, crawl_url: str) -> Optional[Dict]:
+        """
+        Probes whether a URL is reachable the same way a crawl would fetch it.
+
+        Args:
+            crawl_url: The store URL to check.
+
+        Returns:
+            Dict with ``reachable`` and ``resolved_url``, or None on failure.
+        """
+        try:
+            return self.crawler_client.check_url(crawl_url)
+        except CustomAPIException as e:
+            logger.error(
+                f"Error {e.status_code} checking url for crawl_url={crawl_url}: {e}"
+            )
+            return None

--- a/retail/services/tests/test_crawler.py
+++ b/retail/services/tests/test_crawler.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from retail.clients.exceptions import CustomAPIException
+from retail.services.crawler.service import CrawlerService
+
+
+class TestCrawlerService(TestCase):
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.service = CrawlerService(crawler_client=self.mock_client)
+        self.crawl_url = "https://www.mystore.com.br/"
+        self.webhook_url = "https://example.com/webhook"
+        self.project_context = {
+            "vtex_account": "mystore",
+            "objective": "support",
+            "instructions": [],
+        }
+
+    def test_start_crawling_success(self):
+        expected = {"status": "started"}
+        self.mock_client.start_crawling.return_value = expected
+
+        result = self.service.start_crawling(
+            self.crawl_url, self.webhook_url, self.project_context
+        )
+
+        self.mock_client.start_crawling.assert_called_once_with(
+            self.crawl_url, self.webhook_url, self.project_context
+        )
+        self.assertEqual(result, expected)
+
+    def test_start_crawling_returns_none_on_custom_api_exception(self):
+        self.mock_client.start_crawling.side_effect = CustomAPIException(
+            status_code=502, detail="crawler down"
+        )
+
+        result = self.service.start_crawling(
+            self.crawl_url, self.webhook_url, self.project_context
+        )
+
+        self.assertIsNone(result)
+
+    def test_detect_storefront_type_success(self):
+        expected = {
+            "store_url": self.crawl_url,
+            "storefront_type": "vtex_io",
+        }
+        self.mock_client.detect_storefront_type.return_value = expected
+
+        result = self.service.detect_storefront_type(self.crawl_url)
+
+        self.mock_client.detect_storefront_type.assert_called_once_with(self.crawl_url)
+        self.assertEqual(result, expected)
+
+    def test_detect_storefront_type_returns_none_on_custom_api_exception(self):
+        self.mock_client.detect_storefront_type.side_effect = CustomAPIException(
+            status_code=500, detail="timeout"
+        )
+
+        result = self.service.detect_storefront_type(self.crawl_url)
+
+        self.assertIsNone(result)
+
+    def test_check_url_success(self):
+        expected = {"reachable": True, "resolved_url": self.crawl_url}
+        self.mock_client.check_url.return_value = expected
+
+        result = self.service.check_url(self.crawl_url)
+
+        self.mock_client.check_url.assert_called_once_with(self.crawl_url)
+        self.assertEqual(result, expected)
+
+    def test_check_url_returns_none_on_custom_api_exception(self):
+        self.mock_client.check_url.side_effect = CustomAPIException(
+            status_code=502, detail="crawler unavailable"
+        )
+
+        result = self.service.check_url(self.crawl_url)
+
+        self.mock_client.check_url.assert_called_once_with(self.crawl_url)
+        self.assertIsNone(result)

--- a/retail/services/tests/test_crawler.py
+++ b/retail/services/tests/test_crawler.py
@@ -81,3 +81,13 @@ class TestCrawlerService(TestCase):
 
         self.mock_client.check_url.assert_called_once_with(self.crawl_url)
         self.assertIsNone(result)
+
+    def test_check_url_returns_unreachable_on_client_error(self):
+        self.mock_client.check_url.side_effect = CustomAPIException(
+            status_code=400, detail={"errors": {"crawl_url": ["Invalid URL"]}}
+        )
+
+        result = self.service.check_url(self.crawl_url)
+
+        self.mock_client.check_url.assert_called_once_with(self.crawl_url)
+        self.assertEqual(result, {"reachable": False})

--- a/retail/swagger.py
+++ b/retail/swagger.py
@@ -6,7 +6,7 @@ from rest_framework import permissions
 view = get_schema_view(
     openapi.Info(
         title="Gallery API Documentation",
-        default_version="v5.54.0",
+        default_version="v5.55.0",
         description="Documentation of the Gallery APIs",
     ),
     public=True,


### PR DESCRIPTION
## Check URL Reachability Endpoint

- Added `check_url` method to `CrawlerClient` and `CrawlerClientInterface` to probe whether a URL is reachable the same way a crawl would fetch it, returning `reachable` and `resolved_url`.
- Added `check_url` to `CrawlerService` to wrap the client call and handle `CustomAPIException`, returning `None` on failure.
- Introduced `CheckUrlSerializer` to validate that `crawl_url` is a required URL field on incoming requests.
- Created `CheckUrlDTO` to carry `vtex_account` and `crawl_url` between the view and use case layers.
- Developed `CheckUrlUseCase` with a `CheckUrlResult` dataclass that distinguishes between a reachable URL (`valid=True`), an unreachable URL (`valid=False`), and a crawler communications failure (`unavailable=True`), returning HTTP 502 only in the latter case.
- Created `CheckUrlView` at `POST /api/onboard/<vtex_account>/check-url/` to validate the request, execute the use case, and return the appropriate response and status code.
- Added tests for `CheckUrlUseCase` covering reachable, unreachable, missing `resolved_url`, and crawler-unavailable scenarios, as well as `CheckUrlResult.to_dict()` and `http_status` behavior.
- Added tests for `CheckUrlView` covering valid, invalid, crawler-unavailable (502), and missing `crawl_url` (400) cases.