### PR TITLE
feat: Add VTEX back-in-stock WhatsApp notification pipeline

### DIFF
--- a/retail/agents/domains/agent_integration/usecases/assign.py
+++ b/retail/agents/domains/agent_integration/usecases/assign.py
@@ -26,6 +26,7 @@ from retail.interfaces.services.integrations import IntegrationsServiceInterface
 from retail.interfaces.services.meta import MetaServiceInterface
 from retail.projects.agentic_cx_tasks import task_ensure_agentic_cx_script_active
 from retail.projects.models import Project
+from retail.vtex.usecases.resolve_storefront_origin import resolve_storefront_origin
 from retail.templates.usecases.create_library_template import (
     LibraryTemplateData,
     CreateLibraryTemplateUseCase,
@@ -43,6 +44,9 @@ from retail.services.aws_s3.converters import ImageUrlToBase64Converter
 from retail.agents.shared.country_code_utils import DEFAULT_TEMPLATE_LANGUAGE
 from retail.agents.domains.agent_integration.usecases.build_abandoned_cart_translation import (
     BuildAbandonedCartTranslationUseCase,
+)
+from retail.agents.domains.agent_integration.usecases.build_back_in_stock_translation import (
+    BuildBackInStockTranslationUseCase,
 )
 from retail.agents.domains.agent_integration.usecases.build_payment_recovery_translation import (
     BuildPaymentRecoveryTranslationUseCase,
@@ -84,7 +88,12 @@ class IntegrationsButtonFormat(TypedDict):
 AGENT_DEFAULT_TEMPLATE_DISPLAY_NAMES: Dict[str, str] = {
     "ABANDONED_CART_AGENT_UUID": "Abandoned Cart",
     "PAYMENT_RECOVERY_AGENT_UUID": "Payment Recovery",
+    "BACK_IN_STOCK_AGENT_UUID": "Back in stock",
 }
+
+BACK_IN_STOCK_BUTTON_EXAMPLE_PATH = (
+    "/checkout/cart/add?sku=1&qty=1&seller=1&redirect=true"
+)
 
 
 class AssignAgentUseCase:
@@ -287,12 +296,14 @@ class AssignAgentUseCase:
         """
         Return the contact_percentage override for specific agent types.
 
-        Payment recovery and order status must reach 100% of eligible
-        contacts from day one; other agents keep the model default (10%).
+        Payment recovery, order status and back in stock must reach 100%
+        of eligible contacts from day one (back in stock is an explicit
+        shopper opt-in). Other agents keep the model default (10%).
         """
         full_rollout_setting_names = (
             "PAYMENT_RECOVERY_AGENT_UUID",
             "ORDER_STATUS_AGENT_UUID",
+            "BACK_IN_STOCK_AGENT_UUID",
         )
         for setting_name in full_rollout_setting_names:
             agent_uuid = getattr(settings, setting_name, "")
@@ -721,6 +732,8 @@ class AssignAgentUseCase:
            create a default custom template using the custom template flow.
         4) If the agent is the Payment Recovery agent (PAYMENT_RECOVERY_AGENT_UUID),
            create a default custom template and a VTEX hook via proxy.
+        5) If the agent is the Back in stock agent (BACK_IN_STOCK_AGENT_UUID),
+           create a default custom marketing template.
 
         The initial_template_language is automatically detected from VTEX tenant locale.
         """
@@ -790,6 +803,16 @@ class AssignAgentUseCase:
                     f"[AssignAgent] Skipping hook creation — template failed for "
                     f"integrated_agent={integrated_agent.uuid}"
                 )
+
+        back_in_stock_agent_uuid = getattr(settings, "BACK_IN_STOCK_AGENT_UUID", "")
+        if back_in_stock_agent_uuid and str(agent.uuid) == back_in_stock_agent_uuid:
+            logger.info(f"[AssignAgent] back in stock agent detected={agent.uuid}")
+            self._create_default_back_in_stock_template(
+                integrated_agent=integrated_agent,
+                project=project,
+                project_uuid=project_uuid,
+                app_uuid=app_uuid,
+            )
 
         return integrated_agent
 
@@ -935,6 +958,108 @@ class AssignAgentUseCase:
                 "integrated agent %s: %s",
                 integrated_agent.uuid,
                 exc,
+            )
+
+    def _create_default_back_in_stock_template(
+        self,
+        integrated_agent: IntegratedAgent,
+        project: Project,
+        project_uuid: UUID,
+        app_uuid: UUID,
+    ) -> None:
+        """Create the unique marketing template for the back-in-stock agent.
+
+        Header IMAGE uses the same placeholder as abandoned cart. The URL
+        button host is the storefront; the lambda supplies ``button`` as
+        the add-to-cart path at send time.
+        """
+        template_language = integrated_agent.config.get(
+            "initial_template_language", DEFAULT_TEMPLATE_LANGUAGE
+        )
+
+        try:
+            logger.info(
+                f"[AssignAgent] Back in stock template flow start for "
+                f"integrated_agent={integrated_agent.uuid}, language={template_language}"
+            )
+
+            button_base_url = resolve_storefront_origin(project).origin
+            button_url_example = f"{button_base_url}{BACK_IN_STOCK_BUTTON_EXAMPLE_PATH}"
+            logger.info(
+                f"[AssignAgent] back_in_stock_button_url_resolved: "
+                f"project={project.uuid} vtex_account={project.vtex_account} "
+                f"button_base_url={button_base_url!r}"
+            )
+
+            placeholder_image_url = settings.ABANDONED_CART_DEFAULT_IMAGE_URL
+            image_converter = ImageUrlToBase64Converter()
+            placeholder_image_base64 = image_converter.convert(placeholder_image_url)
+            if not placeholder_image_base64:
+                raise ValueError(
+                    f"Failed to convert placeholder image URL to base64: "
+                    f"{placeholder_image_url}"
+                )
+
+            template_translation = (
+                BuildBackInStockTranslationUseCase.build_template_translation(
+                    language_code=template_language,
+                    button_base_url=button_base_url,
+                    button_url_example=button_url_example,
+                    header_image_base64=placeholder_image_base64,
+                )
+            )
+
+            payload: CreateCustomTemplateData = {
+                "template_translation": template_translation,
+                "category": "MARKETING",
+                "app_uuid": str(app_uuid),
+                "project_uuid": str(project_uuid),
+                "display_name": AGENT_DEFAULT_TEMPLATE_DISPLAY_NAMES[
+                    "BACK_IN_STOCK_AGENT_UUID"
+                ],
+                "start_condition": "If sku_id is not empty",
+                "parameters": [
+                    {
+                        "name": "start_condition",
+                        "value": "If sku_id is not empty",
+                    },
+                    {
+                        "name": "variables",
+                        "value": [
+                            {
+                                "name": "1",
+                                "type": "text",
+                                "definition": "Client name",
+                                "fallback": "Cliente",
+                            },
+                            {
+                                "name": "2",
+                                "type": "text",
+                                "definition": "Product name",
+                                "fallback": "Produto",
+                            },
+                        ],
+                    },
+                ],
+                "integrated_agent_uuid": integrated_agent.uuid,
+                "use_agent_rule": True,
+            }
+
+            use_case = CreateCustomTemplateUseCase()
+            use_case.execute(payload)
+            logger.info(
+                f"[AssignAgent] Back in stock template created for "
+                f"integrated_agent={integrated_agent.uuid}, language={template_language}"
+            )
+        except CustomTemplateAlreadyExists:
+            logger.info(
+                f"Custom back in stock template already exists for "
+                f"integrated agent {integrated_agent.uuid}"
+            )
+        except Exception as exc:
+            logger.exception(
+                "Error while creating default back in stock template for "
+                f"integrated agent {integrated_agent.uuid}: {exc}"
             )
 
     def _build_payment_recovery_webhook_url(

--- a/retail/agents/domains/agent_integration/usecases/build_back_in_stock_translation.py
+++ b/retail/agents/domains/agent_integration/usecases/build_back_in_stock_translation.py
@@ -1,0 +1,100 @@
+"""Translations for the back-in-stock WhatsApp marketing template."""
+
+from typing import Any, Dict, Optional
+
+from retail.agents.shared.country_code_utils import DEFAULT_TEMPLATE_LANGUAGE
+
+
+class BuildBackInStockTranslationUseCase:
+    """Build back-in-stock template translations for Meta/WhatsApp."""
+
+    _TRANSLATIONS: Dict[str, Dict[str, Any]] = {
+        "pt_BR": {
+            "body_text": (
+                "Ótimas notícias, {{1}}. {{2}} já está de volta ao estoque. "
+                "Toque no botão para comprar"
+            ),
+            "body_example": ["João", "Camiseta Azul"],
+            "button_url_text": "Comprar",
+            "button_quick_reply_text": "Parar promoções",
+        },
+        "en": {
+            "body_text": (
+                "Great news, {{1}}. {{2}} is back in stock. " "Tap the button to buy it"
+            ),
+            "body_example": ["John", "Blue T-shirt"],
+            "button_url_text": "Buy",
+            "button_quick_reply_text": "Stop promotions",
+        },
+        "es": {
+            "body_text": (
+                "Buenas noticias, {{1}}. {{2}} ya está de vuelta en stock. "
+                "Toca el botón para comprarlo"
+            ),
+            "body_example": ["Juan", "Camiseta azul"],
+            "button_url_text": "Comprar",
+            "button_quick_reply_text": "Parar promociones",
+        },
+    }
+
+    @classmethod
+    def _normalize_language_code(cls, language_code: str) -> str:
+        if language_code in cls._TRANSLATIONS:
+            return language_code
+        if "_" in language_code:
+            base_code = language_code.split("_")[0]
+            if base_code in cls._TRANSLATIONS:
+                return base_code
+        return language_code
+
+    @classmethod
+    def get_translation(cls, language_code: str) -> Optional[Dict[str, Any]]:
+        return cls._TRANSLATIONS.get(cls._normalize_language_code(language_code))
+
+    @classmethod
+    def get_translation_or_default(cls, language_code: str) -> Dict[str, Any]:
+        translation = cls.get_translation(language_code)
+        if translation is None:
+            return cls._TRANSLATIONS[DEFAULT_TEMPLATE_LANGUAGE]
+        return translation
+
+    @classmethod
+    def build_template_translation(
+        cls,
+        language_code: str,
+        button_base_url: str,
+        button_url_example: str,
+        header_image_base64: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build the payload expected by CreateCustomTemplateUseCase."""
+        normalized_code = cls._normalize_language_code(language_code)
+        translation_data = cls.get_translation_or_default(language_code)
+
+        template_translation: Dict[str, Any] = {
+            "template_body": translation_data["body_text"],
+            "template_body_params": translation_data["body_example"],
+            "template_button": [
+                {
+                    "type": "URL",
+                    "text": translation_data["button_url_text"],
+                    "url": {
+                        "base_url": button_base_url,
+                        "url_suffix_example": button_url_example,
+                    },
+                },
+                {
+                    "type": "QUICK_REPLY",
+                    "text": translation_data["button_quick_reply_text"],
+                },
+            ],
+            "category": "MARKETING",
+            "language": normalized_code,
+        }
+
+        if header_image_base64:
+            template_translation["template_header"] = {
+                "header_type": "IMAGE",
+                "text": header_image_base64,
+            }
+
+        return template_translation

--- a/retail/agents/shared/cache.py
+++ b/retail/agents/shared/cache.py
@@ -22,12 +22,14 @@ class AgentRole(str, Enum):
     ABANDONED_CART = "abandoned_cart"
     ORDER_STATUS = "order_status"
     PAYMENT_RECOVERY = "payment_recovery"
+    BACK_IN_STOCK = "back_in_stock"
 
 
 ROLE_SETTING_NAMES: Dict[AgentRole, str] = {
     AgentRole.ABANDONED_CART: "ABANDONED_CART_AGENT_UUID",
     AgentRole.ORDER_STATUS: "ORDER_STATUS_AGENT_UUID",
     AgentRole.PAYMENT_RECOVERY: "PAYMENT_RECOVERY_AGENT_UUID",
+    AgentRole.BACK_IN_STOCK: "BACK_IN_STOCK_AGENT_UUID",
 }
 
 

--- a/retail/agents/tests/shared/test_cache.py
+++ b/retail/agents/tests/shared/test_cache.py
@@ -14,6 +14,7 @@ from retail.agents.shared.cache import (
 PAYMENT_RECOVERY_AGENT_UUID = str(uuid.uuid4())
 ABANDONED_CART_AGENT_UUID = str(uuid.uuid4())
 ORDER_STATUS_AGENT_UUID = str(uuid.uuid4())
+BACK_IN_STOCK_AGENT_UUID = str(uuid.uuid4())
 
 
 class IntegratedAgentCacheHandlerRedisWebhookTest(TestCase):
@@ -110,6 +111,7 @@ class IntegratedAgentCacheHandlerRedisRoleCacheTest(TestCase):
             (AgentRole.PAYMENT_RECOVERY, "payment_recovery"),
             (AgentRole.ABANDONED_CART, "abandoned_cart"),
             (AgentRole.ORDER_STATUS, "order_status"),
+            (AgentRole.BACK_IN_STOCK, "back_in_stock"),
         ):
             with self.subTest(role=role):
                 key = self.cache_handler.get_role_cache_key(self.project_uuid, role)
@@ -183,10 +185,17 @@ class ResolveRoleTest(TestCase):
         role = self.cache_handler.resolve_role(self.integrated_agent)
         self.assertEqual(role, AgentRole.ORDER_STATUS)
 
+    @override_settings(BACK_IN_STOCK_AGENT_UUID=BACK_IN_STOCK_AGENT_UUID)
+    def test_resolves_back_in_stock_role(self):
+        self.integrated_agent.agent.uuid = BACK_IN_STOCK_AGENT_UUID
+        role = self.cache_handler.resolve_role(self.integrated_agent)
+        self.assertEqual(role, AgentRole.BACK_IN_STOCK)
+
     @override_settings(
         PAYMENT_RECOVERY_AGENT_UUID=PAYMENT_RECOVERY_AGENT_UUID,
         ABANDONED_CART_AGENT_UUID=ABANDONED_CART_AGENT_UUID,
         ORDER_STATUS_AGENT_UUID=ORDER_STATUS_AGENT_UUID,
+        BACK_IN_STOCK_AGENT_UUID=BACK_IN_STOCK_AGENT_UUID,
     )
     def test_returns_none_for_unrelated_agent(self):
         self.integrated_agent.agent.uuid = str(uuid.uuid4())
@@ -197,6 +206,7 @@ class ResolveRoleTest(TestCase):
         PAYMENT_RECOVERY_AGENT_UUID="",
         ABANDONED_CART_AGENT_UUID="",
         ORDER_STATUS_AGENT_UUID="",
+        BACK_IN_STOCK_AGENT_UUID="",
     )
     def test_returns_none_when_settings_are_empty(self):
         self.integrated_agent.agent.uuid = PAYMENT_RECOVERY_AGENT_UUID
@@ -236,6 +246,7 @@ class InvalidateAllForTest(TestCase):
         PAYMENT_RECOVERY_AGENT_UUID="",
         ABANDONED_CART_AGENT_UUID="",
         ORDER_STATUS_AGENT_UUID="",
+        BACK_IN_STOCK_AGENT_UUID="",
     )
     @patch("django.core.cache.cache.delete")
     def test_clears_only_webhook_key_when_role_unknown(self, mock_cache_delete):

--- a/retail/agents/tests/usecases/test_assign_back_in_stock.py
+++ b/retail/agents/tests/usecases/test_assign_back_in_stock.py
@@ -1,0 +1,123 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_integration.usecases.assign import (
+    BACK_IN_STOCK_BUTTON_EXAMPLE_PATH,
+    AssignAgentUseCase,
+)
+from retail.agents.domains.agent_integration.usecases.fetch_country_phone_code import (
+    FetchCountryPhoneCodeUseCase,
+    VtexLocaleInfo,
+)
+from retail.agents.domains.agent_management.models import Agent
+from retail.projects.models import Project
+
+BACK_IN_STOCK_AGENT_UUID = str(uuid.uuid4())
+
+
+@override_settings(BACK_IN_STOCK_AGENT_UUID=BACK_IN_STOCK_AGENT_UUID)
+class AssignBackInStockTemplateTest(TestCase):
+    def setUp(self):
+        self.mock_fetch_phone_code = MagicMock(spec=FetchCountryPhoneCodeUseCase)
+        self.mock_fetch_phone_code.fetch_locale_info.return_value = VtexLocaleInfo(
+            country_phone_code="55",
+            meta_language="pt_BR",
+            vtex_locale="pt-BR",
+        )
+        self.use_case = AssignAgentUseCase(
+            fetch_country_phone_code_usecase=self.mock_fetch_phone_code,
+            sync_vtex_sub_accounts_usecase=MagicMock(),
+        )
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(),
+            name="Test Project",
+            vtex_account="teststore",
+            config={"vtex_host_store": "https://www.realstore.com.br/"},
+        )
+        self.integrated_agent = MagicMock(spec=IntegratedAgent)
+        self.integrated_agent.uuid = uuid.uuid4()
+        self.integrated_agent.config = {"initial_template_language": "pt_BR"}
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateCustomTemplateUseCase"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.ImageUrlToBase64Converter"
+    )
+    @override_settings(
+        ABANDONED_CART_DEFAULT_IMAGE_URL="https://placehold.co/1200x628/png?text=Test"
+    )
+    def test_uses_vtex_host_store_for_button_base_url(
+        self, mock_converter_cls, mock_custom_template_cls
+    ):
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = "data:image/png;base64,abc"
+        mock_converter_cls.return_value = mock_converter
+        mock_template_usecase = MagicMock()
+        mock_custom_template_cls.return_value = mock_template_usecase
+
+        self.use_case._create_default_back_in_stock_template(
+            integrated_agent=self.integrated_agent,
+            project=self.project,
+            project_uuid=self.project.uuid,
+            app_uuid=uuid.uuid4(),
+        )
+
+        payload = mock_template_usecase.execute.call_args[0][0]
+        button = payload["template_translation"]["template_button"][0]
+        self.assertEqual(button["url"]["base_url"], "https://www.realstore.com.br")
+        self.assertEqual(
+            button["url"]["url_suffix_example"],
+            f"https://www.realstore.com.br{BACK_IN_STOCK_BUTTON_EXAMPLE_PATH}",
+        )
+        self.assertEqual(payload["display_name"], "Back in stock")
+        self.assertEqual(payload["category"], "MARKETING")
+        self.assertTrue(payload["use_agent_rule"])
+        variable_names = [item["name"] for item in payload["parameters"][1]["value"]]
+        self.assertEqual(variable_names, ["1", "2"])
+
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.CreateCustomTemplateUseCase"
+    )
+    @patch(
+        "retail.agents.domains.agent_integration.usecases.assign.ImageUrlToBase64Converter"
+    )
+    @override_settings(
+        ABANDONED_CART_DEFAULT_IMAGE_URL="https://placehold.co/1200x628/png?text=Test"
+    )
+    def test_falls_back_to_myvtex_when_host_store_missing(
+        self, mock_converter_cls, mock_custom_template_cls
+    ):
+        self.project.config = {}
+        self.project.save(update_fields=["config"])
+
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = "data:image/png;base64,abc"
+        mock_converter_cls.return_value = mock_converter
+        mock_template_usecase = MagicMock()
+        mock_custom_template_cls.return_value = mock_template_usecase
+
+        self.use_case._create_default_back_in_stock_template(
+            integrated_agent=self.integrated_agent,
+            project=self.project,
+            project_uuid=self.project.uuid,
+            app_uuid=uuid.uuid4(),
+        )
+
+        payload = mock_template_usecase.execute.call_args[0][0]
+        button = payload["template_translation"]["template_button"][0]
+        self.assertEqual(button["url"]["base_url"], "https://teststore.myvtex.com")
+        self.assertNotIn("vtexcommercestable", button["url"]["base_url"])
+
+    def test_contact_percentage_is_100(self):
+        agent = Agent.objects.create(
+            uuid=BACK_IN_STOCK_AGENT_UUID,
+            name="Back in stock",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        self.assertEqual(self.use_case._resolve_contact_percentage(agent), 100)

--- a/retail/agents/tests/usecases/test_assign_payment_recovery.py
+++ b/retail/agents/tests/usecases/test_assign_payment_recovery.py
@@ -404,6 +404,18 @@ class GetReservedDisplayNamesTest(TestCase):
         reserved = self.use_case._get_reserved_display_names(agent)
         self.assertEqual(reserved, [])
 
+    @override_settings(BACK_IN_STOCK_AGENT_UUID=ABANDONED_CART_UUID)
+    def test_returns_back_in_stock_for_back_in_stock_agent(self):
+        agent = Agent.objects.create(
+            uuid=ABANDONED_CART_UUID,
+            name="Back in stock",
+            lambda_arn="arn:aws:lambda:fake",
+            project=self.project,
+            credentials={},
+        )
+        reserved = self.use_case._get_reserved_display_names(agent)
+        self.assertEqual(reserved, ["Back in stock"])
+
 
 class CreateTemplatesSkipReservedDisplayNamesTest(TestCase):
     def setUp(self):

--- a/retail/agents/tests/usecases/test_build_back_in_stock_translation.py
+++ b/retail/agents/tests/usecases/test_build_back_in_stock_translation.py
@@ -1,0 +1,82 @@
+from django.test import SimpleTestCase
+
+from retail.agents.domains.agent_integration.usecases.build_back_in_stock_translation import (
+    BuildBackInStockTranslationUseCase,
+)
+
+
+class BuildBackInStockTranslationTest(SimpleTestCase):
+    def test_pt_br_copy_and_two_body_variables(self):
+        result = BuildBackInStockTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+            button_base_url="https://www.loja.com.br",
+            button_url_example="https://www.loja.com.br/apple/p",
+            header_image_base64="data:image/png;base64,abc",
+        )
+
+        self.assertEqual(result["language"], "pt_BR")
+        self.assertEqual(result["category"], "MARKETING")
+        self.assertIn("{{1}}", result["template_body"])
+        self.assertIn("{{2}}", result["template_body"])
+        self.assertIn("Ótimas notícias", result["template_body"])
+        self.assertIn("Toque no botão para comprar", result["template_body"])
+        self.assertEqual(result["template_body_params"], ["João", "Camiseta Azul"])
+        self.assertEqual(result["template_header"]["header_type"], "IMAGE")
+
+        buttons = result["template_button"]
+        self.assertEqual(buttons[0]["type"], "URL")
+        self.assertEqual(buttons[0]["text"], "Comprar")
+        self.assertEqual(buttons[0]["url"]["base_url"], "https://www.loja.com.br")
+        self.assertEqual(buttons[1]["type"], "QUICK_REPLY")
+        self.assertEqual(buttons[1]["text"], "Parar promoções")
+
+    def test_en_us_falls_back_to_en(self):
+        result = BuildBackInStockTranslationUseCase.build_template_translation(
+            language_code="en_US",
+            button_base_url="https://store.com",
+            button_url_example="https://store.com/apple/p",
+        )
+
+        self.assertEqual(result["language"], "en")
+        self.assertIn("Great news", result["template_body"])
+        self.assertEqual(result["template_button"][0]["text"], "Buy")
+
+    def test_es_copy(self):
+        result = BuildBackInStockTranslationUseCase.build_template_translation(
+            language_code="es",
+            button_base_url="https://tienda.com",
+            button_url_example="https://tienda.com/apple/p",
+        )
+
+        self.assertEqual(result["language"], "es")
+        self.assertIn("Buenas noticias", result["template_body"])
+        self.assertEqual(result["template_button"][0]["text"], "Comprar")
+
+    def test_omits_header_when_image_missing(self):
+        result = BuildBackInStockTranslationUseCase.build_template_translation(
+            language_code="pt_BR",
+            button_base_url="https://www.loja.com.br",
+            button_url_example="https://www.loja.com.br/apple/p",
+        )
+
+        self.assertNotIn("template_header", result)
+
+    def test_unknown_language_keeps_code_and_uses_default_copy(self):
+        result = BuildBackInStockTranslationUseCase.build_template_translation(
+            language_code="fr",
+            button_base_url="https://boutique.fr",
+            button_url_example="https://boutique.fr/apple/p",
+        )
+
+        self.assertEqual(result["language"], "fr")
+        self.assertIn("Ótimas notícias", result["template_body"])
+
+    def test_unknown_underscored_language_uses_default_copy(self):
+        result = BuildBackInStockTranslationUseCase.build_template_translation(
+            language_code="zh_CN",
+            button_base_url="https://store.cn",
+            button_url_example="https://store.cn/apple/p",
+        )
+
+        self.assertEqual(result["language"], "zh_CN")
+        self.assertIn("Ótimas notícias", result["template_body"])

--- a/retail/api/vtex_projects/serializers.py
+++ b/retail/api/vtex_projects/serializers.py
@@ -1,7 +1,12 @@
 from rest_framework import serializers
 
 
-ALLOWED_AGENT_TYPES = ("abandoned_cart", "order_status", "payment_recovery")
+ALLOWED_AGENT_TYPES = (
+    "abandoned_cart",
+    "order_status",
+    "payment_recovery",
+    "back_in_stock",
+)
 
 
 class AgentActiveQuerySerializer(serializers.Serializer):

--- a/retail/api/vtex_projects/tests/test_check_agent_active.py
+++ b/retail/api/vtex_projects/tests/test_check_agent_active.py
@@ -79,6 +79,27 @@ class CheckAgentActiveUseCaseTest(TestCase):
         )
 
     @patch(
+        "retail.api.vtex_projects.usecases.check_agent_active.IntegratedAgent.objects"
+    )
+    @patch("retail.api.vtex_projects.usecases.check_agent_active.Project.objects")
+    @patch("retail.api.vtex_projects.usecases.check_agent_active.settings")
+    def test_returns_true_when_back_in_stock_agent_active(
+        self, mock_settings, mock_project_qs, mock_ia_qs
+    ):
+        mock_settings.BACK_IN_STOCK_AGENT_UUID = "bis-123"
+        mock_project_qs.get.return_value = self.project
+        mock_ia_qs.filter.return_value.exists.return_value = True
+
+        result = self.use_case.execute(self.vtex_account, "back_in_stock")
+
+        self.assertTrue(result)
+        mock_ia_qs.filter.assert_called_once_with(
+            agent__uuid="bis-123",
+            project=self.project,
+            is_active=True,
+        )
+
+    @patch(
         "retail.api.vtex_projects.usecases.check_agent_active.IntegratedFeature.objects"
     )
     @patch(

--- a/retail/api/vtex_projects/tests/test_views.py
+++ b/retail/api/vtex_projects/tests/test_views.py
@@ -130,6 +130,24 @@ class AgentActiveViewTest(TestCase):
 
     @_jwt_auth_bypass("teststore")
     @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
+    def test_accepts_back_in_stock_agent_type(self, mock_use_case_cls, _auth):
+        mock_use_case_cls.return_value.execute_any.return_value = True
+
+        request = self.factory.get(
+            f"/api/vtex-projects/{self.vtex_account}/agent-active/",
+            {"agent": "back_in_stock"},
+        )
+        response = self.view(request, vtex_account=self.vtex_account)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["is_active"])
+        mock_use_case_cls.return_value.execute_any.assert_called_once_with(
+            vtex_account=self.vtex_account,
+            agent_types=["back_in_stock"],
+        )
+
+    @_jwt_auth_bypass("teststore")
+    @patch("retail.api.vtex_projects.views.CheckAgentActiveUseCase")
     def test_accepts_repeated_agent_param_with_or_semantics(
         self, mock_use_case_cls, _auth
     ):

--- a/retail/api/vtex_projects/usecases/check_agent_active.py
+++ b/retail/api/vtex_projects/usecases/check_agent_active.py
@@ -15,6 +15,7 @@ AGENT_UUID_SETTINGS_MAP = {
     "abandoned_cart": "ABANDONED_CART_AGENT_UUID",
     "order_status": "ORDER_STATUS_AGENT_UUID",
     "payment_recovery": "PAYMENT_RECOVERY_AGENT_UUID",
+    "back_in_stock": "BACK_IN_STOCK_AGENT_UUID",
 }
 
 CACHE_TIMEOUT = 60

--- a/retail/clients/tests/test_vtex_io_client.py
+++ b/retail/clients/tests/test_vtex_io_client.py
@@ -17,6 +17,24 @@ class VtexIOClientProxyResponseTest(TestCase):
         self.assertEqual(headers["Accept-Encoding"], "identity")
 
     @patch.object(VtexIOClient, "make_request")
+    def test_cleanup_availability_notify_posts_to_io_route(self, mock_make_request):
+        response = MagicMock()
+        response.json.return_value = {"deleted": 1, "scanned": 2, "skipped": False}
+        mock_make_request.return_value = response
+
+        result = self.client.cleanup_availability_notify(
+            account_domain="lojasrede.myvtex.com",
+            vtex_account="lojasrede",
+        )
+
+        mock_make_request.assert_called_once()
+        args, kwargs = mock_make_request.call_args
+        self.assertEqual(kwargs.get("method") or args[1], "POST")
+        url = args[0] if args else kwargs.get("url")
+        self.assertIn("/_v/availability-notify/cleanup", url)
+        self.assertEqual(result, {"deleted": 1, "scanned": 2, "skipped": False})
+
+    @patch.object(VtexIOClient, "make_request")
     def test_proxy_vtex_raises_custom_api_exception_on_invalid_json(
         self, mock_make_request
     ):

--- a/retail/clients/vtex_io/client.py
+++ b/retail/clients/vtex_io/client.py
@@ -271,6 +271,15 @@ class VtexIOClient(RequestClient, VtexIOClientInterface):
         )
         return response.json()
 
+    def cleanup_availability_notify(
+        self, account_domain: str, vtex_account: str
+    ) -> dict:
+        """POST already-sent subscription cleanup to the VTEX IO app."""
+        url = self._get_url(account_domain, "/availability-notify/cleanup")
+        headers = self._get_jwt_headers(vtex_account)
+        response = self.make_request(url, method="POST", headers=headers)
+        return response.json()
+
     def proxy_vtex(
         self,
         account_domain: str,

--- a/retail/interfaces/clients/vtex_io/interface.py
+++ b/retail/interfaces/clients/vtex_io/interface.py
@@ -102,6 +102,22 @@ class VtexIOClientInterface(ABC):
         pass
 
     @abstractmethod
+    def cleanup_availability_notify(
+        self, account_domain: str, vtex_account: str
+    ) -> dict:
+        """
+        Ask VTEX IO to delete already-sent back-in-stock subscriptions.
+
+        Args:
+            account_domain (str): VTEX account domain.
+            vtex_account (str): VTEX account for JWT token generation.
+
+        Returns:
+            dict: Cleanup result from VTEX IO.
+        """
+        pass
+
+    @abstractmethod
     def proxy_vtex(
         self,
         account_domain: str,

--- a/retail/services/tests/test_vtex_io.py
+++ b/retail/services/tests/test_vtex_io.py
@@ -158,6 +158,45 @@ class TestVtexIOService(TestCase):
         )
         self.assertEqual(result, {"status": 200})
 
+    def test_cleanup_availability_notify_delegates_to_client(self):
+        expected = {"deleted": 3, "scanned": 10, "skipped": False}
+        self.mock_client.cleanup_availability_notify.return_value = expected
+
+        result = self.service.cleanup_availability_notify(
+            account_domain=self.account_domain,
+            vtex_account=self.vtex_account,
+        )
+
+        self.mock_client.cleanup_availability_notify.assert_called_once_with(
+            account_domain=self.account_domain,
+            vtex_account=self.vtex_account,
+        )
+        self.assertEqual(result, expected)
+
+    def test_cleanup_availability_notify_returns_none_on_client_error(self):
+        from retail.clients.exceptions import CustomAPIException
+
+        self.mock_client.cleanup_availability_notify.side_effect = CustomAPIException(
+            detail="fail", status_code=500
+        )
+
+        result = self.service.cleanup_availability_notify(
+            account_domain=self.account_domain,
+            vtex_account=self.vtex_account,
+        )
+
+        self.assertIsNone(result)
+
+    def test_cleanup_availability_notify_returns_none_on_unexpected_error(self):
+        self.mock_client.cleanup_availability_notify.side_effect = RuntimeError("boom")
+
+        result = self.service.cleanup_availability_notify(
+            account_domain=self.account_domain,
+            vtex_account=self.vtex_account,
+        )
+
+        self.assertIsNone(result)
+
     def test_proxy_payment_gateway_with_minimal_params(self):
         self.mock_client.proxy_payment_gateway.return_value = {}
 

--- a/retail/services/vtex_io/service.py
+++ b/retail/services/vtex_io/service.py
@@ -1,7 +1,12 @@
-from typing import Union
+import logging
+from typing import Optional, Union
 
+from retail.clients.exceptions import CustomAPIException
 from retail.interfaces.clients.vtex_io.interface import VtexIOClientInterface
 from retail.clients.vtex_io.client import VtexIOClient
+
+
+logger = logging.getLogger(__name__)
 
 
 class VtexIOService:
@@ -124,6 +129,32 @@ class VtexIOService:
             account_domain=account_domain,
             vtex_account=vtex_account,
         )
+
+    def cleanup_availability_notify(
+        self, account_domain: str, vtex_account: str
+    ) -> Optional[dict]:
+        """Delete already-sent back-in-stock subscriptions on VTEX IO.
+
+        Infra failures are logged and collapsed to ``None`` so the daily
+        task can continue with the next account.
+        """
+        try:
+            return self.client.cleanup_availability_notify(
+                account_domain=account_domain,
+                vtex_account=vtex_account,
+            )
+        except CustomAPIException as exc:
+            logger.error(
+                f"Availability-notify cleanup failed for "
+                f"vtex_account={vtex_account}: status={exc.status_code}"
+            )
+            return None
+        except Exception as exc:
+            logger.error(
+                f"Availability-notify cleanup failed for "
+                f"vtex_account={vtex_account}: {exc}"
+            )
+            return None
 
     def proxy_vtex(
         self,

--- a/retail/settings.py
+++ b/retail/settings.py
@@ -325,10 +325,21 @@ AGENT_EXECUTION_CELERY_QUEUE = env.str(
     "AGENT_EXECUTION_CELERY_QUEUE", default="agent-executions"
 )
 
+# Dedicated Celery queue for back-in-stock WhatsApp sends. The HTTP
+# webhook answers 200 as soon as the job is queued; a worker started
+# with ``celery-worker back-in-stock`` processes the send.
+BACK_IN_STOCK_CELERY_QUEUE = env.str(
+    "BACK_IN_STOCK_CELERY_QUEUE", default="back-in-stock"
+)
+
 CELERY_BEAT_SCHEDULE = {
     "task-cleanup-old-carts": {
         "task": "task_cleanup_old_carts",
         "schedule": crontab(minute=0, hour=2),
+    },
+    "task-cleanup-back-in-stock-subscriptions": {
+        "task": "task_cleanup_back_in_stock_subscriptions",
+        "schedule": crontab(minute=0, hour=3),
     },
     "task-cleanup-old-executions": {
         "task": "task_cleanup_old_executions",
@@ -343,6 +354,7 @@ CELERY_BEAT_SCHEDULE = {
 CELERY_TASK_ROUTES = {
     "task_cleanup_old_executions": {"queue": AGENT_EXECUTION_CELERY_QUEUE},
     "task_flush_execution_logs": {"queue": AGENT_EXECUTION_CELERY_QUEUE},
+    "task_process_back_in_stock_notification": {"queue": BACK_IN_STOCK_CELERY_QUEUE},
 }
 
 
@@ -477,6 +489,7 @@ ABANDONED_CART_CLONE_ORDER_FORM_ENABLED = env.bool(
     "ABANDONED_CART_CLONE_ORDER_FORM_ENABLED", default=False
 )
 PAYMENT_RECOVERY_AGENT_UUID = env.str("PAYMENT_RECOVERY_AGENT_UUID", default="")
+BACK_IN_STOCK_AGENT_UUID = env.str("BACK_IN_STOCK_AGENT_UUID", default="")
 
 # Time window (in seconds) to ignore repeated order status events.
 # An identical event (same project, agent, order, and current state) arriving

--- a/retail/vtex/tasks.py
+++ b/retail/vtex/tasks.py
@@ -26,6 +26,13 @@ from retail.webhooks.vtex.usecases.typing import OrderStatusDTO
 from retail.agents.domains.agent_webhook.usecases.abandoned_cart import (
     AgentAbandonedCartUseCase,
 )
+from retail.vtex.usecases.cleanup_back_in_stock_subscriptions import (
+    CleanupBackInStockSubscriptionsUseCase,
+)
+from retail.webhooks.vtex.usecases.dto import ProcessBackInStockNotificationDTO
+from retail.webhooks.vtex.usecases.process_back_in_stock_notification import (
+    ProcessBackInStockNotificationUseCase,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -315,6 +322,39 @@ def task_notify_lead(lead_uuid: str):
         )
 
 
+@shared_task(name="task_process_back_in_stock_notification")
+def task_process_back_in_stock_notification(
+    account: str,
+    sku_id: str,
+    phone: str,
+    name: str = "",
+    locale: str = "pt-BR",
+) -> None:
+    """Process a back-in-stock notification queued by the IO webhook.
+
+    The HTTP view already answered 200. Inactive agents are discarded
+    here. Do not log ``phone``. Wrapped in ``execution_log_scope`` so a
+    failed send finalises the AgentExecution row as ``error`` instead of
+    leaving it in ``processing``.
+    """
+    with execution_log_scope(
+        error_data={"vtex_account": account, "sku_id": sku_id},
+        log_prefix="[BACK_IN_STOCK]",
+        sentry_tags={"service": "back_in_stock", "vtex_account": account},
+        reraise=(Exception,),
+        suppress=(),
+    ) as exec_logger:
+        dto = ProcessBackInStockNotificationDTO(
+            sku_id=sku_id,
+            phone=phone,
+            name=name,
+            locale=locale,
+        )
+        ProcessBackInStockNotificationUseCase.from_vtex_account(
+            account, exec_logger=exec_logger
+        ).execute(dto)
+
+
 @shared_task(name="task_cleanup_old_carts")
 def task_cleanup_old_carts():
     try:
@@ -324,3 +364,15 @@ def task_cleanup_old_carts():
         logger.info("Old cart records have been cleaned up.")
     except Exception as e:
         logger.error(f"Error cleaning up old cart records: {str(e)}", exc_info=True)
+
+
+@shared_task(name="task_cleanup_back_in_stock_subscriptions")
+def task_cleanup_back_in_stock_subscriptions() -> None:
+    """Ask IO to delete already-sent back-in-stock subscriptions."""
+    try:
+        CleanupBackInStockSubscriptionsUseCase().execute()
+    except Exception as exc:
+        logger.error(
+            f"Error cleaning up back-in-stock subscriptions: {exc}",
+            exc_info=True,
+        )

--- a/retail/vtex/tests/test_task_cleanup_back_in_stock_subscriptions.py
+++ b/retail/vtex/tests/test_task_cleanup_back_in_stock_subscriptions.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+
+from retail.vtex.tasks import task_cleanup_back_in_stock_subscriptions
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "task-cleanup-back-in-stock-tests",
+        }
+    }
+)
+class TaskCleanupBackInStockSubscriptionsTest(TestCase):
+    @patch("retail.vtex.tasks.CleanupBackInStockSubscriptionsUseCase")
+    def test_delegates_to_use_case(self, mock_use_case_cls):
+        task_cleanup_back_in_stock_subscriptions()
+
+        mock_use_case_cls.return_value.execute.assert_called_once_with()
+
+    @patch("retail.vtex.tasks.CleanupBackInStockSubscriptionsUseCase")
+    def test_swallows_unexpected_error(self, mock_use_case_cls):
+        mock_use_case_cls.return_value.execute.side_effect = RuntimeError("boom")
+
+        task_cleanup_back_in_stock_subscriptions()
+
+    def test_beat_schedule_includes_daily_cleanup(self):
+        from django.conf import settings
+
+        self.assertIn(
+            "task-cleanup-back-in-stock-subscriptions",
+            settings.CELERY_BEAT_SCHEDULE,
+        )
+        entry = settings.CELERY_BEAT_SCHEDULE[
+            "task-cleanup-back-in-stock-subscriptions"
+        ]
+        self.assertEqual(entry["task"], "task_cleanup_back_in_stock_subscriptions")

--- a/retail/vtex/tests/test_task_process_back_in_stock_notification.py
+++ b/retail/vtex/tests/test_task_process_back_in_stock_notification.py
@@ -1,0 +1,65 @@
+from unittest.mock import ANY, patch
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from retail.vtex.tasks import task_process_back_in_stock_notification
+from retail.webhooks.vtex.usecases.dto import ProcessBackInStockNotificationDTO
+from retail.webhooks.vtex.usecases.exceptions import BackInStockSendNotReadyError
+
+
+USE_CASE_PATH = "retail.vtex.tasks.ProcessBackInStockNotificationUseCase"
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "task-process-back-in-stock-tests",
+        }
+    }
+)
+class TaskProcessBackInStockNotificationTest(TestCase):
+    @patch(USE_CASE_PATH)
+    def test_delegates_to_use_case(self, mock_use_case_cls):
+        task_process_back_in_stock_notification(
+            account="gaboulstore",
+            sku_id="9",
+            phone="5511999887766",
+            name="Maria Silva",
+            locale="pt-BR",
+        )
+
+        mock_use_case_cls.from_vtex_account.assert_called_once_with(
+            "gaboulstore", exec_logger=ANY
+        )
+        mock_use_case_cls.from_vtex_account.return_value.execute.assert_called_once_with(
+            ProcessBackInStockNotificationDTO(
+                sku_id="9",
+                phone="5511999887766",
+                name="Maria Silva",
+                locale="pt-BR",
+            )
+        )
+
+    @patch(USE_CASE_PATH)
+    def test_propagates_send_failure_for_worker_retry(self, mock_use_case_cls):
+        mock_use_case_cls.from_vtex_account.return_value.execute.side_effect = (
+            BackInStockSendNotReadyError("send failed")
+        )
+
+        with self.assertRaises(BackInStockSendNotReadyError):
+            task_process_back_in_stock_notification(
+                account="gaboulstore",
+                sku_id="9",
+                phone="5511999887766",
+            )
+
+    def test_routes_to_back_in_stock_queue(self):
+        self.assertEqual(
+            settings.CELERY_TASK_ROUTES["task_process_back_in_stock_notification"][
+                "queue"
+            ],
+            settings.BACK_IN_STOCK_CELERY_QUEUE,
+        )
+        self.assertEqual(settings.BACK_IN_STOCK_CELERY_QUEUE, "back-in-stock")

--- a/retail/vtex/tests/usecases/test_cleanup_back_in_stock_subscriptions.py
+++ b/retail/vtex/tests/usecases/test_cleanup_back_in_stock_subscriptions.py
@@ -1,0 +1,146 @@
+import uuid
+from unittest.mock import MagicMock
+
+from django.test import TestCase, override_settings
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.projects.models import Project
+from retail.vtex.usecases.cleanup_back_in_stock_subscriptions import (
+    CleanupBackInStockSubscriptionsUseCase,
+)
+
+
+BACK_IN_STOCK_AGENT_UUID = str(uuid.uuid4())
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "cleanup-back-in-stock-subscriptions-tests",
+        }
+    },
+    BACK_IN_STOCK_AGENT_UUID=BACK_IN_STOCK_AGENT_UUID,
+)
+class CleanupBackInStockSubscriptionsUseCaseTest(TestCase):
+    def setUp(self):
+        self.mock_service = MagicMock()
+        self.use_case = CleanupBackInStockSubscriptionsUseCase(
+            vtex_io_service=self.mock_service
+        )
+        self.project_a = Project.objects.create(
+            uuid="11111111-1111-1111-1111-111111111111",
+            name="Store A",
+            vtex_account="storea",
+        )
+        self.project_b = Project.objects.create(
+            uuid="22222222-2222-2222-2222-222222222222",
+            name="Store B",
+            vtex_account="storeb",
+        )
+        Project.objects.create(
+            uuid="33333333-3333-3333-3333-333333333333",
+            name="No account",
+            vtex_account="",
+        )
+        self.agent = Agent.objects.create(
+            uuid=BACK_IN_STOCK_AGENT_UUID,
+            name="Back in stock",
+            slug="back_in_stock",
+            description="Back in stock agent",
+            project=self.project_a,
+        )
+        self._activate_agent(self.project_a)
+        self._activate_agent(self.project_b)
+
+    def _activate_agent(self, project: Project, is_active: bool = True) -> None:
+        IntegratedAgent.objects.create(
+            uuid=uuid.uuid4(),
+            agent=self.agent,
+            project=project,
+            is_active=is_active,
+        )
+
+    def test_posts_cleanup_only_for_accounts_with_active_agent(self):
+        self.mock_service.cleanup_availability_notify.return_value = {
+            "deleted": 2,
+            "scanned": 10,
+            "skipped": False,
+        }
+
+        self.use_case.execute()
+
+        self.mock_service.cleanup_availability_notify.assert_any_call(
+            account_domain="storea.myvtex.com",
+            vtex_account="storea",
+        )
+        self.mock_service.cleanup_availability_notify.assert_any_call(
+            account_domain="storeb.myvtex.com",
+            vtex_account="storeb",
+        )
+        self.assertEqual(self.mock_service.cleanup_availability_notify.call_count, 2)
+
+    def test_skips_account_when_agent_is_inactive(self):
+        IntegratedAgent.objects.filter(project=self.project_b).update(is_active=False)
+        self.mock_service.cleanup_availability_notify.return_value = {
+            "deleted": 1,
+            "scanned": 3,
+            "skipped": False,
+        }
+
+        self.use_case.execute()
+
+        self.mock_service.cleanup_availability_notify.assert_called_once_with(
+            account_domain="storea.myvtex.com",
+            vtex_account="storea",
+        )
+
+    def test_skips_account_without_back_in_stock_agent(self):
+        IntegratedAgent.objects.filter(project=self.project_b).delete()
+        self.mock_service.cleanup_availability_notify.return_value = {
+            "deleted": 1,
+            "scanned": 3,
+            "skipped": False,
+        }
+
+        self.use_case.execute()
+
+        self.mock_service.cleanup_availability_notify.assert_called_once_with(
+            account_domain="storea.myvtex.com",
+            vtex_account="storea",
+        )
+
+    def test_logs_io_response_without_aggregating_deleted(self):
+        io_response = {"deleted": 2, "scanned": 10, "skipped": False}
+        self.mock_service.cleanup_availability_notify.return_value = io_response
+        IntegratedAgent.objects.filter(project=self.project_b).delete()
+
+        with self.assertLogs(
+            "retail.vtex.usecases.cleanup_back_in_stock_subscriptions",
+            level="INFO",
+        ) as logs:
+            self.use_case.execute()
+
+        combined = " ".join(logs.output)
+        self.assertIn("response=", combined)
+        self.assertIn("deleted", combined)
+        self.assertIn("2", combined)
+
+    def test_continues_when_one_account_fails(self):
+        def _cleanup(account_domain, vtex_account):
+            if vtex_account == "storea":
+                return None
+            return {"deleted": 1, "scanned": 3, "skipped": False}
+
+        self.mock_service.cleanup_availability_notify.side_effect = _cleanup
+
+        self.use_case.execute()
+
+        self.assertEqual(self.mock_service.cleanup_availability_notify.call_count, 2)
+
+    def test_does_not_call_io_when_agent_uuid_is_not_configured(self):
+        with self.settings(BACK_IN_STOCK_AGENT_UUID=""):
+            self.use_case.execute()
+
+        self.mock_service.cleanup_availability_notify.assert_not_called()

--- a/retail/vtex/tests/usecases/test_resolve_storefront_origin.py
+++ b/retail/vtex/tests/usecases/test_resolve_storefront_origin.py
@@ -1,0 +1,35 @@
+from uuid import uuid4
+
+from django.test import TestCase
+
+from retail.projects.models import Project
+from retail.vtex.usecases.resolve_storefront_origin import resolve_storefront_origin
+
+
+class ResolveStorefrontOriginTest(TestCase):
+    def test_uses_vtex_host_store_netloc(self):
+        project = Project.objects.create(
+            uuid=uuid4(),
+            name="Store",
+            vtex_account="teststore",
+            config={"vtex_host_store": "https://www.realstore.com.br/"},
+        )
+
+        result = resolve_storefront_origin(project)
+
+        self.assertEqual(result.origin, "https://www.realstore.com.br")
+        self.assertFalse(result.used_default)
+
+    def test_falls_back_to_myvtex_when_host_store_missing(self):
+        project = Project.objects.create(
+            uuid=uuid4(),
+            name="Store",
+            vtex_account="teststore",
+            config={},
+        )
+
+        result = resolve_storefront_origin(project)
+
+        self.assertEqual(result.origin, "https://teststore.myvtex.com")
+        self.assertTrue(result.used_default)
+        self.assertNotIn("vtexcommercestable", result.origin)

--- a/retail/vtex/tests/webhooks/test_back_in_stock_notification_stack.py
+++ b/retail/vtex/tests/webhooks/test_back_in_stock_notification_stack.py
@@ -1,0 +1,332 @@
+import json
+from io import BytesIO
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from retail.agents.domains.agent_execution.context import clear_execution_context
+from retail.agents.domains.agent_execution.models import (
+    AgentExecution,
+    AgentExecutionStatus,
+)
+from retail.agents.domains.agent_execution.row_mapper import resolve_log_status
+from retail.agents.domains.agent_execution.services.buffer import (
+    ExecutionBufferService,
+)
+from retail.agents.domains.agent_execution.services.traces_storage import (
+    ExecutionTracesStorageService,
+)
+from retail.agents.domains.agent_execution.status_mapping import (
+    LOG_STATUS_DELIVERED,
+    LOG_STATUS_READ,
+    LOG_STATUS_SENT,
+)
+from retail.agents.domains.agent_execution.tests._fakes import (
+    FakeRedisConnection,
+    FakeS3Client,
+)
+from retail.agents.domains.agent_execution.usecases.flush_executions import (
+    FlushExecutionsUseCase,
+)
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.broadcasts.models import BroadcastMessage, BroadcastStatus
+from retail.internal.test_mixins import patch_retail_auth
+from retail.projects.models import Project
+from retail.templates.models import Template, Version
+from retail.vtex.tasks import task_process_back_in_stock_notification
+from retail.webhooks.vtex.usecases.exceptions import BackInStockSendNotReadyError
+from retail.webhooks.vtex.views.back_in_stock_notification import (
+    NOTIFICATION_RECEIVED,
+    BackInStockNotification,
+)
+
+
+BACK_IN_STOCK_AGENT_UUID = str(uuid4())
+WEBHOOK_PATH = "/webhook/vtex/back-in-stock/api/notification/"
+PHONE = "5511999887766"
+PRODUCT_NAME = "Camiseta Preta"
+IMAGE_URL = "https://cdn.loja.com.br/sku.png"
+BUTTON_PATH = "/checkout/cart/add?sku=9&qty=1&seller=1&redirect=true"
+FLOWS_BROADCAST_ID = 4242
+
+LAMBDA_SUCCESS_BODY = {
+    "status": 0,
+    "template": "back_in_stock",
+    "contact_urn": f"whatsapp:{PHONE}",
+    "language": "pt-BR",
+    "template_variables": {
+        "1": "Maria Silva",
+        "2": PRODUCT_NAME,
+        "button": BUTTON_PATH,
+        "image_url": IMAGE_URL,
+    },
+}
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "back-in-stock-notification-stack-tests",
+        }
+    },
+    BACK_IN_STOCK_AGENT_UUID=BACK_IN_STOCK_AGENT_UUID,
+    EXECUTION_TRACES_BUCKET="test-traces-bucket",
+    AGENT_EXECUTION_LOGGING_ENABLED=True,
+)
+class BackInStockNotificationStackTest(TestCase):
+    """HTTP accept → project/agent lookup → lambda → Flows broadcast → logs.
+
+    Lambda and Flows are the only mocked boundaries. The rest of the
+    stack (view, task, use case, AgentWebhookUseCase, Broadcast builder,
+    BroadcastMessage, AgentExecution) runs for real.
+    """
+
+    def setUp(self):
+        cache.clear()
+        clear_execution_context()
+        self.addCleanup(clear_execution_context)
+
+        self.fake_redis = FakeRedisConnection()
+        self.traces_storage = ExecutionTracesStorageService(
+            s3_service=FakeS3Client(bucket_name="test-traces-bucket")
+        )
+        self.lambda_calls = []
+        self.flows_messages = []
+        self.lambda_body = dict(LAMBDA_SUCCESS_BODY)
+
+        self.project = Project.objects.create(
+            uuid=uuid4(),
+            name="Stack store",
+            vtex_account="gaboulstore",
+            config={"vtex_host_store": "https://www.loja.com.br/"},
+        )
+        self.agent = Agent.objects.create(
+            uuid=BACK_IN_STOCK_AGENT_UUID,
+            name="Back in stock",
+            slug="back_in_stock",
+            description="Back in stock agent",
+            project=self.project,
+            lambda_arn="arn:aws:lambda:us-east-1:123:function:back-in-stock",
+        )
+        self.channel_uuid = uuid4()
+        self.integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid4(),
+            agent=self.agent,
+            project=self.project,
+            channel_uuid=self.channel_uuid,
+            is_active=True,
+            contact_percentage=100,
+            config={},
+        )
+        self._create_approved_template()
+
+        self.factory = APIRequestFactory()
+        self.view = BackInStockNotification.as_view()
+
+        self._start_stack_patches()
+
+    def tearDown(self):
+        cache.clear()
+
+    def _create_approved_template(self) -> None:
+        template = Template.objects.create(
+            name="back_in_stock",
+            integrated_agent=self.integrated_agent,
+            metadata={"language": "pt_BR", "body": "Oi {{1}}, {{2}} voltou."},
+            is_active=True,
+        )
+        version = Version.objects.create(
+            template=template,
+            template_name="back_in_stock",
+            integrations_app_uuid=uuid4(),
+            project=self.project,
+            status="APPROVED",
+        )
+        template.current_version = version
+        template.save(update_fields=["current_version"])
+
+    def _start_stack_patches(self) -> None:
+        patches = [
+            patch(
+                "retail.agents.domains.agent_execution.services.buffer."
+                "get_redis_connection",
+                return_value=self.fake_redis,
+            ),
+            patch(
+                "retail.agents.domains.agent_execution.services.buffer."
+                "get_shared_traces_storage",
+                return_value=self.traces_storage,
+            ),
+            patch(
+                "retail.agents.domains.agent_webhook.services.active_agent."
+                "JWTUsecase.generate_jwt_token",
+                return_value="test-jwt",
+            ),
+            patch(
+                "retail.agents.domains.agent_webhook.services.active_agent."
+                "AwsLambdaService.__init__",
+                lambda self, client=None, region_name=None: None,
+            ),
+            patch(
+                "retail.agents.domains.agent_webhook.services.active_agent."
+                "AwsLambdaService.invoke",
+                side_effect=self._invoke_lambda,
+            ),
+            patch(
+                "retail.agents.domains.agent_webhook.services.broadcast."
+                "FlowsService.__init__",
+                lambda self, client=None: None,
+            ),
+            patch(
+                "retail.agents.domains.agent_webhook.services.broadcast."
+                "FlowsService.send_whatsapp_broadcast",
+                side_effect=self._send_broadcast,
+            ),
+            patch(
+                "retail.agents.domains.agent_webhook.services.broadcast."
+                "send_commerce_webhook_data",
+            ),
+        ]
+        for patcher in patches:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _invoke_lambda(self, *args):
+        function_name, payload = args[-2], args[-1]
+        self.lambda_calls.append({"function_name": function_name, "payload": payload})
+        return {"Payload": BytesIO(json.dumps(self.lambda_body).encode())}
+
+    def _send_broadcast(self, *args):
+        message = args[-1]
+        self.flows_messages.append(message)
+        return {"id": FLOWS_BROADCAST_ID, "status": "queued"}
+
+    def _flush_executions(self) -> None:
+        buffer = ExecutionBufferService(traces_storage=self.traces_storage)
+        FlushExecutionsUseCase(
+            buffer=buffer, traces_storage=self.traces_storage
+        ).execute()
+
+    def _post_notification(self):
+        request = self.factory.post(
+            WEBHOOK_PATH,
+            {
+                "sku_id": "9",
+                "shoppers": [
+                    {
+                        "phone": PHONE,
+                        "name": "Maria Silva",
+                        "locale": "pt-BR",
+                    }
+                ],
+            },
+            format="json",
+        )
+        return self.view(request)
+
+    def _run_queued_task_inline(self, *args, **kwargs):
+        task_process_back_in_stock_notification(**kwargs["kwargs"])
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_full_stack_sends_flows_broadcast_and_marks_execution_sent(self, _auth):
+        with patch.object(
+            task_process_back_in_stock_notification,
+            "apply_async",
+            side_effect=self._run_queued_task_inline,
+        ):
+            response = self._post_notification()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"message": NOTIFICATION_RECEIVED})
+
+        self.assertEqual(len(self.lambda_calls), 1)
+        lambda_call = self.lambda_calls[0]
+        self.assertEqual(
+            lambda_call["function_name"],
+            "arn:aws:lambda:us-east-1:123:function:back-in-stock",
+        )
+        self.assertEqual(
+            lambda_call["payload"]["payload"],
+            {
+                "sku_id": "9",
+                "client_name": "Maria Silva",
+                "phone_number": PHONE,
+                "store": "https://www.loja.com.br",
+            },
+        )
+        self.assertEqual(
+            lambda_call["payload"]["project"]["vtex_account"], "gaboulstore"
+        )
+
+        self.assertEqual(len(self.flows_messages), 1)
+        flows_message = self.flows_messages[0]
+        self.assertEqual(flows_message["project"], str(self.project.uuid))
+        self.assertEqual(flows_message["urns"], [f"whatsapp:{PHONE}"])
+        self.assertEqual(flows_message["channel"], str(self.channel_uuid))
+        self.assertEqual(
+            flows_message["msg"]["template"],
+            {
+                "name": "back_in_stock",
+                "locale": "pt-BR",
+                "variables": ["Maria Silva", PRODUCT_NAME],
+            },
+        )
+        self.assertEqual(
+            flows_message["msg"]["buttons"],
+            [
+                {
+                    "sub_type": "url",
+                    "parameters": [{"type": "text", "text": BUTTON_PATH}],
+                }
+            ],
+        )
+        self.assertEqual(
+            flows_message["msg"]["attachments"], [f"image/png:{IMAGE_URL}"]
+        )
+
+        broadcast = BroadcastMessage.objects.get()
+        self.assertEqual(broadcast.broadcast_id, FLOWS_BROADCAST_ID)
+        self.assertEqual(broadcast.contact_urn, f"whatsapp:{PHONE}")
+        self.assertEqual(broadcast.integrated_agent, self.integrated_agent)
+
+        self._flush_executions()
+        execution = AgentExecution.objects.select_related("broadcast_message").get(
+            integrated_agent=self.integrated_agent
+        )
+        self.assertEqual(execution.status, AgentExecutionStatus.SUCCESS)
+        self.assertEqual(execution.contact_urn, f"whatsapp:{PHONE}")
+        self.assertEqual(execution.broadcast_id, FLOWS_BROADCAST_ID)
+        self.assertEqual(execution.broadcast_message_id, broadcast.uuid)
+        self.assertEqual(resolve_log_status(execution), LOG_STATUS_SENT)
+
+        broadcast.status = BroadcastStatus.DELIVERED
+        broadcast.save(update_fields=["status"])
+        execution.refresh_from_db()
+        self.assertEqual(resolve_log_status(execution), LOG_STATUS_DELIVERED)
+
+        broadcast.status = BroadcastStatus.READ
+        broadcast.save(update_fields=["status"])
+        execution.refresh_from_db()
+        self.assertEqual(resolve_log_status(execution), LOG_STATUS_READ)
+
+    def test_full_stack_raises_when_lambda_omits_rule_matched_status(self):
+        self.lambda_body.pop("status")
+
+        with self.assertRaises(BackInStockSendNotReadyError):
+            task_process_back_in_stock_notification(
+                account="gaboulstore",
+                sku_id="9",
+                phone=PHONE,
+                name="Maria Silva",
+                locale="pt-BR",
+            )
+
+        self.assertEqual(len(self.lambda_calls), 1)
+        self.assertEqual(self.flows_messages, [])
+        self.assertFalse(BroadcastMessage.objects.exists())

--- a/retail/vtex/tests/webhooks/test_back_in_stock_notification_view.py
+++ b/retail/vtex/tests/webhooks/test_back_in_stock_notification_view.py
@@ -1,0 +1,198 @@
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from retail.internal.test_mixins import patch_retail_auth
+from retail.webhooks.vtex.usecases.dto import (
+    EnqueueBackInStockNotificationsDTO,
+    ProcessBackInStockNotificationDTO,
+)
+from retail.webhooks.vtex.views.back_in_stock_notification import (
+    NOTIFICATION_RECEIVED,
+    BackInStockNotification,
+)
+
+
+WEBHOOK_PATH = "/webhook/vtex/back-in-stock/api/notification/"
+USE_CASE_PATH = (
+    "retail.webhooks.vtex.views.back_in_stock_notification."
+    "EnqueueBackInStockNotificationsUseCase"
+)
+
+CACHE_SETTINGS = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "back-in-stock-notification-view-tests",
+    }
+}
+
+VALID_PAYLOAD = {
+    "sku_id": "9",
+    "shoppers": [
+        {
+            "phone": "5511999887766",
+            "name": "Maria Silva",
+            "locale": "pt-BR",
+        },
+        {
+            "phone": "5511888776655",
+            "name": "João Santos",
+        },
+    ],
+}
+
+
+@override_settings(
+    CACHES=CACHE_SETTINGS,
+    BACK_IN_STOCK_CELERY_QUEUE="back-in-stock",
+)
+class BackInStockNotificationViewTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.factory = APIRequestFactory()
+        self.view = BackInStockNotification.as_view()
+        self.use_case_patcher = patch(USE_CASE_PATH)
+        self.mock_use_case_cls = self.use_case_patcher.start()
+        self.addCleanup(self.use_case_patcher.stop)
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_url_matches_io_contract(self):
+        self.assertEqual(reverse("back-in-stock"), WEBHOOK_PATH)
+
+    def _post(self, payload):
+        request = self.factory.post(WEBHOOK_PATH, payload, format="json")
+        return self.view(request)
+
+    def test_returns_401_without_token(self):
+        response = self._post(VALID_PAYLOAD)
+
+        self.assertIn(response.status_code, [401, 403])
+        self.mock_use_case_cls.return_value.execute.assert_not_called()
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_returns_400_when_sku_id_missing(self, _auth):
+        payload = {**VALID_PAYLOAD}
+        del payload["sku_id"]
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.mock_use_case_cls.return_value.execute.assert_not_called()
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_returns_400_when_shoppers_missing(self, _auth):
+        payload = {"sku_id": "9"}
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.mock_use_case_cls.return_value.execute.assert_not_called()
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_returns_400_when_shoppers_is_empty(self, _auth):
+        payload = {"sku_id": "9", "shoppers": []}
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.mock_use_case_cls.return_value.execute.assert_not_called()
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_returns_400_when_a_shopper_phone_is_missing(self, _auth):
+        payload = {
+            "sku_id": "9",
+            "shoppers": [{"name": "Maria Silva"}],
+        }
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.mock_use_case_cls.return_value.execute.assert_not_called()
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_returns_400_when_a_shopper_phone_is_not_digits_only(self, _auth):
+        payload = {
+            "sku_id": "9",
+            "shoppers": [{"phone": "+55 11 99988-7766"}],
+        }
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.mock_use_case_cls.return_value.execute.assert_not_called()
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_rejects_legacy_single_shopper_payload(self, _auth):
+        payload = {
+            "sku_id": "9",
+            "phone": "5511999887766",
+            "name": "Maria Silva",
+            "locale": "pt-BR",
+        }
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.mock_use_case_cls.return_value.execute.assert_not_called()
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_delegates_validated_batch_to_use_case(self, _auth):
+        response = self._post(VALID_PAYLOAD)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["message"], NOTIFICATION_RECEIVED)
+        self.assertNotIn("discarded", response.data)
+        self.mock_use_case_cls.return_value.execute.assert_called_once_with(
+            EnqueueBackInStockNotificationsDTO(
+                account="gaboulstore",
+                shoppers=(
+                    ProcessBackInStockNotificationDTO(
+                        sku_id="9",
+                        phone="5511999887766",
+                        name="Maria Silva",
+                        locale="pt-BR",
+                    ),
+                    ProcessBackInStockNotificationDTO(
+                        sku_id="9",
+                        phone="5511888776655",
+                        name="João Santos",
+                        locale="pt-BR",
+                    ),
+                ),
+            )
+        )
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_ignores_account_and_project_id_in_body(self, _auth):
+        payload = {
+            **VALID_PAYLOAD,
+            "account": "otherstore",
+            "project_id": "11111111-1111-1111-1111-111111111111",
+        }
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        dto = self.mock_use_case_cls.return_value.execute.call_args.args[0]
+        self.assertEqual(dto.account, "gaboulstore")
+
+    @patch_retail_auth(vtex_account="gaboulstore")
+    def test_optional_shopper_fields_are_not_required(self, _auth):
+        payload = {
+            "sku_id": "9",
+            "shoppers": [{"phone": "5511999887766"}],
+        }
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        dto = self.mock_use_case_cls.return_value.execute.call_args.args[0]
+        self.assertEqual(len(dto.shoppers), 1)
+        self.assertEqual(dto.shoppers[0].name, "")
+        self.assertEqual(dto.shoppers[0].locale, "pt-BR")

--- a/retail/vtex/tests/webhooks/test_enqueue_back_in_stock_notifications.py
+++ b/retail/vtex/tests/webhooks/test_enqueue_back_in_stock_notifications.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase, override_settings
+
+from retail.webhooks.vtex.usecases.dto import (
+    EnqueueBackInStockNotificationsDTO,
+    ProcessBackInStockNotificationDTO,
+)
+from retail.webhooks.vtex.usecases.enqueue_back_in_stock_notifications import (
+    EnqueueBackInStockNotificationsUseCase,
+)
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "enqueue-back-in-stock-notifications-tests",
+        }
+    },
+    BACK_IN_STOCK_CELERY_QUEUE="back-in-stock",
+)
+class EnqueueBackInStockNotificationsUseCaseTest(TestCase):
+    def setUp(self):
+        self.mock_task = MagicMock()
+        self.use_case = EnqueueBackInStockNotificationsUseCase(
+            process_task=self.mock_task
+        )
+
+    def test_queues_one_task_per_shopper_in_fifo_order(self):
+        dto = EnqueueBackInStockNotificationsDTO(
+            account="gaboulstore",
+            shoppers=(
+                ProcessBackInStockNotificationDTO(
+                    sku_id="9",
+                    phone="5511999887766",
+                    name="Maria Silva",
+                    locale="pt-BR",
+                ),
+                ProcessBackInStockNotificationDTO(
+                    sku_id="9",
+                    phone="5511888776655",
+                    name="João Santos",
+                    locale="pt-BR",
+                ),
+            ),
+        )
+
+        self.use_case.execute(dto)
+
+        queued = [
+            call.kwargs["kwargs"] for call in self.mock_task.apply_async.call_args_list
+        ]
+        self.assertEqual(
+            queued,
+            [
+                {
+                    "account": "gaboulstore",
+                    "sku_id": "9",
+                    "phone": "5511999887766",
+                    "name": "Maria Silva",
+                    "locale": "pt-BR",
+                },
+                {
+                    "account": "gaboulstore",
+                    "sku_id": "9",
+                    "phone": "5511888776655",
+                    "name": "João Santos",
+                    "locale": "pt-BR",
+                },
+            ],
+        )
+        for call in self.mock_task.apply_async.call_args_list:
+            self.assertEqual(call.kwargs["queue"], "back-in-stock")
+
+    def test_logs_batch_size_without_phone(self):
+        dto = EnqueueBackInStockNotificationsDTO(
+            account="gaboulstore",
+            shoppers=(
+                ProcessBackInStockNotificationDTO(
+                    sku_id="9",
+                    phone="5511999887766",
+                    name="Maria Silva",
+                    locale="pt-BR",
+                ),
+            ),
+        )
+
+        with self.assertLogs(
+            "retail.webhooks.vtex.usecases.enqueue_back_in_stock_notifications",
+            level="INFO",
+        ) as logs:
+            self.use_case.execute(dto)
+
+        combined = " ".join(logs.output)
+        self.assertIn("shoppers=1", combined)
+        self.assertIn("sku_id=9", combined)
+        self.assertNotIn("5511999887766", combined)
+
+    def test_stops_and_logs_when_broker_fails_mid_batch(self):
+        dto = EnqueueBackInStockNotificationsDTO(
+            account="gaboulstore",
+            shoppers=(
+                ProcessBackInStockNotificationDTO(
+                    sku_id="9",
+                    phone="5511999887766",
+                    name="Maria Silva",
+                    locale="pt-BR",
+                ),
+                ProcessBackInStockNotificationDTO(
+                    sku_id="9",
+                    phone="5511888776655",
+                    name="João Santos",
+                    locale="pt-BR",
+                ),
+            ),
+        )
+        self.mock_task.apply_async.side_effect = [None, RuntimeError("broker down")]
+
+        with self.assertLogs(
+            "retail.webhooks.vtex.usecases.enqueue_back_in_stock_notifications",
+            level="ERROR",
+        ) as logs:
+            with self.assertRaises(RuntimeError):
+                self.use_case.execute(dto)
+
+        self.assertEqual(self.mock_task.apply_async.call_count, 2)
+        combined = " ".join(logs.output)
+        self.assertIn("queued=1", combined)
+        self.assertIn("remaining=1", combined)
+        self.assertNotIn("5511888776655", combined)

--- a/retail/vtex/tests/webhooks/test_process_back_in_stock_notification.py
+++ b/retail/vtex/tests/webhooks/test_process_back_in_stock_notification.py
@@ -1,0 +1,171 @@
+import uuid
+from unittest.mock import MagicMock
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_management.models import Agent
+from retail.projects.models import Project
+from retail.webhooks.vtex.usecases.dto import ProcessBackInStockNotificationDTO
+from retail.webhooks.vtex.usecases.exceptions import BackInStockSendNotReadyError
+from retail.webhooks.vtex.usecases.process_back_in_stock_notification import (
+    DISCARD_AGENT_INACTIVE,
+    NOTIFICATION_SENT,
+    ProcessBackInStockNotificationUseCase,
+)
+
+
+BACK_IN_STOCK_AGENT_UUID = str(uuid.uuid4())
+LAMBDA_PAYLOAD = {
+    "sku_id": "9",
+    "client_name": "Maria Silva",
+    "phone_number": "5511999887766",
+    "store": "https://test-account.myvtex.com",
+}
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "process-back-in-stock-notification-tests",
+        }
+    },
+    BACK_IN_STOCK_AGENT_UUID=BACK_IN_STOCK_AGENT_UUID,
+)
+class ProcessBackInStockNotificationUseCaseTest(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(),
+            name="Test store",
+            vtex_account="test-account",
+        )
+        self.agent = Agent.objects.create(
+            uuid=BACK_IN_STOCK_AGENT_UUID,
+            name="Back in stock",
+            slug="back_in_stock",
+            description="Back in stock agent",
+            project=self.project,
+        )
+        self.integrated_agent = IntegratedAgent.objects.create(
+            uuid=uuid.uuid4(),
+            agent=self.agent,
+            project=self.project,
+        )
+        self.dto = ProcessBackInStockNotificationDTO(
+            sku_id="9",
+            phone="5511999887766",
+            name="Maria Silva",
+            locale="pt-BR",
+        )
+        self.execution_uuid = uuid.uuid4()
+        self.mock_webhook = MagicMock()
+        self.mock_webhook.execute_from_task.return_value = {"template": "back_in_stock"}
+        self.mock_exec_logger = MagicMock()
+        self.mock_exec_logger.log_webhook_received.return_value = self.execution_uuid
+
+    def tearDown(self):
+        cache.clear()
+
+    def _use_case(self) -> ProcessBackInStockNotificationUseCase:
+        return ProcessBackInStockNotificationUseCase(
+            account="test-account",
+            exec_logger=self.mock_exec_logger,
+            agent_webhook=self.mock_webhook,
+        )
+
+    def test_discards_when_project_is_missing(self):
+        result = ProcessBackInStockNotificationUseCase.from_vtex_account(
+            "missing-account"
+        ).execute(self.dto)
+
+        self.assertTrue(result.discarded)
+        self.assertEqual(result.reason, DISCARD_AGENT_INACTIVE)
+        self.mock_webhook.execute_from_task.assert_not_called()
+
+    def test_discards_when_agent_is_inactive(self):
+        self.integrated_agent.is_active = False
+        self.integrated_agent.save(update_fields=["is_active"])
+
+        result = self._use_case().execute(self.dto)
+
+        self.assertTrue(result.discarded)
+        self.assertEqual(result.reason, DISCARD_AGENT_INACTIVE)
+        self.mock_webhook.execute_from_task.assert_not_called()
+
+    def test_discards_when_agent_uuid_is_not_configured(self):
+        with self.settings(BACK_IN_STOCK_AGENT_UUID=""):
+            result = self._use_case().execute(self.dto)
+
+        self.assertTrue(result.discarded)
+        self.assertEqual(result.reason, DISCARD_AGENT_INACTIVE)
+        self.mock_webhook.execute_from_task.assert_not_called()
+
+    def test_sends_minimum_lambda_payload_when_agent_is_active(self):
+        result = self._use_case().execute(self.dto)
+
+        self.assertFalse(result.discarded)
+        self.assertEqual(result.reason, NOTIFICATION_SENT)
+        self.mock_exec_logger.log_webhook_received.assert_called_once_with(
+            integrated_agent=self.integrated_agent,
+            payload=LAMBDA_PAYLOAD,
+            contact_urn="whatsapp:5511999887766",
+        )
+        self.mock_webhook.execute_from_task.assert_called_once_with(
+            integrated_agent_uuid=str(self.integrated_agent.uuid),
+            payload=LAMBDA_PAYLOAD,
+            params={},
+            forwarded_execution_uuid=self.execution_uuid,
+        )
+
+    def test_sends_project_store_when_vtex_host_store_is_set(self):
+        self.project.config = {"vtex_host_store": "https://www.loja.com.br/"}
+        self.project.save(update_fields=["config"])
+
+        with self.assertLogs(
+            "retail.webhooks.vtex.usecases.process_back_in_stock_notification",
+            level="INFO",
+        ) as logs:
+            self._use_case().execute(self.dto)
+
+        payload = self.mock_webhook.execute_from_task.call_args.kwargs["payload"]
+        self.assertEqual(payload["store"], "https://www.loja.com.br")
+        self.assertNotIn("Store was not defined on the project", " ".join(logs.output))
+
+    def test_logs_when_sending_default_store(self):
+        with self.assertLogs(
+            "retail.webhooks.vtex.usecases.process_back_in_stock_notification",
+            level="INFO",
+        ) as logs:
+            self._use_case().execute(self.dto)
+
+        combined = " ".join(logs.output)
+        self.assertIn("Store was not defined on the project", combined)
+        self.assertIn("sending the default for this agent", combined)
+        self.assertIn("store=https://test-account.myvtex.com", combined)
+        self.assertNotIn("5511999887766", combined)
+
+    def test_raises_when_lambda_does_not_dispatch(self):
+        self.mock_webhook.execute_from_task.return_value = None
+
+        with self.assertRaises(BackInStockSendNotReadyError):
+            self._use_case().execute(self.dto)
+
+    def test_raises_when_lambda_call_fails(self):
+        self.mock_webhook.execute_from_task.side_effect = RuntimeError("lambda down")
+
+        with self.assertRaises(BackInStockSendNotReadyError):
+            self._use_case().execute(self.dto)
+
+    def test_does_not_log_phone(self):
+        with self.assertLogs(
+            "retail.webhooks.vtex.usecases.process_back_in_stock_notification",
+            level="INFO",
+        ) as logs:
+            self._use_case().execute(self.dto)
+
+        combined = " ".join(logs.output)
+        self.assertNotIn("5511999887766", combined)
+        self.assertIn("sku_id=9", combined)

--- a/retail/vtex/usecases/cleanup_back_in_stock_subscriptions.py
+++ b/retail/vtex/usecases/cleanup_back_in_stock_subscriptions.py
@@ -1,0 +1,67 @@
+import logging
+from typing import Iterable, Optional
+
+from django.conf import settings
+
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.shared.cache import AgentRole, ROLE_SETTING_NAMES
+from retail.services.vtex_io.service import VtexIOService
+
+
+logger = logging.getLogger(__name__)
+
+
+class CleanupBackInStockSubscriptionsUseCase:
+    """Ask VTEX IO to delete already-sent back-in-stock subscriptions.
+
+    Only accounts with an active back-in-stock agent are contacted. IO
+    only removes rows that were already sent and are at least 15 days
+    old. Pending subscriptions are left untouched. Failures on one
+    account do not stop the remaining accounts. The IO response is
+    logged as-is.
+    """
+
+    def __init__(self, vtex_io_service: Optional[VtexIOService] = None) -> None:
+        self.vtex_io_service = vtex_io_service or VtexIOService()
+
+    def execute(self) -> None:
+        for vtex_account in self._active_vtex_accounts():
+            self._cleanup_account(vtex_account)
+        logger.info("[BACK_IN_STOCK] Cleanup batch finished")
+
+    def _active_vtex_accounts(self) -> Iterable[str]:
+        agent_uuid = getattr(settings, ROLE_SETTING_NAMES[AgentRole.BACK_IN_STOCK], "")
+        if not agent_uuid:
+            logger.warning(
+                "[BACK_IN_STOCK] Cleanup skipped: BACK_IN_STOCK_AGENT_UUID "
+                "is not configured"
+            )
+            return []
+
+        return (
+            IntegratedAgent.objects.filter(
+                is_active=True,
+                agent__uuid=agent_uuid,
+            )
+            .exclude(project__vtex_account__isnull=True)
+            .exclude(project__vtex_account="")
+            .values_list("project__vtex_account", flat=True)
+            .distinct()
+        )
+
+    def _cleanup_account(self, vtex_account: str) -> None:
+        logger.info(f"[BACK_IN_STOCK] Cleanup starting: vtex_account={vtex_account}")
+        result = self.vtex_io_service.cleanup_availability_notify(
+            account_domain=f"{vtex_account}.myvtex.com",
+            vtex_account=vtex_account,
+        )
+        if result is None:
+            logger.warning(
+                f"[BACK_IN_STOCK] Cleanup skipped: vtex_account={vtex_account}"
+            )
+            return
+
+        logger.info(
+            f"[BACK_IN_STOCK] Cleanup finished: vtex_account={vtex_account} "
+            f"response={result}"
+        )

--- a/retail/vtex/usecases/resolve_storefront_origin.py
+++ b/retail/vtex/usecases/resolve_storefront_origin.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from retail.projects.models import Project
+
+
+@dataclass(frozen=True)
+class StorefrontOrigin:
+    origin: str
+    used_default: bool
+
+
+def resolve_storefront_origin(project: Project) -> StorefrontOrigin:
+    """Shopper-facing store origin: ``https://{host}`` with no path.
+
+    Prefers ``project.config["vtex_host_store"]``. Falls back to
+    ``{vtex_account}.myvtex.com`` — never ``vtexcommercestable``.
+    """
+    vtex_host_store = (project.config or {}).get("vtex_host_store")
+    if vtex_host_store:
+        host = urlparse(vtex_host_store).netloc
+        if host:
+            return StorefrontOrigin(origin=f"https://{host}", used_default=False)
+    return StorefrontOrigin(
+        origin=f"https://{project.vtex_account}.myvtex.com",
+        used_default=True,
+    )

--- a/retail/webhooks/vtex/serializers.py
+++ b/retail/webhooks/vtex/serializers.py
@@ -21,6 +21,30 @@ class ExternalAbandonedCartSerializer(serializers.Serializer):
     name = serializers.CharField()
 
 
+class BackInStockShopperSerializer(serializers.Serializer):
+    """One shopper in a back-in-stock batch.
+
+    Array order is FIFO (index 0 subscribed first). ``phone`` is digits
+    only. ``name`` and ``locale`` are optional.
+    """
+
+    phone = serializers.RegexField(regex=r"^\d+$")
+    name = serializers.CharField(required=False, allow_blank=True, default="")
+    locale = serializers.CharField(required=False, allow_blank=True, default="pt-BR")
+
+
+class BackInStockNotificationSerializer(serializers.Serializer):
+    """Validate a back-in-stock batch from VTEX IO.
+
+    One SKU plus a non-empty shopper list. Tenant comes from the JWT,
+    not the body. Extra keys such as ``account`` or ``project_id`` are
+    ignored.
+    """
+
+    sku_id = serializers.CharField()
+    shoppers = BackInStockShopperSerializer(many=True, allow_empty=False)
+
+
 class OrderStatusSerializer(serializers.Serializer):
     recorder = serializers.JSONField()
     domain = serializers.CharField()

--- a/retail/webhooks/vtex/urls.py
+++ b/retail/webhooks/vtex/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from retail.webhooks.vtex.views.order_status import OrderStatusWebhook
 from .views.abandoned_cart_notification import AbandonedCartNotification
+from .views.back_in_stock_notification import BackInStockNotification
 
 
 urlpatterns = [
@@ -14,5 +15,10 @@ urlpatterns = [
         "vtex/order-status/api/notification/",
         OrderStatusWebhook.as_view(),
         name="order-status",
+    ),
+    path(
+        "vtex/back-in-stock/api/notification/",
+        BackInStockNotification.as_view(),
+        name="back-in-stock",
     ),
 ]

--- a/retail/webhooks/vtex/usecases/dto.py
+++ b/retail/webhooks/vtex/usecases/dto.py
@@ -9,6 +9,50 @@ class ProcessAbandonedCartNotificationDTO:
 
 
 @dataclass(frozen=True)
+class ProcessBackInStockNotificationDTO:
+    sku_id: str
+    phone: str
+    name: str
+    locale: str
+
+
+@dataclass(frozen=True)
+class EnqueueBackInStockNotificationsDTO:
+    account: str
+    shoppers: tuple[ProcessBackInStockNotificationDTO, ...]
+
+
+@dataclass(frozen=True)
+class BackInStockLambdaPayload:
+    """Minimum payload ActiveAgent.invoke needs besides injected project.
+
+    The lambda looks up the SKU and returns ``template``, SKU name,
+    ``image_url`` and the add-to-cart ``button`` path. ``store`` is the
+    shopper-facing origin used to build that cart URL. ``phone_number``
+    is for WhatsApp send only and must never be logged.
+    """
+
+    sku_id: str
+    client_name: str
+    phone_number: str
+    store: str
+
+    def to_lambda_dict(self) -> dict:
+        return {
+            "sku_id": self.sku_id,
+            "client_name": self.client_name,
+            "phone_number": self.phone_number,
+            "store": self.store,
+        }
+
+
+@dataclass(frozen=True)
+class ProcessBackInStockNotificationResult:
+    discarded: bool
+    reason: str
+
+
+@dataclass(frozen=True)
 class ProcessAbandonedCartNotificationResult:
     cart_uuid: str
     cart_id: str

--- a/retail/webhooks/vtex/usecases/enqueue_back_in_stock_notifications.py
+++ b/retail/webhooks/vtex/usecases/enqueue_back_in_stock_notifications.py
@@ -1,0 +1,45 @@
+import logging
+from typing import Any, Optional
+
+from django.conf import settings
+
+from retail.vtex.tasks import task_process_back_in_stock_notification
+from retail.webhooks.vtex.usecases.dto import EnqueueBackInStockNotificationsDTO
+
+
+logger = logging.getLogger(__name__)
+
+
+class EnqueueBackInStockNotificationsUseCase:
+    """Queue one send task per shopper, preserving IO array order (FIFO)."""
+
+    def __init__(self, process_task: Optional[Any] = None) -> None:
+        self._process_task = process_task or task_process_back_in_stock_notification
+
+    def execute(self, dto: EnqueueBackInStockNotificationsDTO) -> None:
+        queue = settings.BACK_IN_STOCK_CELERY_QUEUE
+        shopper_count = len(dto.shoppers)
+        sku_id = dto.shoppers[0].sku_id
+        logger.info(
+            f"[BACK_IN_STOCK] Enqueueing batch: vtex_account={dto.account} "
+            f"sku_id={sku_id} shoppers={shopper_count} queue={queue}"
+        )
+        for index, shopper in enumerate(dto.shoppers):
+            try:
+                self._process_task.apply_async(
+                    kwargs={
+                        "account": dto.account,
+                        "sku_id": shopper.sku_id,
+                        "phone": shopper.phone,
+                        "name": shopper.name,
+                        "locale": shopper.locale,
+                    },
+                    queue=queue,
+                )
+            except Exception:
+                logger.error(
+                    f"[BACK_IN_STOCK] Enqueue failed: vtex_account={dto.account} "
+                    f"sku_id={shopper.sku_id} queued={index} "
+                    f"remaining={shopper_count - index}"
+                )
+                raise

--- a/retail/webhooks/vtex/usecases/exceptions.py
+++ b/retail/webhooks/vtex/usecases/exceptions.py
@@ -8,3 +8,11 @@ class IntegrationNotConfiguredError(Exception):
 
 class InvalidIntegratedAgentError(Exception):
     """Raised when the integrated agent cannot process abandoned cart notifications."""
+
+
+class BackInStockSendNotReadyError(Exception):
+    """Raised when the WhatsApp send did not complete.
+
+    The HTTP webhook already answered 200. This error fails the Celery
+    job so the send can be inspected or retried by retail, not by IO.
+    """

--- a/retail/webhooks/vtex/usecases/process_back_in_stock_notification.py
+++ b/retail/webhooks/vtex/usecases/process_back_in_stock_notification.py
@@ -1,0 +1,159 @@
+import logging
+from typing import Optional
+from uuid import UUID
+
+from retail.agents.domains.agent_execution.services.logger import ExecutionLoggerService
+from retail.agents.domains.agent_integration.models import IntegratedAgent
+from retail.agents.domains.agent_webhook.usecases.base_agent_webhook import (
+    BaseAgentWebhookUseCase,
+)
+from retail.agents.domains.agent_webhook.usecases.webhook import AgentWebhookUseCase
+from retail.agents.shared.cache import AgentRole, IntegratedAgentCacheHandler
+from retail.interfaces.services.execution_logger import (
+    ExecutionLoggerServiceInterface,
+)
+from retail.projects.models import Project
+from retail.vtex.usecases.resolve_storefront_origin import resolve_storefront_origin
+from retail.webhooks.vtex.usecases.dto import (
+    BackInStockLambdaPayload,
+    ProcessBackInStockNotificationDTO,
+    ProcessBackInStockNotificationResult,
+)
+from retail.webhooks.vtex.usecases.exceptions import BackInStockSendNotReadyError
+
+
+logger = logging.getLogger(__name__)
+
+DISCARD_AGENT_INACTIVE = "Agent is not active for this account."
+NOTIFICATION_SENT = "Notification sent."
+
+
+class ProcessBackInStockNotificationUseCase(BaseAgentWebhookUseCase):
+    """Process a queued back-in-stock notification.
+
+    Runs in the Celery worker, not in the HTTP request. Inactive agents
+    are discarded without retry. A failed WhatsApp send raises so Celery
+    can surface the error; the IO webhook already answered 200.
+    """
+
+    def __init__(
+        self,
+        account: str,
+        cache_handler: Optional[IntegratedAgentCacheHandler] = None,
+        exec_logger: Optional[ExecutionLoggerServiceInterface] = None,
+        agent_webhook: Optional[AgentWebhookUseCase] = None,
+    ) -> None:
+        super().__init__(cache_handler=cache_handler)
+        self.account = account
+        self._exec_logger = exec_logger
+        self._agent_webhook = agent_webhook
+
+    @classmethod
+    def from_vtex_account(
+        cls,
+        account: str,
+        exec_logger: Optional[ExecutionLoggerServiceInterface] = None,
+    ) -> "ProcessBackInStockNotificationUseCase":
+        return cls(account=account, exec_logger=exec_logger)
+
+    def execute(
+        self, dto: ProcessBackInStockNotificationDTO
+    ) -> ProcessBackInStockNotificationResult:
+        log_context = self._log_context(dto)
+        logger.info(f"[BACK_IN_STOCK] Processing notification: {log_context}")
+
+        project = self.get_project_by_vtex_account(self.account)
+        if project is None:
+            logger.info(
+                f"[BACK_IN_STOCK] Discarding inactive: {log_context} "
+                f"reason=project_not_found"
+            )
+            return ProcessBackInStockNotificationResult(
+                discarded=True, reason=DISCARD_AGENT_INACTIVE
+            )
+
+        log_context = f"{log_context} project_uuid={project.uuid}"
+        integrated_agent = self.get_integrated_agent_if_exists(
+            project, AgentRole.BACK_IN_STOCK
+        )
+        if integrated_agent is None:
+            logger.info(
+                f"[BACK_IN_STOCK] Discarding inactive: {log_context} "
+                f"reason=agent_inactive"
+            )
+            return ProcessBackInStockNotificationResult(
+                discarded=True, reason=DISCARD_AGENT_INACTIVE
+            )
+
+        payload = self._build_lambda_payload(dto, project, log_context)
+        self._start_agent_flow(dto, payload, integrated_agent, log_context)
+        return ProcessBackInStockNotificationResult(
+            discarded=False, reason=NOTIFICATION_SENT
+        )
+
+    def _build_lambda_payload(
+        self,
+        dto: ProcessBackInStockNotificationDTO,
+        project: Project,
+        log_context: str,
+    ) -> BackInStockLambdaPayload:
+        storefront = resolve_storefront_origin(project)
+        if storefront.used_default:
+            logger.info(
+                f"[BACK_IN_STOCK] Store was not defined on the project, "
+                f"sending the default for this agent: "
+                f"{log_context} store={storefront.origin}"
+            )
+        return BackInStockLambdaPayload(
+            sku_id=dto.sku_id,
+            client_name=dto.name,
+            phone_number=dto.phone,
+            store=storefront.origin,
+        )
+
+    def _start_agent_flow(
+        self,
+        dto: ProcessBackInStockNotificationDTO,
+        payload: BackInStockLambdaPayload,
+        integrated_agent: IntegratedAgent,
+        log_context: str,
+    ) -> None:
+        exec_logger = self._exec_logger or ExecutionLoggerService()
+        webhook = self._agent_webhook or AgentWebhookUseCase(exec_logger=exec_logger)
+        lambda_payload = payload.to_lambda_dict()
+        execution_uuid = exec_logger.log_webhook_received(
+            integrated_agent=integrated_agent,
+            payload=lambda_payload,
+            contact_urn=f"whatsapp:{dto.phone}",
+        )
+        try:
+            result = webhook.execute_from_task(
+                integrated_agent_uuid=str(integrated_agent.uuid),
+                payload=lambda_payload,
+                params={},
+                forwarded_execution_uuid=_as_optional_uuid(execution_uuid),
+            )
+        except Exception as exc:
+            logger.error(f"[BACK_IN_STOCK] Send failed: {log_context} error={exc}")
+            raise BackInStockSendNotReadyError(
+                "Back in stock WhatsApp send failed."
+            ) from exc
+
+        if result is None:
+            logger.info(
+                f"[BACK_IN_STOCK] Send skipped: {log_context} "
+                f"reason=lambda_or_broadcast_did_not_dispatch"
+            )
+            raise BackInStockSendNotReadyError(
+                "Back in stock WhatsApp send did not dispatch."
+            )
+
+        logger.info(f"[BACK_IN_STOCK] Sent: {log_context}")
+
+    def _log_context(self, dto: ProcessBackInStockNotificationDTO) -> str:
+        return f"vtex_account={self.account} sku_id={dto.sku_id}"
+
+
+def _as_optional_uuid(value: Optional[UUID]) -> Optional[UUID]:
+    """Drop non-UUID logger no-ops (disabled logging returns None)."""
+    return value if isinstance(value, UUID) else None

--- a/retail/webhooks/vtex/views/back_in_stock_notification.py
+++ b/retail/webhooks/vtex/views/back_in_stock_notification.py
@@ -1,0 +1,49 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.request import Request
+from rest_framework import status
+
+from retail.internal.weni_mixins import WeniAuthMixin
+from retail.webhooks.vtex.serializers import BackInStockNotificationSerializer
+from retail.webhooks.vtex.usecases.dto import (
+    EnqueueBackInStockNotificationsDTO,
+    ProcessBackInStockNotificationDTO,
+)
+from retail.webhooks.vtex.usecases.enqueue_back_in_stock_notifications import (
+    EnqueueBackInStockNotificationsUseCase,
+)
+
+
+NOTIFICATION_RECEIVED = "Notification received."
+
+
+class BackInStockNotification(WeniAuthMixin, APIView):
+    """Accept a back-in-stock batch from VTEX IO.
+
+    Validates the body and delegates enqueue to the use case. The HTTP
+    200 only means the batch was accepted, not that WhatsApp was sent.
+    Tenant (``vtex_account``) comes from ``self.auth``.
+    """
+
+    def post(self, request: Request) -> Response:
+        serializer = BackInStockNotificationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        validated_data = serializer.validated_data
+        dto = EnqueueBackInStockNotificationsDTO(
+            account=self.auth.vtex_account,
+            shoppers=tuple(
+                ProcessBackInStockNotificationDTO(
+                    sku_id=validated_data["sku_id"],
+                    phone=shopper["phone"],
+                    name=shopper["name"],
+                    locale=shopper["locale"],
+                )
+                for shopper in validated_data["shoppers"]
+            ),
+        )
+        EnqueueBackInStockNotificationsUseCase().execute(dto)
+        return Response(
+            {"message": NOTIFICATION_RECEIVED},
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## What

Retail now accepts the IO batch webhook (POST /webhook/vtex/back-in-stock/api/notification/), answers 200, and enqueues one Celery task per shopper (FIFO, back-in-stock queue). The worker sends WhatsApp only when the gallery agent is active: lambda with {sku_id, client_name, phone_number, store}, then Flows. Assign creates the MARKETING template (product image, prototype copy, Buy now button, contact_percentage 100). A daily beat asks IO to delete already-notified subscriptions.

## Why

With an active back-in-stock agent, shoppers can subscribe on the product page to be notified when that SKU is back in stock. VTEX IO tells retail when stock returns; retail then sends the WhatsApp message so the shopper can buy before it sells out again.